### PR TITLE
feat: claude-cc statusline implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+coverage/
+*.tgz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-04-09
+
+### Added
+
+- Unidirectional statusline pipeline: stdin → parsers → RenderContext → render → stdout
+- 3-line custom mode with progressive truncation for narrow terminals
+- 1-line minimal mode (auto-switches at <70 columns, or `--minimal` flag)
+- **Line 1 (Identity):** model, git branch with staged/modified/untracked counts, directory, lines changed, active task, worktree, agent, session name, output style, version
+- **Line 2 (Metrics):** 20-segment context bar with color thresholds (green/yellow/orange/blinking red), token counts (input/output), cost with burn rate ($/h), session duration, token speed (tok/s), rate limit usage (5h/7d) with countdown, vim mode, thinking effort level
+- **Line 3 (Activity):** active and completed tools with count badges, todo progress bar with status counts (conditional)
+- **Line 4 (GSD):** current GSD task and update notification (conditional, `--gsd` flag)
+- Git status parser with 5-second TTL file cache
+- Transcript parser (JSONL) with mtime+size caching — extracts tools, agents, todos, thinking effort
+- Token speed calculation with 2-second sliding window
+- Memory usage detection (Linux `os.freemem`, macOS `vm_stat`)
+- GSD integration — current task from todos, update availability check
+- 3-tier color system: named ANSI (default), 256-color, truecolor — named by default to respect terminal themes
+- Nerd Font icons: fa-robot, dev-git-branch, fa-folder-open, fa-fire, fa-skull, fa-comment, fa-clock, fa-bolt, fa-tree, fa-cubes, fa-hammer, fa-warning
+- Config file support (`~/.config/claude-cc/config.json`) with 22 display toggles
+- CLI flags: `--minimal` (force minimal mode), `--gsd` (enable GSD features)
+- Dependency injection for full testability
+- Unicode-aware display width calculation (CJK, emoji, combining marks, zero-width joiners)
+- Progressive field truncation adapting to terminal width
+- Stdin parser with progressive timeout (250ms first-byte, 30ms idle)
+- Terminal width detection: TTY columns → COLUMNS env → /proc tree walk → tput fallback → 120 default
+- Secure file cache with exclusive write flag (`wx`) and 0o600 permissions
+- Path validation on transcript parser (only `~/.claude` or `/tmp`)
+- Session ID sanitization in GSD parser (whitelist `\w` and `-`)
+- Safe `execFile` wrapper (no shell injection) with configurable timeouts
+- npm publishable with `"files": ["dist"]` and `prepublishOnly` script
+- 138 tests across 21 test files with Vitest
+- TypeScript strict mode, ES2022 target, NodeNext ESM
+- Zero runtime dependencies
+
+### Security
+
+- Cache writes use `wx` flag (O_EXCL) to prevent symlink attacks
+- Transcript path validation restricts reads to `~/.claude` and `/tmp`
+- GSD session IDs sanitized against path traversal
+- `execFile` used instead of `exec` to prevent shell injection (except terminal width detection where shell redirect is required with procfs-sourced paths)
+
+[Unreleased]: https://github.com/cativo23/claude-cc/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/cativo23/claude-cc/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,0 +1,159 @@
+# claude-cc
+
+Claude Command Center — a statusline plugin for [Claude Code](https://code.claude.com).
+
+![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)
+![Tests](https://img.shields.io/badge/tests-136%20passing-green)
+![Dependencies](https://img.shields.io/badge/runtime%20deps-0-brightgreen)
+
+## Features
+
+- **3-line custom mode** + **1-line minimal mode** (auto-switches at <70 columns)
+- **Context bar** with color thresholds (green → yellow → orange → blinking red)
+- **Git status** with branch, staged/modified/untracked counts (5s TTL cache)
+- **Token metrics** — input/output counts, speed (tok/s), cost + burn rate ($/h)
+- **Rate limits** — 5h/7d usage with color warnings and reset countdown
+- **Transcript parsing** — active tools, agents, and todo progress
+- **GSD integration** — current task and update notifications
+- **Memory usage** display
+- **Nerd Font icons** throughout
+- **3-tier color system** — named ANSI, 256-color, truecolor (auto-detected)
+- **Config-driven** — toggle any feature via JSON config + CLI flags
+- **Zero runtime dependencies**
+
+## Install
+
+```bash
+npm install -g claude-cc
+```
+
+Or clone and build:
+
+```bash
+git clone https://github.com/cativo23/claude-cc.git
+cd claude-cc
+npm install
+npm run build
+```
+
+## Setup
+
+Add to `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "claude-cc",
+    "padding": 0
+  }
+}
+```
+
+If installed from source:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "node /path/to/claude-cc/dist/index.js",
+    "padding": 0
+  }
+}
+```
+
+## Display
+
+### Custom Mode (default, >=70 columns)
+
+```
+ Opus 4.6 (1M context) │  main ⇡1 !2 │  my-project     +150 -30 │ default │ v2.1.92
+[████████░░░░░░░░░░░░] 21% │  131k↑ 25k↓ │ $1.31 $2.24/h │  35m06s │ 142 tok/s │  72%(5h)
+✓ Read ×3 | ✓ Edit ×2 | ✓ Bash ×5 │ ████████░░ 8/10 | ◐ 1 | ○ 1
+```
+
+### Minimal Mode (<70 columns or `--minimal`)
+
+```
+my-project |  main | Opus 4.6 | ████░░░░░░░░░░░░░░░░ 21% | 131k↑ 25k↓ | $1.31
+```
+
+## Configuration
+
+Create `~/.config/claude-cc/config.json`:
+
+```json
+{
+  "layout": "auto",
+  "gsd": false,
+  "display": {
+    "model": true,
+    "branch": true,
+    "gitChanges": true,
+    "directory": true,
+    "contextBar": true,
+    "tokens": true,
+    "cost": true,
+    "burnRate": true,
+    "duration": true,
+    "tokenSpeed": true,
+    "rateLimits": true,
+    "tools": true,
+    "todos": true,
+    "vim": true,
+    "effort": true,
+    "worktree": true,
+    "agent": true,
+    "sessionName": true,
+    "style": true,
+    "version": true,
+    "linesChanged": true,
+    "memory": true
+  },
+  "colors": {
+    "mode": "auto"
+  }
+}
+```
+
+All fields are optional — defaults are shown above.
+
+### CLI Flags
+
+```bash
+claude-cc --minimal    # Force minimal mode
+claude-cc --gsd        # Enable GSD integration
+```
+
+## Architecture
+
+```
+stdin (JSON from Claude Code)
+  → parsers (git, transcript, token-speed, memory, gsd)
+  → RenderContext
+  → render (line1-4 or minimal)
+  → stdout
+```
+
+- **Dependency injection** for testability
+- **File caching** — TTL-based (git, speed) and mtime-based (transcript)
+- **Progressive truncation** — adapts to terminal width
+
+## Development
+
+```bash
+npm run dev          # Watch mode (tsc --watch)
+npm test             # Run tests
+npm run test:watch   # Watch mode
+npm run test:coverage # With coverage
+npm run lint         # Type check
+npm run build        # Compile to dist/
+```
+
+## Credits
+
+Inspired by [claude-hud](https://github.com/jarrodwatts/claude-hud). Migrated from [claude-setup](https://github.com/cativo23/claude-setup) statusline.
+
+## License
+
+MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2488 @@
+{
+  "name": "claude-cc",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "claude-cc",
+      "version": "0.1.0",
+      "license": "MIT",
+      "bin": {
+        "claude-cc": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.3",
+        "@vitest/coverage-v8": "^3.1.3",
+        "typescript": "^5.8.3",
+        "vitest": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "prepublishOnly": "npm run build && npm run test"
   },
   "devDependencies": {
     "@types/node": "^22.15.3",
@@ -24,5 +25,19 @@
   "engines": {
     "node": ">=18"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cativo23/claude-cc.git"
+  },
+  "keywords": [
+    "claude-code",
+    "claude",
+    "statusline",
+    "terminal",
+    "nerd-font"
+  ],
+  "files": [
+    "dist"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "claude-cc",
+  "version": "0.1.0",
+  "description": "Claude Command Center — statusline plugin for Claude Code",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "claude-cc": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.3",
+    "@vitest/coverage-v8": "^3.1.3",
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.3"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT"
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,36 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { DEFAULT_CONFIG, DEFAULT_DISPLAY, type HudConfig, type DisplayToggles, type ColorConfig } from './types.js';
+
+export function loadConfig(configDir: string = join(homedir(), '.config', 'claude-cc')): HudConfig {
+  const p = join(configDir, 'config.json');
+  if (!existsSync(p)) return { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } };
+  try {
+    const raw = JSON.parse(readFileSync(p, 'utf8'));
+    return mergeConfig(raw);
+  } catch { return { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } }; }
+}
+
+function mergeConfig(raw: Record<string, unknown>): HudConfig {
+  const layout = (['custom', 'minimal', 'auto'] as const).includes(raw.layout as never) ? raw.layout as HudConfig['layout'] : DEFAULT_CONFIG.layout;
+  const display = { ...DEFAULT_DISPLAY };
+  if (raw.display && typeof raw.display === 'object') {
+    for (const k of Object.keys(DEFAULT_DISPLAY) as (keyof DisplayToggles)[]) {
+      if (typeof (raw.display as Record<string, unknown>)[k] === 'boolean') display[k] = (raw.display as Record<string, boolean>)[k];
+    }
+  }
+  const colors: ColorConfig = { ...DEFAULT_CONFIG.colors };
+  if (raw.colors && typeof raw.colors === 'object') {
+    const m = (raw.colors as Record<string, unknown>).mode;
+    if (['auto', 'named', '256', 'truecolor'].includes(m as string)) colors.mode = m as ColorConfig['mode'];
+  }
+  return { layout, gsd: typeof raw.gsd === 'boolean' ? raw.gsd : DEFAULT_CONFIG.gsd, display, colors };
+}
+
+export function mergeCliFlags(config: HudConfig, argv: string[]): HudConfig {
+  const r = { ...config, display: { ...config.display }, colors: { ...config.colors } };
+  if (argv.includes('--minimal')) r.layout = 'minimal';
+  if (argv.includes('--gsd')) r.gsd = true;
+  return r;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { fileURLToPath } from 'node:url';
 import { readStdin as defaultReadStdin } from './stdin.js';
 import { parseGitStatus } from './parsers/git.js';
 import { parseTranscript } from './parsers/transcript.js';
@@ -42,6 +43,7 @@ export async function main(overrides: Partial<Dependencies> = {}): Promise<strin
 }
 
 // Run when invoked directly
-if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/'))) {
+const __filename = fileURLToPath(import.meta.url);
+if (process.argv[1] && (__filename === process.argv[1] || __filename === process.argv[1] + '.js')) {
   main().then(o => process.stdout.write(o)).catch(e => { if (!(e instanceof SyntaxError)) process.stderr.write(`Statusline error: ${e.message}\n`); });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import { readStdin as defaultReadStdin } from './stdin.js';
+import { parseGitStatus } from './parsers/git.js';
+import { parseTranscript } from './parsers/transcript.js';
+import { getTokenSpeed } from './parsers/token-speed.js';
+import { getMemoryInfo } from './parsers/memory.js';
+import { getGsdInfo } from './parsers/gsd.js';
+import { getTermCols, getLayoutCols } from './utils/terminal.js';
+import { loadConfig, mergeCliFlags } from './config.js';
+import { render } from './render/index.js';
+import type { Dependencies, RenderContext } from './types.js';
+import { EMPTY_TRANSCRIPT } from './types.js';
+
+const defaultDeps: Dependencies = {
+  readStdin: () => defaultReadStdin(process.stdin),
+  parseGit: (cwd) => parseGitStatus(cwd),
+  parseTranscript: (path) => parseTranscript(path),
+  getTokenSpeed: (ctx) => getTokenSpeed(ctx),
+  getMemoryInfo: () => getMemoryInfo(),
+  getGsdInfo: (session) => getGsdInfo(session),
+  getTermCols: () => getTermCols(),
+};
+
+export async function main(overrides: Partial<Dependencies> = {}): Promise<string> {
+  const deps = { ...defaultDeps, ...overrides };
+  const config = mergeCliFlags(loadConfig(), process.argv);
+  const input = await deps.readStdin();
+  const cwd = input.cwd || input.workspace?.current_dir || process.cwd();
+
+  const [git, transcript, tokenSpeed, memory, gsd] = await Promise.all([
+    deps.parseGit(cwd),
+    input.transcript_path ? deps.parseTranscript(input.transcript_path) : Promise.resolve(EMPTY_TRANSCRIPT),
+    Promise.resolve(deps.getTokenSpeed(input.context_window)),
+    Promise.resolve(deps.getMemoryInfo()),
+    config.gsd ? Promise.resolve(deps.getGsdInfo(input.session_id)) : Promise.resolve(null),
+  ]);
+
+  const rawCols = deps.getTermCols();
+  const isTTY = !!(process.stdout.columns || process.stderr.columns);
+  const cols = getLayoutCols(rawCols, isTTY);
+  return render({ input, git, transcript, tokenSpeed, memory, gsd, cols, config } as RenderContext);
+}
+
+// Run when invoked directly
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/'))) {
+  main().then(o => process.stdout.write(o)).catch(e => { if (!(e instanceof SyntaxError)) process.stderr.write(`Statusline error: ${e.message}\n`); });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,13 +28,14 @@ export async function main(overrides: Partial<Dependencies> = {}): Promise<strin
   const input = await deps.readStdin();
   const cwd = input.cwd || input.workspace?.current_dir || process.cwd();
 
-  const [git, transcript, tokenSpeed, memory, gsd] = await Promise.all([
+  const [git, transcript] = await Promise.all([
     deps.parseGit(cwd),
     input.transcript_path ? deps.parseTranscript(input.transcript_path) : Promise.resolve(EMPTY_TRANSCRIPT),
-    Promise.resolve(deps.getTokenSpeed(input.context_window)),
-    Promise.resolve(deps.getMemoryInfo()),
-    config.gsd ? Promise.resolve(deps.getGsdInfo(input.session_id)) : Promise.resolve(null),
   ]);
+
+  const tokenSpeed = deps.getTokenSpeed(input.context_window);
+  const memory = deps.getMemoryInfo();
+  const gsd = config.gsd ? deps.getGsdInfo(input.session_id) : null;
 
   const rawCols = deps.getTermCols();
   const isTTY = !!(process.stdout.columns || process.stderr.columns);

--- a/src/parsers/git.ts
+++ b/src/parsers/git.ts
@@ -1,0 +1,36 @@
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { readTtlCache, writeTtlCache } from '../utils/cache.js';
+import { safeExec, type ExecOptions } from '../utils/exec.js';
+import type { GitStatus } from '../types.js';
+import { EMPTY_GIT } from '../types.js';
+
+type ExecFn = (cmd: string, args: string[], opts?: ExecOptions) => Promise<string>;
+const GIT_CACHE_TTL = 5000;
+
+function cacheKey(cwd: string): string {
+  return 'git-' + createHash('md5').update(cwd).digest('hex').slice(0, 8);
+}
+
+export async function parseGitStatus(cwd: string, exec: ExecFn = safeExec): Promise<GitStatus> {
+  const key = cacheKey(cwd);
+  const cached = readTtlCache<GitStatus>(key, tmpdir(), GIT_CACHE_TTL);
+  if (cached) return cached;
+
+  const branch = await exec('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd, timeoutMs: 2000 });
+  if (!branch) return EMPTY_GIT;
+
+  const result: GitStatus = { branch, staged: 0, modified: 0, untracked: 0 };
+  const status = await exec('git', ['status', '--porcelain'], { cwd, timeoutMs: 2000 });
+  if (status) {
+    const lines = status.split('\n').filter(Boolean);
+    // staged: index status is A/D/R/C/T (not space, not ?, not M which shows as modified)
+    result.staged = lines.filter(l => l[0] !== ' ' && l[0] !== '?' && l[0] !== 'M').length;
+    // modified: M in index (col 0) or worktree (col 1)
+    result.modified = lines.filter(l => l[0] === 'M' || l[1] === 'M').length;
+    result.untracked = lines.filter(l => l.startsWith('??')).length;
+  }
+
+  writeTtlCache(key, result, tmpdir());
+  return result;
+}

--- a/src/parsers/gsd.ts
+++ b/src/parsers/gsd.ts
@@ -1,0 +1,31 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { homedir } from 'node:os';
+import type { GsdInfo } from '../types.js';
+
+export function getGsdInfo(session: string, claudeDir: string = join(process.env['CLAUDE_CONFIG_DIR'] || join(homedir(), '.claude'))): GsdInfo | null {
+  let updateAvailable = false;
+  let currentTask: string | undefined;
+
+  const cacheFile = join(claudeDir, 'cache', 'gsd-update-check.json');
+  if (existsSync(cacheFile)) { try { if (JSON.parse(readFileSync(cacheFile, 'utf8')).update_available) updateAvailable = true; } catch {} }
+
+  const todosDir = join(claudeDir, 'todos');
+  if (session && existsSync(todosDir)) {
+    try {
+      const sanitized = (session || '').replace(/[^\w-]/g, '');
+      const files = readdirSync(todosDir).filter(f => f.startsWith(sanitized) && f.includes('-agent-') && f.endsWith('.json'))
+        .map(f => ({ name: f, mtime: statSync(join(todosDir, f)).mtime })).sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+      if (files.length > 0) {
+        const todoPath = join(todosDir, files[0].name);
+        if (!resolve(todoPath).startsWith(resolve(todosDir))) return null;
+        const todos = JSON.parse(readFileSync(resolve(todoPath), 'utf8'));
+        const ip = todos.find((t: { status: string; activeForm?: string }) => t.status === 'in_progress');
+        if (ip?.activeForm) currentTask = ip.activeForm;
+      }
+    } catch {}
+  }
+
+  if (!updateAvailable && !currentTask) return null;
+  return { updateAvailable, currentTask };
+}

--- a/src/parsers/memory.ts
+++ b/src/parsers/memory.ts
@@ -1,0 +1,24 @@
+import { totalmem, freemem, platform } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import type { MemoryInfo } from '../types.js';
+
+export function getMemoryInfo(): MemoryInfo | null {
+  try {
+    if (platform() === 'darwin') {
+      const output = execFileSync('vm_stat', [], { encoding: 'utf8', timeout: 2000 });
+      const psMatch = output.match(/page size of (\d+) bytes/);
+      const ps = psMatch ? parseInt(psMatch[1], 10) : 16384;
+      const active = output.match(/Pages active:\s+(\d+)/);
+      const wired = output.match(/Pages wired down:\s+(\d+)/);
+      const compressed = output.match(/Pages occupied by compressor:\s+(\d+)/);
+      if (!active || !wired) return null;
+      const usedBytes = (parseInt(active[1], 10) + parseInt(wired[1], 10) + (compressed ? parseInt(compressed[1], 10) : 0)) * ps;
+      const totalBytes = totalmem();
+      return { usedBytes, totalBytes, percentage: Math.min(100, Math.max(0, Math.round((usedBytes / totalBytes) * 100))) };
+    }
+    const totalBytes = totalmem();
+    if (totalBytes <= 0) return null;
+    const usedBytes = totalBytes - freemem();
+    return { usedBytes, totalBytes, percentage: Math.min(100, Math.max(0, Math.round((usedBytes / totalBytes) * 100))) };
+  } catch { return null; }
+}

--- a/src/parsers/token-speed.ts
+++ b/src/parsers/token-speed.ts
@@ -1,0 +1,26 @@
+import { readTtlCache, writeTtlCache } from '../utils/cache.js';
+import { tmpdir } from 'node:os';
+
+const SPEED_CACHE_TTL = 2000;
+interface SpeedCache { outputTokens: number; timestamp: number; }
+interface ContextWindow { used_percentage: number; remaining_percentage: number; current_usage?: { output_tokens: number }; }
+
+export function getTokenSpeed(contextWindow: ContextWindow, cacheDir: string = tmpdir()): number | null {
+  const outputTokens = contextWindow?.current_usage?.output_tokens;
+  if (typeof outputTokens !== 'number' || !Number.isFinite(outputTokens)) return null;
+
+  const now = Date.now();
+  const previous = readTtlCache<SpeedCache>('speed', cacheDir, SPEED_CACHE_TTL);
+
+  let speed: number | null = null;
+  if (previous && outputTokens >= previous.outputTokens) {
+    const deltaTokens = outputTokens - previous.outputTokens;
+    const deltaMs = now - previous.timestamp;
+    if (deltaTokens > 0 && deltaMs > 0 && deltaMs <= SPEED_CACHE_TTL) {
+      speed = Math.round(deltaTokens / (deltaMs / 1000));
+    }
+  }
+
+  writeTtlCache('speed', { outputTokens, timestamp: now }, cacheDir);
+  return speed;
+}

--- a/src/parsers/transcript.ts
+++ b/src/parsers/transcript.ts
@@ -4,6 +4,11 @@ import { resolve } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
 import type { TranscriptData, ToolEntry, AgentEntry, TodoEntry, TodoStatus, ThinkingEffort } from '../types.js';
 import { EMPTY_TRANSCRIPT } from '../types.js';
+import { isMtimeFresh, getMtimeState, type MtimeState } from '../utils/cache.js';
+
+let cachedResult: TranscriptData | null = null;
+let cachedMtime: MtimeState | null = null;
+let cachedPath: string | null = null;
 
 const MAX_LINES = 50_000;
 
@@ -36,6 +41,11 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
 
   const resolved = resolve(transcriptPath);
   if (!resolved.startsWith(homedir()) && !resolved.startsWith(tmpdir())) return result;
+
+  const currentMtime = getMtimeState(transcriptPath);
+  if (currentMtime && cachedPath === transcriptPath && cachedMtime && isMtimeFresh(transcriptPath, cachedMtime) && cachedResult) {
+    return cachedResult;
+  }
 
   const toolMap = new Map<string, ToolEntry>();
   const agentMap = new Map<string, AgentEntry>();
@@ -121,5 +131,8 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   result.agents = Array.from(agentMap.values()).slice(-10);
   result.todos = todos;
   result.thinkingEffort = thinkingEffort;
+  cachedResult = result;
+  cachedMtime = currentMtime;
+  cachedPath = transcriptPath;
   return result;
 }

--- a/src/parsers/transcript.ts
+++ b/src/parsers/transcript.ts
@@ -1,0 +1,125 @@
+import { createReadStream, existsSync } from 'node:fs';
+import { createInterface } from 'node:readline';
+import { resolve } from 'node:path';
+import { homedir, tmpdir } from 'node:os';
+import type { TranscriptData, ToolEntry, AgentEntry, TodoEntry, TodoStatus, ThinkingEffort } from '../types.js';
+import { EMPTY_TRANSCRIPT } from '../types.js';
+
+const MAX_LINES = 50_000;
+
+export function normalizeTodoStatus(status: string | undefined): TodoStatus {
+  if (!status) return 'pending';
+  const s = String(status).toLowerCase();
+  if (s === 'completed' || s === 'done') return 'completed';
+  if (s === 'in_progress' || s === 'in-progress' || s === 'running') return 'in_progress';
+  return 'pending';
+}
+
+export function extractToolTarget(toolName: string, input: Record<string, unknown> | undefined): string | undefined {
+  if (!input) return undefined;
+  switch (toolName) {
+    case 'Read': case 'Write': case 'Edit':
+      return (input.file_path ?? input.path) as string | undefined;
+    case 'Glob': case 'Grep':
+      return input.pattern as string | undefined;
+    case 'Bash': {
+      const cmd = (input.command as string) || '';
+      return cmd.length > 30 ? cmd.slice(0, 30) + '...' : cmd;
+    }
+    default: return undefined;
+  }
+}
+
+export async function parseTranscript(transcriptPath: string): Promise<TranscriptData> {
+  const result: TranscriptData = { ...EMPTY_TRANSCRIPT, tools: [], agents: [], todos: [] };
+  if (!transcriptPath || !existsSync(transcriptPath)) return result;
+
+  const resolved = resolve(transcriptPath);
+  if (!resolved.startsWith(homedir()) && !resolved.startsWith(tmpdir())) return result;
+
+  const toolMap = new Map<string, ToolEntry>();
+  const agentMap = new Map<string, AgentEntry>();
+  let todos: TodoEntry[] = [];
+  const taskIdToIndex = new Map<string, number>();
+  let thinkingEffort: ThinkingEffort = '';
+
+  let fileStream: ReturnType<typeof createReadStream> | null = null;
+  try {
+    fileStream = createReadStream(transcriptPath);
+    const rl = createInterface({ input: fileStream, crlfDelay: Infinity });
+    let lineCount = 0;
+
+    for await (const line of rl) {
+      if (!line.trim()) continue;
+      if (++lineCount > MAX_LINES) break;
+
+      try {
+        const entry = JSON.parse(line);
+        if (!result.sessionStart && entry.timestamp) result.sessionStart = new Date(entry.timestamp);
+
+        const effortMatch = line.match(/Set model to .+ with (low|medium|high|max) effort/);
+        if (effortMatch) thinkingEffort = effortMatch[1] as ThinkingEffort;
+
+        const timestamp = entry.timestamp ? new Date(entry.timestamp) : new Date();
+        const content = entry.message?.content;
+        if (!content || !Array.isArray(content)) continue;
+
+        for (const block of content) {
+          if (block.type === 'tool_use' && block.id && block.name) {
+            toolMap.set(block.id, { id: block.id, name: block.name, target: extractToolTarget(block.name, block.input), status: 'running', startTime: timestamp });
+
+            if (block.name === 'Task') {
+              const inp = block.input || {};
+              agentMap.set(block.id, { id: block.id, type: inp.subagent_type || 'unknown', model: inp.model, description: inp.description, status: 'running', startTime: timestamp });
+            }
+
+            if (block.name === 'TodoWrite' && block.input?.todos && Array.isArray(block.input.todos)) {
+              const existingById = new Map(todos.map(t => [t.id || t.content, t]));
+              todos = block.input.todos.map((t: { id?: string; content?: string; status?: string }) => {
+                const id = t.id || t.content || '';
+                const existing = existingById.get(id);
+                if (existing && (!t.status || t.status === existing.status)) return existing;
+                return { id: t.id || '', content: t.content || '', status: normalizeTodoStatus(t.status) };
+              });
+            }
+
+            if (block.name === 'TaskCreate') {
+              const inp = block.input || {};
+              const todoContent = (typeof inp.subject === 'string' ? inp.subject : '') || (typeof inp.description === 'string' ? inp.description : '') || 'Untitled task';
+              todos.push({ id: inp.taskId || block.id, content: todoContent, status: normalizeTodoStatus(inp.status) });
+              if (inp.taskId || block.id) taskIdToIndex.set(String(inp.taskId || block.id), todos.length - 1);
+            }
+
+            if (block.name === 'TaskUpdate') {
+              const inp = block.input || {};
+              let index: number | null = inp.taskId && taskIdToIndex.has(String(inp.taskId)) ? taskIdToIndex.get(String(inp.taskId))! : null;
+              if (index === null && typeof inp.taskId === 'string' && /^\d+$/.test(inp.taskId)) {
+                const n = parseInt(inp.taskId, 10) - 1;
+                if (n >= 0 && n < todos.length) index = n;
+              }
+              if (index !== null && todos[index]) {
+                if (inp.status) todos[index].status = normalizeTodoStatus(inp.status);
+                const subj = typeof inp.subject === 'string' ? inp.subject : '';
+                const desc = typeof inp.description === 'string' ? inp.description : '';
+                if (subj || desc) todos[index].content = subj || desc;
+              }
+            }
+          }
+
+          if (block.type === 'tool_result' && block.tool_use_id) {
+            const tool = toolMap.get(block.tool_use_id);
+            if (tool) { tool.status = block.is_error ? 'error' : 'completed'; tool.endTime = timestamp; }
+            const agent = agentMap.get(block.tool_use_id);
+            if (agent) { agent.status = 'completed'; agent.endTime = timestamp; }
+          }
+        }
+      } catch { /* skip malformed */ }
+    }
+  } catch { /* partial results */ } finally { fileStream?.destroy(); }
+
+  result.tools = Array.from(toolMap.values()).slice(-20);
+  result.agents = Array.from(agentMap.values()).slice(-10);
+  result.todos = todos;
+  result.thinkingEffort = thinkingEffort;
+  return result;
+}

--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -20,31 +20,35 @@ export interface Colors {
 export function createColors(mode: ColorMode): Colors {
   const wrap = (code: string) => (s: string) => `${code}${s}${RST}`;
 
-  if (mode === 'truecolor') {
-    return {
-      cyan: wrap('\x1b[38;2;0;255;255m'), magenta: wrap('\x1b[38;2;255;0;255m'),
-      yellow: wrap('\x1b[38;2;255;255;0m'), green: wrap('\x1b[38;2;0;255;0m'),
-      orange: wrap('\x1b[38;2;255;165;0m'), red: wrap('\x1b[31m'),
-      blinkRed: wrap('\x1b[5;31m'), gray: wrap('\x1b[90m'),
-      brightBlue: wrap('\x1b[38;2;100;149;237m'), dim: wrap('\x1b[2m'), bold: wrap('\x1b[1m'),
-    };
-  }
-  if (mode === '256') {
-    return {
-      cyan: wrap('\x1b[38;5;51m'), magenta: wrap('\x1b[38;5;201m'),
-      yellow: wrap('\x1b[38;5;226m'), green: wrap('\x1b[38;5;46m'),
-      orange: wrap('\x1b[38;5;208m'), red: wrap('\x1b[31m'),
-      blinkRed: wrap('\x1b[5;31m'), gray: wrap('\x1b[90m'),
-      brightBlue: wrap('\x1b[38;5;111m'), dim: wrap('\x1b[2m'), bold: wrap('\x1b[1m'),
-    };
-  }
-  return {
+  // Named ANSI colors as default — respects terminal theme (like the original JS).
+  // Only orange uses 256-color (no named ANSI equivalent).
+  // Truecolor/256 modes available for users who override via config.
+  const named: Colors = {
     cyan: wrap('\x1b[36m'), magenta: wrap('\x1b[35m'),
     yellow: wrap('\x1b[33m'), green: wrap('\x1b[32m'),
     orange: wrap('\x1b[38;5;208m'), red: wrap('\x1b[31m'),
     blinkRed: wrap('\x1b[5;31m'), gray: wrap('\x1b[90m'),
     brightBlue: wrap('\x1b[94m'), dim: wrap('\x1b[2m'), bold: wrap('\x1b[1m'),
   };
+
+  if (mode === 'truecolor') {
+    return {
+      ...named,
+      cyan: wrap('\x1b[38;2;0;255;255m'), magenta: wrap('\x1b[38;2;255;0;255m'),
+      yellow: wrap('\x1b[38;2;255;255;0m'), green: wrap('\x1b[38;2;0;255;0m'),
+      orange: wrap('\x1b[38;2;255;165;0m'),
+      brightBlue: wrap('\x1b[38;2;100;149;237m'),
+    };
+  }
+  if (mode === '256') {
+    return {
+      ...named,
+      cyan: wrap('\x1b[38;5;51m'), magenta: wrap('\x1b[38;5;201m'),
+      yellow: wrap('\x1b[38;5;226m'), green: wrap('\x1b[38;5;46m'),
+      brightBlue: wrap('\x1b[38;5;111m'),
+    };
+  }
+  return named;
 }
 
 export function stripAnsi(str: string): string {
@@ -52,10 +56,8 @@ export function stripAnsi(str: string): string {
 }
 
 export function detectColorMode(): ColorMode {
-  const colorterm = process.env['COLORTERM'] ?? '';
-  if (colorterm === 'truecolor' || colorterm === '24bit') return 'truecolor';
-  const term = process.env['TERM'] ?? '';
-  if (term.includes('256color')) return '256';
+  // Default to named ANSI — respects terminal theme colors.
+  // Only upgrade if user explicitly sets colors.mode in config.
   return 'named';
 }
 

--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -1,0 +1,73 @@
+export type ColorMode = 'named' | '256' | 'truecolor';
+export type ColorName = 'cyan' | 'magenta' | 'yellow' | 'green' | 'orange' | 'red' | 'blinkRed' | 'gray' | 'brightBlue' | 'dim' | 'bold';
+
+const RST = '\x1b[0m';
+
+export interface Colors {
+  cyan: (s: string) => string;
+  magenta: (s: string) => string;
+  yellow: (s: string) => string;
+  green: (s: string) => string;
+  orange: (s: string) => string;
+  red: (s: string) => string;
+  blinkRed: (s: string) => string;
+  gray: (s: string) => string;
+  brightBlue: (s: string) => string;
+  dim: (s: string) => string;
+  bold: (s: string) => string;
+}
+
+export function createColors(mode: ColorMode): Colors {
+  const wrap = (code: string) => (s: string) => `${code}${s}${RST}`;
+
+  if (mode === 'truecolor') {
+    return {
+      cyan: wrap('\x1b[38;2;0;255;255m'), magenta: wrap('\x1b[38;2;255;0;255m'),
+      yellow: wrap('\x1b[38;2;255;255;0m'), green: wrap('\x1b[38;2;0;255;0m'),
+      orange: wrap('\x1b[38;2;255;165;0m'), red: wrap('\x1b[31m'),
+      blinkRed: wrap('\x1b[5;31m'), gray: wrap('\x1b[90m'),
+      brightBlue: wrap('\x1b[38;2;100;149;237m'), dim: wrap('\x1b[2m'), bold: wrap('\x1b[1m'),
+    };
+  }
+  if (mode === '256') {
+    return {
+      cyan: wrap('\x1b[38;5;51m'), magenta: wrap('\x1b[38;5;201m'),
+      yellow: wrap('\x1b[38;5;226m'), green: wrap('\x1b[38;5;46m'),
+      orange: wrap('\x1b[38;5;208m'), red: wrap('\x1b[31m'),
+      blinkRed: wrap('\x1b[5;31m'), gray: wrap('\x1b[90m'),
+      brightBlue: wrap('\x1b[38;5;111m'), dim: wrap('\x1b[2m'), bold: wrap('\x1b[1m'),
+    };
+  }
+  return {
+    cyan: wrap('\x1b[36m'), magenta: wrap('\x1b[35m'),
+    yellow: wrap('\x1b[33m'), green: wrap('\x1b[32m'),
+    orange: wrap('\x1b[38;5;208m'), red: wrap('\x1b[31m'),
+    blinkRed: wrap('\x1b[5;31m'), gray: wrap('\x1b[90m'),
+    brightBlue: wrap('\x1b[94m'), dim: wrap('\x1b[2m'), bold: wrap('\x1b[1m'),
+  };
+}
+
+export function stripAnsi(str: string): string {
+  return str.replace(/\x1b\[\??[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b[()][AB012]/g, '');
+}
+
+export function detectColorMode(): ColorMode {
+  const colorterm = process.env['COLORTERM'] ?? '';
+  if (colorterm === 'truecolor' || colorterm === '24bit') return 'truecolor';
+  const term = process.env['TERM'] ?? '';
+  if (term.includes('256color')) return '256';
+  return 'named';
+}
+
+export function getContextColor(pct: number): ColorName {
+  if (pct < 50) return 'green';
+  if (pct < 65) return 'yellow';
+  if (pct < 80) return 'orange';
+  return 'blinkRed';
+}
+
+export function getQuotaColor(pct: number): ColorName {
+  if (pct < 70) return 'yellow';
+  if (pct < 85) return 'orange';
+  return 'blinkRed';
+}

--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -67,6 +67,7 @@ export function getContextColor(pct: number): ColorName {
 }
 
 export function getQuotaColor(pct: number): ColorName {
+  if (pct < 50) return 'green';
   if (pct < 70) return 'yellow';
   if (pct < 85) return 'orange';
   return 'blinkRed';

--- a/src/render/icons.ts
+++ b/src/render/icons.ts
@@ -1,0 +1,19 @@
+export const ICONS = {
+  model:    '\uEE0D',  // fa-robot
+  branch:   '\uE725',  // dev-git-branch
+  folder:   '\uF07C',  // fa-folder-open
+  fire:     '\uF06D',  // fa-fire (context 65-79%)
+  skull:    '\uEE15',  // fa-skull (context >=80%)
+  comment:  '\uF075',  // fa-comment (tokens)
+  clock:    '\uF017',  // fa-clock (duration)
+  bolt:     '\uF0E7',  // fa-bolt (token speed, rate limits)
+  tree:     '\uF1BB',  // fa-tree (worktree)
+  cubes:    '\uF1B3',  // fa-cubes (agent)
+  hammer:   '\uEEFF',  // fa-hammer (GSD task)
+  warning:  '\uF071',  // fa-warning (GSD update)
+  barFull:  '\u2588',  // block full
+  barEmpty: '\u2591',  // block light
+  ellipsis: '\u2026',  // ...
+  dash:     '\u2014',  // em-dash
+  checkmark: '\u2713', // checkmark
+} as const;

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -7,7 +7,7 @@ import { renderMinimal } from './minimal.js';
 import type { RenderContext } from '../types.js';
 
 export function render(ctx: RenderContext): string {
-  const { input, git, transcript, tokenSpeed, gsd, cols, config } = ctx;
+  const { input, git, transcript, tokenSpeed, memory, gsd, cols, config } = ctx;
   const colorMode: ColorMode = config.colors.mode === 'auto' ? detectColorMode() : config.colors.mode;
   const c = createColors(colorMode);
 
@@ -17,7 +17,7 @@ export function render(ctx: RenderContext): string {
 
   const lines: string[] = [];
   lines.push(renderLine1(input, git, transcript, c, config.display, cols));
-  lines.push(renderLine2(input, tokenSpeed, transcript.thinkingEffort, c, config.display, cols));
+  lines.push(renderLine2(input, tokenSpeed, transcript.thinkingEffort, c, config.display, cols, memory));
   const l3 = renderLine3(transcript.tools, transcript.todos, c);
   if (l3) lines.push(l3);
   if (config.gsd) { const l4 = renderLine4(gsd, c); if (l4) lines.push(l4); }

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -1,0 +1,25 @@
+import { createColors, detectColorMode, type ColorMode } from './colors.js';
+import { renderLine1 } from './line1.js';
+import { renderLine2 } from './line2.js';
+import { renderLine3 } from './line3.js';
+import { renderLine4 } from './line4.js';
+import { renderMinimal } from './minimal.js';
+import type { RenderContext } from '../types.js';
+
+export function render(ctx: RenderContext): string {
+  const { input, git, transcript, tokenSpeed, gsd, cols, config } = ctx;
+  const colorMode: ColorMode = config.colors.mode === 'auto' ? detectColorMode() : config.colors.mode;
+  const c = createColors(colorMode);
+
+  if (config.layout === 'minimal' || (config.layout === 'auto' && cols < 70)) {
+    return renderMinimal(input, git, transcript, tokenSpeed, gsd, c, config.display, cols);
+  }
+
+  const lines: string[] = [];
+  lines.push(renderLine1(input, git, transcript, c, config.display, cols));
+  lines.push(renderLine2(input, tokenSpeed, transcript.thinkingEffort, c, config.display, cols));
+  const l3 = renderLine3(transcript.tools, transcript.todos, c);
+  if (l3) lines.push(l3);
+  if (config.gsd) { const l4 = renderLine4(gsd, c); if (l4) lines.push(l4); }
+  return lines.filter(Boolean).join('\n');
+}

--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -1,0 +1,105 @@
+import { basename } from 'node:path';
+import { ICONS } from './icons.js';
+import { fitSegments, truncField } from './text.js';
+import type { Colors } from './colors.js';
+import type { ClaudeCodeInput, GitStatus, TranscriptData, DisplayToggles } from '../types.js';
+
+const SEP = ` \x1b[90m│\x1b[0m `;
+
+function getModelName(model: ClaudeCodeInput['model']): string {
+  if (typeof model === 'string') return model;
+  if (model && typeof model === 'object' && 'display_name' in model) return model.display_name;
+  return '';
+}
+
+function getActiveTodo(transcript: TranscriptData): string | undefined {
+  const inProgress = transcript.todos.filter(t => t.status === 'in_progress');
+  return inProgress[0]?.content;
+}
+
+export function renderLine1(
+  input: ClaudeCodeInput,
+  git: GitStatus,
+  transcript: TranscriptData,
+  c: Colors,
+  display: DisplayToggles,
+  cols: number
+): string {
+  const left: string[] = [];
+  const right: string[] = [];
+
+  // Model
+  if (display.model) {
+    const modelName = getModelName(input.model);
+    if (modelName) left.push(c.cyan(`${ICONS.model} ${modelName}`));
+  }
+
+  // Branch + git changes
+  if (display.branch && git.branch) {
+    const branchLen = cols < 60 ? 12 : cols < 80 ? 20 : cols < 100 ? 30 : cols < 120 ? 40 : 60;
+    const branchName = truncField(git.branch, branchLen);
+    let branchStr = c.magenta(`${ICONS.branch} ${branchName}`);
+
+    if (display.gitChanges) {
+      const parts: string[] = [];
+      if (git.staged > 0) parts.push(c.green(`+${git.staged}`));
+      if (git.modified > 0) parts.push(c.yellow(`~${git.modified}`));
+      if (git.untracked > 0) parts.push(c.gray(`?${git.untracked}`));
+      if (parts.length > 0) branchStr += ' ' + parts.join(' ');
+    }
+    left.push(branchStr);
+  }
+
+  // Directory
+  if (display.directory) {
+    const cwd = input.cwd || input.workspace?.current_dir || '';
+    if (cwd) {
+      const dirName = basename(cwd) || cwd;
+      const dirLen = cols < 80 ? 12 : cols < 120 ? 20 : 30;
+      left.push(c.brightBlue(`${ICONS.folder} ${truncField(dirName, dirLen)}`));
+    }
+  }
+
+  // Lines changed (right side)
+  if (display.linesChanged && input.cost) {
+    const added = input.cost.total_lines_added ?? 0;
+    const removed = input.cost.total_lines_removed ?? 0;
+    if (added > 0 || removed > 0) {
+      right.push(`${c.green(`+${added}`)} ${c.red(`-${removed}`)}`);
+    }
+  }
+
+  // Active task from todos
+  const activeTask = getActiveTodo(transcript);
+  if (activeTask) {
+    right.push(c.yellow(truncField(activeTask, 30)));
+  }
+
+  // Worktree
+  if (display.worktree && input.worktree?.name) {
+    right.push(c.gray(`${ICONS.tree} ${truncField(input.worktree.name, 15)}`));
+  }
+
+  // Agent
+  if (display.agent && input.agent?.name) {
+    right.push(c.gray(`${ICONS.cubes} ${truncField(input.agent.name, 15)}`));
+  }
+
+  // Session name
+  if (display.sessionName && input.session_name) {
+    right.push(c.dim(truncField(input.session_name, 20)));
+  }
+
+  // Style
+  if (display.style && input.output_style?.name && input.output_style.name !== 'default') {
+    right.push(c.dim(input.output_style.name));
+  }
+
+  // Version
+  if (display.version && input.version) {
+    right.push(c.dim(`v${input.version}`));
+  }
+
+  if (left.length === 0 && right.length === 0) return '';
+  return fitSegments(left, right, SEP, cols);
+}

--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -43,7 +43,7 @@ export function renderLine1(
     if (display.gitChanges) {
       const parts: string[] = [];
       if (git.staged > 0) parts.push(c.green(`+${git.staged}`));
-      if (git.modified > 0) parts.push(c.yellow(`~${git.modified}`));
+      if (git.modified > 0) parts.push(c.yellow(`!${git.modified}`));
       if (git.untracked > 0) parts.push(c.gray(`?${git.untracked}`));
       if (parts.length > 0) branchStr += ' ' + parts.join(' ');
     }

--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -91,8 +91,8 @@ export function renderLine1(
   }
 
   // Style
-  if (display.style && input.output_style?.name && input.output_style.name !== 'default') {
-    right.push(c.dim(input.output_style.name));
+  if (display.style && input.output_style?.name) {
+    right.push(c.gray(input.output_style.name));
   }
 
   // Version

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -1,0 +1,112 @@
+import { ICONS } from './icons.js';
+import { padLine, displayWidth } from './text.js';
+import { getContextColor, getQuotaColor, type Colors } from './colors.js';
+import { formatTokens, formatDuration, formatCost, formatBurnRate } from '../utils/format.js';
+import type { ClaudeCodeInput, DisplayToggles, ThinkingEffort } from '../types.js';
+
+const SEP = ` \x1b[90m│\x1b[0m `;
+
+function buildContextBar(pct: number, c: Colors): string {
+  const SEGMENTS = 20;
+  const filled = Math.round((pct / 100) * SEGMENTS);
+  const colorFn = c[getContextColor(pct)];
+  const bar = colorFn(ICONS.barFull.repeat(filled)) + c.dim(ICONS.barEmpty.repeat(SEGMENTS - filled));
+  let icon = '';
+  if (pct >= 80) icon = c.blinkRed(ICONS.skull);
+  else if (pct >= 65) icon = c.orange(ICONS.fire);
+  const pctStr = colorFn(`${pct.toFixed(0)}%`);
+  return `[${bar}] ${pctStr}${icon ? ' ' + icon : ''}`;
+}
+
+function formatCountdown(resetsAt: number): string {
+  const diffMs = resetsAt - Date.now();
+  if (diffMs <= 0) return '';
+  const totalSec = Math.floor(diffMs / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  if (h > 0) return `${h}h${String(m).padStart(2, '0')}m`;
+  if (m > 0) return `${m}m${String(s).padStart(2, '0')}s`;
+  return `${s}s`;
+}
+
+export function renderLine2(
+  input: ClaudeCodeInput,
+  tokenSpeed: number | null,
+  thinkingEffort: ThinkingEffort,
+  c: Colors,
+  display: DisplayToggles,
+  cols: number
+): string {
+  const leftParts: string[] = [];
+  const rightParts: string[] = [];
+
+  // Context bar
+  if (display.contextBar) {
+    const pct = input.context_window.used_percentage;
+    leftParts.push(buildContextBar(pct, c));
+  }
+
+  // Tokens
+  if (display.tokens) {
+    const inTokens = input.context_window.total_input_tokens;
+    const outTokens = input.context_window.total_output_tokens;
+    const parts: string[] = [];
+    if (inTokens != null) parts.push(`${formatTokens(inTokens)}↑`);
+    if (outTokens != null) parts.push(`${formatTokens(outTokens)}↓`);
+    if (parts.length > 0) leftParts.push(`${ICONS.comment} ${parts.join(' ')}`);
+  }
+
+  // Cost + burn rate
+  if (display.cost && input.cost) {
+    const costStr = formatCost(input.cost.total_cost_usd);
+    let costPart = costStr;
+    if (display.burnRate) {
+      const burn = formatBurnRate(input.cost.total_cost_usd, input.cost.total_duration_ms);
+      if (burn) costPart += ` ${c.dim(burn)}`;
+    }
+    leftParts.push(costPart);
+  }
+
+  // Duration
+  if (display.duration && input.cost) {
+    leftParts.push(`${ICONS.clock} ${formatDuration(input.cost.total_duration_ms)}`);
+  }
+
+  // Token speed
+  if (display.tokenSpeed && tokenSpeed != null) {
+    leftParts.push(c.dim(`${ICONS.bolt}${tokenSpeed} tok/s`));
+  }
+
+  // Rate limits (only show if >=50%)
+  if (display.rateLimits && input.rate_limits) {
+    const limits: [string, typeof input.rate_limits.five_hour][] = [
+      ['5h', input.rate_limits.five_hour],
+      ['7d', input.rate_limits.seven_day],
+    ];
+    for (const [label, win] of limits) {
+      if (!win || win.used_percentage < 50) continue;
+      const colorFn = c[getQuotaColor(win.used_percentage)];
+      let limitStr = colorFn(`${ICONS.bolt} ${win.used_percentage.toFixed(0)}%(${label})`);
+      if (win.used_percentage >= 70 && win.resets_at) {
+        const countdown = formatCountdown(win.resets_at);
+        if (countdown) limitStr += c.dim(` ${countdown}`);
+      }
+      leftParts.push(limitStr);
+    }
+  }
+
+  // Right side: vim mode
+  if (display.vim && input.vim?.mode) {
+    rightParts.push(c.dim(`[${input.vim.mode}]`));
+  }
+
+  // Right side: effort (hidden if medium)
+  if (display.effort && thinkingEffort && thinkingEffort !== 'medium') {
+    rightParts.push(c.dim(`^${thinkingEffort}`));
+  }
+
+  const leftStr = leftParts.join(SEP);
+  if (rightParts.length === 0) return leftStr;
+  return padLine(leftStr, rightParts.join(' '), cols);
+}

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -14,7 +14,7 @@ function buildContextBar(pct: number, c: Colors): string {
   let icon = '';
   if (pct >= 80) icon = c.blinkRed(ICONS.skull);
   else if (pct >= 65) icon = c.orange(ICONS.fire);
-  const pctStr = colorFn(`${pct.toFixed(0)}%`);
+  const pctStr = colorFn(`${pct < 10 ? pct.toFixed(1) : pct.toFixed(0)}%`);
   return `[${bar}] ${pctStr}${icon ? ' ' + icon : ''}`;
 }
 

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -2,7 +2,7 @@ import { ICONS } from './icons.js';
 import { padLine, displayWidth } from './text.js';
 import { getContextColor, getQuotaColor, type Colors } from './colors.js';
 import { formatTokens, formatDuration, formatCost, formatBurnRate } from '../utils/format.js';
-import type { ClaudeCodeInput, DisplayToggles, ThinkingEffort } from '../types.js';
+import type { ClaudeCodeInput, DisplayToggles, ThinkingEffort, MemoryInfo } from '../types.js';
 
 const SEP = ` \x1b[90m│\x1b[0m `;
 
@@ -36,7 +36,8 @@ export function renderLine2(
   thinkingEffort: ThinkingEffort,
   c: Colors,
   display: DisplayToggles,
-  cols: number
+  cols: number,
+  memory: MemoryInfo | null = null
 ): string {
   const leftParts: string[] = [];
   const rightParts: string[] = [];
@@ -71,6 +72,11 @@ export function renderLine2(
   // Duration
   if (display.duration && input.cost) {
     leftParts.push(`${ICONS.clock} ${formatDuration(input.cost.total_duration_ms)}`);
+  }
+
+  // Memory
+  if (display.memory && memory) {
+    leftParts.push(c.dim(`${memory.percentage}% mem`));
   }
 
   // Token speed

--- a/src/render/line3.ts
+++ b/src/render/line3.ts
@@ -1,0 +1,73 @@
+import { ICONS } from './icons.js';
+import { truncField } from './text.js';
+import type { Colors } from './colors.js';
+import type { ToolEntry, TodoEntry } from '../types.js';
+
+const EXCLUDED_TOOLS = new Set(['TodoWrite', 'TaskCreate', 'TaskUpdate']);
+const SEP_GRAY = ` \x1b[90m│\x1b[0m `;
+
+function buildToolsPart(tools: ToolEntry[], c: Colors): string {
+  const relevant = tools.filter(t => !EXCLUDED_TOOLS.has(t.name));
+  if (relevant.length === 0) return '';
+
+  const parts: string[] = [];
+
+  // Running tools (last 2)
+  const running = relevant.filter(t => t.status === 'running').slice(-2);
+  for (const tool of running) {
+    const target = tool.target ? `: ${truncField(tool.target, 20)}` : '';
+    parts.push(c.yellow(`◐ ${tool.name}${target}`));
+  }
+
+  // Completed tools grouped by name (top 4 groups)
+  const completed = relevant.filter(t => t.status === 'completed');
+  const groups = new Map<string, number>();
+  for (const tool of completed) {
+    groups.set(tool.name, (groups.get(tool.name) ?? 0) + 1);
+  }
+
+  const topGroups = Array.from(groups.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 4);
+
+  for (const [name, count] of topGroups) {
+    const countStr = count > 1 ? ` ×${count}` : '';
+    parts.push(c.dim(`${ICONS.checkmark} ${name}${countStr}`));
+  }
+
+  return parts.join(' ');
+}
+
+function buildTodosPart(todos: TodoEntry[], c: Colors): string {
+  if (todos.length === 0) return '';
+
+  const total = todos.length;
+  const completed = todos.filter(t => t.status === 'completed').length;
+  const inProgress = todos.filter(t => t.status === 'in_progress').length;
+  const pending = todos.filter(t => t.status === 'pending').length;
+
+  // Progress bar (10 segments)
+  const SEGMENTS = 10;
+  const filledCount = Math.round((completed / total) * SEGMENTS);
+  const bar = c.green(ICONS.barFull.repeat(filledCount)) + c.dim(ICONS.barEmpty.repeat(SEGMENTS - filledCount));
+  let str = `${bar} ${completed}/${total}`;
+
+  if (inProgress > 0) str += ` ${c.yellow(`◐ ${inProgress}`)}`;
+  if (pending > 0) str += ` ${c.dim(`○ ${pending}`)}`;
+
+  return str;
+}
+
+export function renderLine3(
+  tools: ToolEntry[],
+  todos: TodoEntry[],
+  c: Colors
+): string {
+  const toolsPart = buildToolsPart(tools, c);
+  const todosPart = buildTodosPart(todos, c);
+
+  if (!toolsPart && !todosPart) return '';
+  if (!toolsPart) return todosPart;
+  if (!todosPart) return toolsPart;
+  return toolsPart + SEP_GRAY + todosPart;
+}

--- a/src/render/line4.ts
+++ b/src/render/line4.ts
@@ -1,0 +1,24 @@
+import { ICONS } from './icons.js';
+import { truncField } from './text.js';
+import type { Colors } from './colors.js';
+import type { GsdInfo } from '../types.js';
+
+export function renderLine4(
+  gsd: GsdInfo | null,
+  c: Colors
+): string {
+  if (!gsd) return '';
+  if (!gsd.currentTask && !gsd.updateAvailable) return '';
+
+  const parts: string[] = [c.dim('GSD')];
+
+  if (gsd.currentTask) {
+    parts.push(c.bold(`${ICONS.hammer} ${truncField(gsd.currentTask, 40)}`));
+  }
+
+  if (gsd.updateAvailable) {
+    parts.push(c.yellow(`${ICONS.warning} GSD update available`));
+  }
+
+  return parts.join(' ');
+}

--- a/src/render/minimal.ts
+++ b/src/render/minimal.ts
@@ -1,0 +1,138 @@
+import { basename } from 'node:path';
+import { ICONS } from './icons.js';
+import { truncField } from './text.js';
+import { getContextColor, type Colors } from './colors.js';
+import { formatTokens, formatDuration, formatCost } from '../utils/format.js';
+import { renderLine3 } from './line3.js';
+import type { ClaudeCodeInput, GitStatus, TranscriptData, DisplayToggles, GsdInfo } from '../types.js';
+
+const SEP = ` \x1b[90m|\x1b[0m `;
+
+function getModelName(model: ClaudeCodeInput['model']): string {
+  if (typeof model === 'string') return model;
+  if (model && typeof model === 'object' && 'display_name' in model) return model.display_name;
+  return '';
+}
+
+function buildContextBar(pct: number, c: Colors): string {
+  const SEGMENTS = 10;
+  const filled = Math.round((pct / 100) * SEGMENTS);
+  const colorFn = c[getContextColor(pct)];
+  const bar = colorFn(ICONS.barFull.repeat(filled)) + c.dim(ICONS.barEmpty.repeat(SEGMENTS - filled));
+  return `[${bar} ${colorFn(`${pct.toFixed(0)}%`)}]`;
+}
+
+export function renderMinimal(
+  input: ClaudeCodeInput,
+  git: GitStatus,
+  transcript: TranscriptData,
+  tokenSpeed: number | null,
+  gsd: GsdInfo | null,
+  c: Colors,
+  display: DisplayToggles,
+  cols: number
+): string {
+  const parts: string[] = [];
+
+  // Directory
+  const cwd = input.cwd || input.workspace?.current_dir || '';
+  if (display.directory && cwd) {
+    const dirName = basename(cwd) || cwd;
+    const dirLen = cols < 60 ? 12 : cols < 80 ? 20 : 30;
+    parts.push(c.brightBlue(truncField(dirName, dirLen)));
+  }
+
+  // Branch
+  if (display.branch && git.branch) {
+    const branchLen = cols < 60 ? 12 : cols < 80 ? 20 : git.branch.length;
+    let branchStr = c.magenta(truncField(git.branch, branchLen));
+    if (display.gitChanges) {
+      const changeParts: string[] = [];
+      if (git.staged > 0) changeParts.push(c.green(`+${git.staged}`));
+      if (git.modified > 0) changeParts.push(c.yellow(`~${git.modified}`));
+      if (git.untracked > 0) changeParts.push(c.gray(`?${git.untracked}`));
+      if (changeParts.length > 0) branchStr += ' ' + changeParts.join(' ');
+    }
+    parts.push(branchStr);
+  }
+
+  // Model
+  if (display.model) {
+    const modelName = getModelName(input.model);
+    if (modelName) parts.push(c.cyan(truncField(modelName, 20)));
+  }
+
+  // Context bar
+  if (display.contextBar) {
+    parts.push(buildContextBar(input.context_window.used_percentage, c));
+  }
+
+  // Only add these if cols >= 60
+  if (cols >= 60) {
+    // Tokens
+    if (display.tokens) {
+      const inTokens = input.context_window.total_input_tokens;
+      const outTokens = input.context_window.total_output_tokens;
+      const tParts: string[] = [];
+      if (inTokens != null) tParts.push(`${formatTokens(inTokens)}↑`);
+      if (outTokens != null) tParts.push(`${formatTokens(outTokens)}↓`);
+      if (tParts.length > 0) parts.push(tParts.join(' '));
+    }
+
+    // Cost
+    if (display.cost && input.cost) {
+      parts.push(formatCost(input.cost.total_cost_usd));
+    }
+
+    // Duration
+    if (display.duration && input.cost) {
+      parts.push(formatDuration(input.cost.total_duration_ms));
+    }
+
+    // Token speed
+    if (display.tokenSpeed && tokenSpeed != null) {
+      parts.push(c.dim(`${tokenSpeed} tok/s`));
+    }
+
+    // Lines changed
+    if (display.linesChanged && input.cost) {
+      const added = input.cost.total_lines_added ?? 0;
+      const removed = input.cost.total_lines_removed ?? 0;
+      if (added > 0 || removed > 0) {
+        parts.push(`${c.green(`+${added}`)}${c.red(`-${removed}`)}`);
+      }
+    }
+
+    // Style
+    if (display.style && input.output_style?.name && input.output_style.name !== 'default') {
+      parts.push(c.dim(input.output_style.name));
+    }
+
+    // Version
+    if (display.version && input.version) {
+      parts.push(c.dim(`v${input.version}`));
+    }
+
+    // GSD current task
+    if (gsd?.currentTask) {
+      parts.push(c.yellow(truncField(gsd.currentTask, 20)));
+    }
+
+    // Worktree
+    if (display.worktree && input.worktree?.name) {
+      parts.push(c.dim(`${ICONS.tree} ${truncField(input.worktree.name, 12)}`));
+    }
+
+    // Agent
+    if (display.agent && input.agent?.name) {
+      parts.push(c.dim(`${ICONS.cubes} ${truncField(input.agent.name, 12)}`));
+    }
+  }
+
+  const mainLine = parts.join(SEP);
+
+  // Append tools/todos as extra line
+  const l3 = renderLine3(transcript.tools, transcript.todos, c);
+  if (l3) return mainLine + '\n' + l3;
+  return mainLine;
+}

--- a/src/render/minimal.ts
+++ b/src/render/minimal.ts
@@ -104,7 +104,7 @@ export function renderMinimal(
     }
 
     // Style
-    if (display.style && input.output_style?.name && input.output_style.name !== 'default') {
+    if (display.style && input.output_style?.name) {
       parts.push(c.dim(input.output_style.name));
     }
 

--- a/src/render/text.ts
+++ b/src/render/text.ts
@@ -1,0 +1,54 @@
+import { stripAnsi } from './colors.js';
+
+export function displayWidth(str: string): number {
+  const clean = stripAnsi(str);
+  let w = 0;
+  for (const ch of clean) {
+    const cp = ch.codePointAt(0)!;
+    if ((cp >= 0xFE00 && cp <= 0xFE0F) || cp === 0x200D || (cp >= 0x0300 && cp <= 0x036F)) continue;
+    if (cp >= 0x1F000 || (cp >= 0x2600 && cp <= 0x27BF) || (cp >= 0x2B00 && cp <= 0x2BFF) ||
+        (cp >= 0x4E00 && cp <= 0x9FFF) || (cp >= 0x3000 && cp <= 0x303F) || (cp >= 0xFF00 && cp <= 0xFFEF)) {
+      w += 2;
+    } else { w += 1; }
+  }
+  return w;
+}
+
+export function truncField(str: string, max: number): string {
+  if (str.length <= max) return str;
+  return str.slice(0, Math.max(0, max - 1)) + '\u2026';
+}
+
+export function truncatePath(str: string, maxLen: number = 20): string {
+  if (!str) return '';
+  const normalized = str.replace(/\\/g, '/');
+  if (normalized.length <= maxLen) return normalized;
+  const parts = normalized.split('/');
+  const filename = parts.pop() || normalized;
+  if (filename.length >= maxLen) return filename.slice(0, maxLen - 3) + '...';
+  return '.../' + filename;
+}
+
+export function fitSegments(left: string[], right: string[], sep: string, cols: number): string {
+  const safeCols = cols - 4;
+  const leftStr = left.join(sep);
+  const leftW = displayWidth(leftStr);
+  for (let r = right.length; r >= 0; r--) {
+    const rSlice = right.slice(0, r);
+    if (rSlice.length === 0) return leftStr;
+    const rightStr = rSlice.join(sep);
+    const rightW = displayWidth(rightStr);
+    if (leftW + 1 + rightW <= safeCols) {
+      const gap = Math.max(1, safeCols - leftW - rightW);
+      return leftStr + ' '.repeat(gap) + rightStr;
+    }
+  }
+  return leftStr;
+}
+
+export function padLine(left: string, right: string, cols: number): string {
+  const leftW = displayWidth(left);
+  const rightW = displayWidth(right);
+  const gap = Math.max(1, cols - leftW - rightW);
+  return left + ' '.repeat(gap) + right;
+}

--- a/src/render/text.ts
+++ b/src/render/text.ts
@@ -6,7 +6,8 @@ export function displayWidth(str: string): number {
   for (const ch of clean) {
     const cp = ch.codePointAt(0)!;
     if ((cp >= 0xFE00 && cp <= 0xFE0F) || cp === 0x200D || (cp >= 0x0300 && cp <= 0x036F)) continue;
-    if (cp >= 0x1F000 || (cp >= 0x2600 && cp <= 0x27BF) || (cp >= 0x2B00 && cp <= 0x2BFF) ||
+    if (cp >= 0x1F000 || (cp >= 0x2300 && cp <= 0x257F) || (cp >= 0x25A0 && cp <= 0x25FF) ||
+        (cp >= 0x2600 && cp <= 0x27BF) || (cp >= 0x2B00 && cp <= 0x2BFF) ||
         (cp >= 0x4E00 && cp <= 0x9FFF) || (cp >= 0x3000 && cp <= 0x303F) || (cp >= 0xFF00 && cp <= 0xFFEF)) {
       w += 2;
     } else { w += 1; }
@@ -15,8 +16,17 @@ export function displayWidth(str: string): number {
 }
 
 export function truncField(str: string, max: number): string {
-  if (str.length <= max) return str;
-  return str.slice(0, Math.max(0, max - 1)) + '\u2026';
+  if (displayWidth(str) <= max) return str;
+  // Build truncated string character by character using display width
+  let result = '';
+  let w = 0;
+  for (const ch of str) {
+    const cw = displayWidth(ch);
+    if (w + cw + 1 > max) break; // +1 for ellipsis
+    result += ch;
+    w += cw;
+  }
+  return result + '\u2026';
 }
 
 export function truncatePath(str: string, maxLen: number = 20): string {

--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -1,0 +1,25 @@
+import type { Readable } from 'node:stream';
+import type { ClaudeCodeInput } from './types.js';
+
+export function readStdin(stream: Readable = process.stdin, firstByteTimeoutMs: number = 250, idleTimeoutMs: number = 30): Promise<ClaudeCodeInput> {
+  return new Promise((resolve, reject) => {
+    let input = '';
+    let gotFirstByte = false;
+    const firstByteTimer = setTimeout(() => { cleanup(); reject(new Error('stdin timeout')); }, firstByteTimeoutMs);
+    let idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const cleanup = () => { clearTimeout(firstByteTimer); if (idleTimer) clearTimeout(idleTimer); stream.removeAllListeners(); };
+    const tryParse = () => { try { const d = JSON.parse(input); cleanup(); resolve(d); return true; } catch { return false; } };
+
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk: string) => {
+      if (!gotFirstByte) { gotFirstByte = true; clearTimeout(firstByteTimer); }
+      input += chunk;
+      if (tryParse()) return;
+      if (idleTimer) clearTimeout(idleTimer);
+      idleTimer = setTimeout(() => tryParse(), idleTimeoutMs);
+    });
+    stream.on('end', () => { cleanup(); try { resolve(JSON.parse(input)); } catch (e) { reject(e); } });
+    stream.on('error', (e) => { cleanup(); reject(e); });
+  });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,207 @@
+// ── Claude Code stdin JSON ──────────────────────────────────────────
+
+export interface ClaudeCodeInput {
+  model: string | { display_name: string };
+  session_id: string;
+  session_name?: string;
+  cwd?: string;
+  workspace?: { current_dir: string };
+  context_window: {
+    used_percentage: number;
+    remaining_percentage: number;
+    total_input_tokens?: number;
+    total_output_tokens?: number;
+    current_usage?: { output_tokens: number };
+  };
+  cost: {
+    total_cost_usd: number;
+    total_duration_ms: number;
+    total_lines_added?: number;
+    total_lines_removed?: number;
+  };
+  transcript_path?: string;
+  output_style?: { name: string };
+  version?: string;
+  agent?: { name: string };
+  worktree?: { name: string };
+  vim?: { mode: string };
+  rate_limits?: {
+    five_hour?: RateLimitWindow;
+    seven_day?: RateLimitWindow;
+  };
+  exceeds_200k_tokens?: boolean;
+}
+
+export interface RateLimitWindow {
+  used_percentage: number;
+  resets_at?: number;
+}
+
+// ── Parser outputs ──────────────────────────────────────────────────
+
+export interface GitStatus {
+  branch: string;
+  staged: number;
+  modified: number;
+  untracked: number;
+}
+
+export const EMPTY_GIT: GitStatus = {
+  branch: '',
+  staged: 0,
+  modified: 0,
+  untracked: 0,
+};
+
+export interface TranscriptData {
+  tools: ToolEntry[];
+  agents: AgentEntry[];
+  todos: TodoEntry[];
+  thinkingEffort: ThinkingEffort;
+  sessionStart: Date | null;
+}
+
+export const EMPTY_TRANSCRIPT: TranscriptData = {
+  tools: [],
+  agents: [],
+  todos: [],
+  thinkingEffort: '',
+  sessionStart: null,
+};
+
+export type ThinkingEffort = 'low' | 'medium' | 'high' | 'max' | '';
+
+export type ToolStatus = 'running' | 'completed' | 'error';
+
+export interface ToolEntry {
+  id: string;
+  name: string;
+  target?: string;
+  status: ToolStatus;
+  startTime: Date;
+  endTime?: Date;
+}
+
+export interface AgentEntry {
+  id: string;
+  type: string;
+  model?: string;
+  description?: string;
+  status: ToolStatus;
+  startTime: Date;
+  endTime?: Date;
+}
+
+export type TodoStatus = 'pending' | 'in_progress' | 'completed';
+
+export interface TodoEntry {
+  id: string;
+  content: string;
+  status: TodoStatus;
+}
+
+export interface GsdInfo {
+  currentTask?: string;
+  updateAvailable?: boolean;
+}
+
+export interface MemoryInfo {
+  usedBytes: number;
+  totalBytes: number;
+  percentage: number;
+}
+
+// ── Render context ──────────────────────────────────────────────────
+
+export interface RenderContext {
+  input: ClaudeCodeInput;
+  git: GitStatus;
+  transcript: TranscriptData;
+  tokenSpeed: number | null;
+  memory: MemoryInfo | null;
+  gsd: GsdInfo | null;
+  cols: number;
+  config: HudConfig;
+}
+
+// ── Config ──────────────────────────────────────────────────────────
+
+export interface HudConfig {
+  layout: 'custom' | 'minimal' | 'auto';
+  gsd: boolean;
+  display: DisplayToggles;
+  colors: ColorConfig;
+}
+
+export interface DisplayToggles {
+  model: boolean;
+  branch: boolean;
+  gitChanges: boolean;
+  directory: boolean;
+  contextBar: boolean;
+  tokens: boolean;
+  cost: boolean;
+  burnRate: boolean;
+  duration: boolean;
+  tokenSpeed: boolean;
+  rateLimits: boolean;
+  tools: boolean;
+  todos: boolean;
+  vim: boolean;
+  effort: boolean;
+  worktree: boolean;
+  agent: boolean;
+  sessionName: boolean;
+  style: boolean;
+  version: boolean;
+  linesChanged: boolean;
+  memory: boolean;
+}
+
+export interface ColorConfig {
+  mode: 'auto' | 'named' | '256' | 'truecolor';
+}
+
+export const DEFAULT_DISPLAY: DisplayToggles = {
+  model: true,
+  branch: true,
+  gitChanges: true,
+  directory: true,
+  contextBar: true,
+  tokens: true,
+  cost: true,
+  burnRate: true,
+  duration: true,
+  tokenSpeed: true,
+  rateLimits: true,
+  tools: true,
+  todos: true,
+  vim: true,
+  effort: true,
+  worktree: true,
+  agent: true,
+  sessionName: true,
+  style: true,
+  version: true,
+  linesChanged: true,
+  memory: true,
+};
+
+export const DEFAULT_CONFIG: HudConfig = {
+  layout: 'auto',
+  gsd: false,
+  display: { ...DEFAULT_DISPLAY },
+  colors: { mode: 'auto' },
+};
+
+// ── Dependency injection ────────────────────────────────────────────
+
+export interface Dependencies {
+  readStdin: () => Promise<ClaudeCodeInput>;
+  parseGit: (cwd: string) => Promise<GitStatus>;
+  parseTranscript: (path: string) => Promise<TranscriptData>;
+  getTokenSpeed: (contextWindow: ClaudeCodeInput['context_window']) => number | null;
+  getMemoryInfo: () => MemoryInfo | null;
+  getGsdInfo: (session: string) => GsdInfo | null;
+  getTermCols: () => number;
+}

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, statSync } from 'node:fs';
+import { readFileSync, statSync, unlinkSync, openSync, writeSync, closeSync } from 'node:fs';
 import { join } from 'node:path';
 
 export function readTtlCache<T>(key: string, dir: string, ttlMs: number = 5000): T | null {
@@ -12,7 +12,14 @@ export function readTtlCache<T>(key: string, dir: string, ttlMs: number = 5000):
 
 export function writeTtlCache(key: string, data: unknown, dir: string): void {
   const filePath = join(dir, `claude-cc-${key}.json`);
-  try { writeFileSync(filePath, JSON.stringify(data), { mode: 0o600 }); } catch {}
+  try {
+    // Remove existing file first (prevents symlink following)
+    try { unlinkSync(filePath); } catch {}
+    // Write with exclusive flag
+    const fd = openSync(filePath, 'wx', 0o600);
+    writeSync(fd, JSON.stringify(data));
+    closeSync(fd);
+  } catch {}
 }
 
 export interface MtimeState {

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,35 @@
+import { readFileSync, writeFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function readTtlCache<T>(key: string, dir: string, ttlMs: number = 5000): T | null {
+  const filePath = join(dir, `claude-cc-${key}.json`);
+  try {
+    const stat = statSync(filePath);
+    if (Date.now() - stat.mtimeMs > ttlMs) return null;
+    return JSON.parse(readFileSync(filePath, 'utf8')) as T;
+  } catch { return null; }
+}
+
+export function writeTtlCache(key: string, data: unknown, dir: string): void {
+  const filePath = join(dir, `claude-cc-${key}.json`);
+  try { writeFileSync(filePath, JSON.stringify(data), { mode: 0o600 }); } catch {}
+}
+
+export interface MtimeState {
+  mtime: number;
+  size: number;
+}
+
+export function isMtimeFresh(filePath: string, cached: MtimeState): boolean {
+  try {
+    const stat = statSync(filePath);
+    return stat.mtimeMs === cached.mtime && stat.size === cached.size;
+  } catch { return false; }
+}
+
+export function getMtimeState(filePath: string): MtimeState | null {
+  try {
+    const stat = statSync(filePath);
+    return { mtime: stat.mtimeMs, size: stat.size };
+  } catch { return null; }
+}

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -1,0 +1,16 @@
+import { execFile } from 'node:child_process';
+
+export interface ExecOptions {
+  cwd?: string;
+  timeoutMs?: number;
+}
+
+export function safeExec(cmd: string, args: string[], opts: ExecOptions = {}): Promise<string> {
+  const { cwd, timeoutMs = 2000 } = opts;
+  return new Promise((resolve) => {
+    execFile(cmd, args, { cwd, timeout: timeoutMs, encoding: 'utf8' }, (error, stdout) => {
+      if (error) { resolve(''); return; }
+      resolve((stdout ?? '').trim());
+    });
+  });
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,29 @@
+export function formatTokens(n: number): string {
+  if (n == null) return '';
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+  if (n >= 1_000) return Math.round(n / 1_000) + 'k';
+  return String(n);
+}
+
+export function formatDuration(ms: number): string {
+  if (ms == null) return '';
+  const totalSec = Math.floor(ms / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  if (h > 0) return `${h}h${String(m).padStart(2, '0')}m`;
+  if (m > 0) return `${m}m${String(s).padStart(2, '0')}s`;
+  return `${s}s`;
+}
+
+export function formatCost(usd: number): string {
+  if (usd == null) return '';
+  if (usd < 0.01) return '$' + usd.toFixed(4);
+  return '$' + usd.toFixed(2);
+}
+
+export function formatBurnRate(costUsd: number, durationMs: number): string | null {
+  if (!costUsd || durationMs <= 60_000) return null;
+  const perHour = costUsd / (durationMs / 3_600_000);
+  return '$' + perHour.toFixed(2) + '/h';
+}

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -11,7 +11,7 @@ function getTermColsFromProcTree(): number {
           const link = readlinkSync(`/proc/${pid}/fd/${fd}`);
           if (link.startsWith('/dev/pts/') || link === '/dev/tty') {
             // Shell needed for stdin redirect; path is from procfs, not user input
-            const out = execSync(`stty size < ${link}`, { shell: true, timeout: 500, encoding: 'utf8' }).trim();
+            const out = execSync(`stty size < ${link}`, { shell: '/bin/sh', timeout: 500, encoding: 'utf8' }).trim();
             const cols = parseInt(out.split(/\s+/)[1], 10);
             if (cols > 0) return cols;
           }

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -10,7 +10,8 @@ function getTermColsFromProcTree(): number {
         try {
           const link = readlinkSync(`/proc/${pid}/fd/${fd}`);
           if (link.startsWith('/dev/pts/') || link === '/dev/tty') {
-            // Shell needed for stdin redirect; path is from procfs, not user input
+            // SECURITY NOTE: `link` comes from reading /proc/{pid}/fd symlinks (kernel-controlled),
+            // never from user input. Shell is required for the stdin redirect syntax `< /dev/pts/N`.
             const out = execSync(`stty size < ${link}`, { shell: '/bin/sh', timeout: 500, encoding: 'utf8' }).trim();
             const cols = parseInt(out.split(/\s+/)[1], 10);
             if (cols > 0) return cols;

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -1,0 +1,45 @@
+import { readdirSync, readlinkSync, readFileSync } from 'node:fs';
+import { execFileSync, execSync } from 'node:child_process';
+
+function getTermColsFromProcTree(): number {
+  try {
+    let pid = process.ppid;
+    for (let i = 0; i < 5 && pid > 1; i++) {
+      const fds = readdirSync(`/proc/${pid}/fd`);
+      for (const fd of fds) {
+        try {
+          const link = readlinkSync(`/proc/${pid}/fd/${fd}`);
+          if (link.startsWith('/dev/pts/') || link === '/dev/tty') {
+            // Shell needed for stdin redirect; path is from procfs, not user input
+            const out = execSync(`stty size < ${link}`, { shell: true, timeout: 500, encoding: 'utf8' }).trim();
+            const cols = parseInt(out.split(/\s+/)[1], 10);
+            if (cols > 0) return cols;
+          }
+        } catch {}
+      }
+      const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+      pid = parseInt(stat.split(' ')[3], 10);
+    }
+  } catch {}
+  return 0;
+}
+
+export function getTermCols(): number {
+  let cols = process.stdout.columns || process.stderr.columns;
+  if (cols) return cols;
+  cols = parseInt(process.env['COLUMNS'] ?? '', 10);
+  if (cols > 0) return cols;
+  cols = getTermColsFromProcTree();
+  if (cols > 0) return cols;
+  try {
+    cols = parseInt(execFileSync('tput', ['cols'], { stdio: ['inherit', 'pipe', 'pipe'], timeout: 500, encoding: 'utf8' }).trim(), 10);
+    if (cols > 0) return cols;
+  } catch {}
+  return 120;
+}
+
+export function getLayoutCols(rawCols: number, isTTY: boolean, factor: number = 0.7): number {
+  if (isTTY) return rawCols;
+  const clamped = Math.min(Math.max(factor, 0.3), 1.0);
+  return Math.floor(rawCols * clamped);
+}

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { loadConfig, mergeCliFlags } from '../src/config.js';
+import { DEFAULT_CONFIG } from '../src/types.js';
+
+describe('loadConfig', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'cc-cfg-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('returns defaults when no config', () => { expect(loadConfig(join(dir, 'nope'))).toEqual(DEFAULT_CONFIG); });
+  it('merges partial config', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"layout":"minimal","display":{"model":false}}');
+    const c = loadConfig(dir);
+    expect(c.layout).toBe('minimal');
+    expect(c.display.model).toBe(false);
+    expect(c.display.branch).toBe(true);
+  });
+});
+
+describe('mergeCliFlags', () => {
+  it('overrides layout to minimal', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--minimal']).layout).toBe('minimal'); });
+  it('enables gsd', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--gsd']).gsd).toBe(true); });
+  it('no flags = unchanged', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i'])).toEqual(DEFAULT_CONFIG); });
+});

--- a/tests/fixtures/sample-input.json
+++ b/tests/fixtures/sample-input.json
@@ -1,0 +1,31 @@
+{
+  "model": "Opus 4.6 (1M context)",
+  "session_id": "test-session-123",
+  "session_name": "test-session",
+  "cwd": "/home/user/project",
+  "workspace": { "current_dir": "/home/user/project" },
+  "context_window": {
+    "used_percentage": 5.2,
+    "remaining_percentage": 94.8,
+    "total_input_tokens": 131000,
+    "total_output_tokens": 25000,
+    "current_usage": { "output_tokens": 25000 }
+  },
+  "cost": {
+    "total_cost_usd": 1.31,
+    "total_duration_ms": 2106000,
+    "total_lines_added": 150,
+    "total_lines_removed": 30
+  },
+  "transcript_path": "/home/user/.claude/projects/test/transcript.jsonl",
+  "output_style": { "name": "default" },
+  "version": "2.1.92",
+  "agent": null,
+  "worktree": null,
+  "vim": null,
+  "rate_limits": {
+    "five_hour": { "used_percentage": 12.5 },
+    "seven_day": { "used_percentage": 3.2 }
+  },
+  "exceeds_200k_tokens": false
+}

--- a/tests/fixtures/transcript-basic.jsonl
+++ b/tests/fixtures/transcript-basic.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-04-08T10:00:00Z","message":{"content":[{"type":"tool_use","id":"tu1","name":"Read","input":{"file_path":"/src/index.ts"}}]}}
+{"timestamp":"2026-04-08T10:00:01Z","message":{"content":[{"type":"tool_result","tool_use_id":"tu1","content":"file contents"}]}}

--- a/tests/fixtures/transcript-todos.jsonl
+++ b/tests/fixtures/transcript-todos.jsonl
@@ -1,0 +1,4 @@
+{"timestamp":"2026-04-08T10:00:00Z","message":{"content":[{"type":"tool_use","id":"tc1","name":"TaskCreate","input":{"subject":"Write tests","description":"Add unit tests","taskId":"1"}}]}}
+{"timestamp":"2026-04-08T10:00:01Z","message":{"content":[{"type":"tool_use","id":"tc2","name":"TaskCreate","input":{"subject":"Implement feature","taskId":"2"}}]}}
+{"timestamp":"2026-04-08T10:00:02Z","message":{"content":[{"type":"tool_use","id":"tu1","name":"TaskUpdate","input":{"taskId":"1","status":"in_progress"}}]}}
+{"timestamp":"2026-04-08T10:00:03Z","message":{"content":[{"type":"tool_use","id":"tu2","name":"TaskUpdate","input":{"taskId":"1","status":"completed"}}]}}

--- a/tests/fixtures/transcript-tools.jsonl
+++ b/tests/fixtures/transcript-tools.jsonl
@@ -1,0 +1,7 @@
+{"timestamp":"2026-04-08T10:00:00Z","message":{"content":[{"type":"tool_use","id":"tu1","name":"Read","input":{"file_path":"/src/index.ts"}}]}}
+{"timestamp":"2026-04-08T10:00:01Z","message":{"content":[{"type":"tool_result","tool_use_id":"tu1","content":"ok"}]}}
+{"timestamp":"2026-04-08T10:00:02Z","message":{"content":[{"type":"tool_use","id":"tu2","name":"Bash","input":{"command":"npm test --verbose flag"}}]}}
+{"timestamp":"2026-04-08T10:00:03Z","message":{"content":[{"type":"tool_result","tool_use_id":"tu2","is_error":true,"content":"fail"}]}}
+{"timestamp":"2026-04-08T10:00:04Z","message":{"content":[{"type":"tool_use","id":"tu3","name":"Edit","input":{"file_path":"/src/utils.ts"}}]}}
+{"timestamp":"2026-04-08T10:00:05Z","message":{"content":[{"type":"tool_use","id":"agent1","name":"Task","input":{"subagent_type":"Explore","model":"sonnet","description":"Find files"}}]}}
+{"timestamp":"2026-04-08T10:00:10Z","message":{"content":[{"type":"tool_result","tool_use_id":"agent1","content":"done"}]}}

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { main } from '../src/index.js';
+import { EMPTY_TRANSCRIPT } from '../src/types.js';
+import { stripAnsi } from '../src/render/colors.js';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('main', () => {
+  it('produces multi-line output', async () => {
+    const sample = JSON.parse(readFileSync(join(import.meta.dirname, 'fixtures', 'sample-input.json'), 'utf8'));
+    const output = await main({
+      readStdin: async () => sample,
+      parseGit: async () => ({ branch: 'main', staged: 0, modified: 1, untracked: 0 }),
+      parseTranscript: async () => EMPTY_TRANSCRIPT,
+      getTokenSpeed: () => 142,
+      getMemoryInfo: () => ({ usedBytes: 8e9, totalBytes: 16e9, percentage: 50 }),
+      getGsdInfo: () => null,
+      getTermCols: () => 120,
+    });
+    const plain = stripAnsi(output);
+    expect(plain).toContain('Opus 4.6');
+    expect(plain).toContain('main');
+    expect(plain).toContain('$1.31');
+    expect(output.split('\n').length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/tests/parsers/git.test.ts
+++ b/tests/parsers/git.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseGitStatus } from '../../src/parsers/git.js';
+import { EMPTY_GIT } from '../../src/types.js';
+
+describe('parseGitStatus', () => {
+  it('parses branch and porcelain output', async () => {
+    const exec = vi.fn()
+      .mockResolvedValueOnce('main')
+      .mockResolvedValueOnce('M  file.ts\n?? new.ts\nA  added.ts');
+    const result = await parseGitStatus('/test', exec);
+    expect(result.branch).toBe('main');
+    expect(result.staged).toBe(1);
+    expect(result.modified).toBe(1);
+    expect(result.untracked).toBe(1);
+  });
+  it('returns empty on git failure', async () => {
+    const exec = vi.fn().mockResolvedValue('');
+    expect(await parseGitStatus('/not-a-repo', exec)).toEqual(EMPTY_GIT);
+  });
+  it('handles no changes', async () => {
+    const exec = vi.fn().mockResolvedValueOnce('feature/test').mockResolvedValueOnce('');
+    const result = await parseGitStatus('/clean', exec);
+    expect(result.branch).toBe('feature/test');
+    expect(result.staged).toBe(0);
+  });
+});

--- a/tests/parsers/gsd.test.ts
+++ b/tests/parsers/gsd.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { getGsdInfo } from '../../src/parsers/gsd.js';
+
+describe('getGsdInfo', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'gsd-')); mkdirSync(join(dir, 'cache'), { recursive: true }); mkdirSync(join(dir, 'todos'), { recursive: true }); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('returns null when no data', () => { expect(getGsdInfo('s', dir)).toBeNull(); });
+  it('detects update available', () => {
+    writeFileSync(join(dir, 'cache', 'gsd-update-check.json'), '{"update_available":true}');
+    expect(getGsdInfo('s', dir)?.updateAvailable).toBe(true);
+  });
+  it('reads current task', () => {
+    writeFileSync(join(dir, 'todos', 's-agent-1.json'), JSON.stringify([{ status: 'in_progress', activeForm: 'Building X' }]));
+    expect(getGsdInfo('s', dir)?.currentTask).toBe('Building X');
+  });
+});

--- a/tests/parsers/memory.test.ts
+++ b/tests/parsers/memory.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { getMemoryInfo } from '../../src/parsers/memory.js';
+
+describe('getMemoryInfo', () => {
+  it('returns valid memory info or null', () => {
+    const info = getMemoryInfo();
+    if (info === null) return;
+    expect(info.totalBytes).toBeGreaterThan(0);
+    expect(info.percentage).toBeGreaterThanOrEqual(0);
+    expect(info.percentage).toBeLessThanOrEqual(100);
+  });
+});

--- a/tests/parsers/token-speed.test.ts
+++ b/tests/parsers/token-speed.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { getTokenSpeed } from '../../src/parsers/token-speed.js';
+
+describe('getTokenSpeed', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'claude-cc-speed-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('returns null on first call', () => {
+    expect(getTokenSpeed({ used_percentage: 50, remaining_percentage: 50, current_usage: { output_tokens: 1000 } }, dir)).toBeNull();
+  });
+  it('returns null when output_tokens missing', () => {
+    expect(getTokenSpeed({ used_percentage: 50, remaining_percentage: 50 } as never, dir)).toBeNull();
+  });
+  it('calculates speed from two calls', () => {
+    const ctx1 = { used_percentage: 50, remaining_percentage: 50, current_usage: { output_tokens: 1000 } };
+    const ctx2 = { used_percentage: 50, remaining_percentage: 50, current_usage: { output_tokens: 2000 } };
+    getTokenSpeed(ctx1, dir);
+    const speed = getTokenSpeed(ctx2, dir);
+    if (speed !== null) expect(speed).toBeGreaterThan(0);
+  });
+});

--- a/tests/parsers/transcript.test.ts
+++ b/tests/parsers/transcript.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { parseTranscript, extractToolTarget, normalizeTodoStatus } from '../../src/parsers/transcript.js';
+
+const FIXTURES = join(import.meta.dirname, '..', 'fixtures');
+
+describe('parseTranscript', () => {
+  it('parses basic tool use and result', async () => {
+    const result = await parseTranscript(join(FIXTURES, 'transcript-basic.jsonl'));
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools[0].name).toBe('Read');
+    expect(result.tools[0].status).toBe('completed');
+    expect(result.tools[0].target).toBe('/src/index.ts');
+  });
+  it('parses tools with errors and agents', async () => {
+    const result = await parseTranscript(join(FIXTURES, 'transcript-tools.jsonl'));
+    expect(result.tools.find(t => t.name === 'Bash')?.status).toBe('error');
+    expect(result.tools.find(t => t.name === 'Edit')?.status).toBe('running');
+    expect(result.agents).toHaveLength(1);
+    expect(result.agents[0].type).toBe('Explore');
+    expect(result.agents[0].status).toBe('completed');
+  });
+  it('parses TaskCreate and TaskUpdate', async () => {
+    const result = await parseTranscript(join(FIXTURES, 'transcript-todos.jsonl'));
+    expect(result.todos).toHaveLength(2);
+    expect(result.todos[0].content).toBe('Write tests');
+    expect(result.todos[0].status).toBe('completed');
+    expect(result.todos[1].status).toBe('pending');
+  });
+  it('returns empty for non-existent file', async () => {
+    expect((await parseTranscript('/nonexistent/path.jsonl')).tools).toHaveLength(0);
+  });
+  it('rejects paths outside allowed directories', async () => {
+    expect((await parseTranscript('/etc/passwd')).tools).toHaveLength(0);
+  });
+});
+
+describe('extractToolTarget', () => {
+  it('extracts file_path for Read/Write/Edit', () => { expect(extractToolTarget('Read', { file_path: '/src/index.ts' })).toBe('/src/index.ts'); });
+  it('extracts pattern for Glob/Grep', () => { expect(extractToolTarget('Glob', { pattern: '**/*.ts' })).toBe('**/*.ts'); });
+  it('truncates Bash command at 30 chars', () => { expect(extractToolTarget('Bash', { command: 'a'.repeat(50) })).toBe('a'.repeat(30) + '...'); });
+  it('returns undefined for unknown tools', () => { expect(extractToolTarget('Unknown', {})).toBeUndefined(); });
+});
+
+describe('normalizeTodoStatus', () => {
+  it('normalizes completed/done', () => { expect(normalizeTodoStatus('completed')).toBe('completed'); expect(normalizeTodoStatus('done')).toBe('completed'); });
+  it('normalizes in_progress variants', () => { expect(normalizeTodoStatus('in_progress')).toBe('in_progress'); expect(normalizeTodoStatus('running')).toBe('in_progress'); });
+  it('defaults to pending', () => { expect(normalizeTodoStatus('whatever')).toBe('pending'); expect(normalizeTodoStatus(undefined)).toBe('pending'); });
+});

--- a/tests/render/colors.test.ts
+++ b/tests/render/colors.test.ts
@@ -37,6 +37,7 @@ describe('getContextColor', () => {
 });
 
 describe('getQuotaColor', () => {
+  it('returns green for <50%', () => { expect(getQuotaColor(30)).toBe('green'); });
   it('returns yellow for 50-69%', () => { expect(getQuotaColor(55)).toBe('yellow'); });
   it('returns orange for 70-84%', () => { expect(getQuotaColor(75)).toBe('orange'); });
   it('returns blinkRed for >=85%', () => { expect(getQuotaColor(90)).toBe('blinkRed'); });

--- a/tests/render/colors.test.ts
+++ b/tests/render/colors.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createColors, stripAnsi, detectColorMode, getContextColor, getQuotaColor } from '../../src/render/colors.js';
+
+describe('stripAnsi', () => {
+  it('removes ANSI escape codes', () => {
+    expect(stripAnsi('\x1b[36mhello\x1b[0m')).toBe('hello');
+    expect(stripAnsi('\x1b[38;5;208mworld\x1b[0m')).toBe('world');
+    expect(stripAnsi('\x1b[38;2;255;0;0mred\x1b[0m')).toBe('red');
+  });
+  it('returns plain string unchanged', () => { expect(stripAnsi('hello world')).toBe('hello world'); });
+});
+
+describe('detectColorMode', () => {
+  afterEach(() => { vi.unstubAllEnvs(); });
+  it('detects truecolor from COLORTERM', () => { vi.stubEnv('COLORTERM', 'truecolor'); expect(detectColorMode()).toBe('truecolor'); });
+  it('detects 256 from TERM', () => { vi.stubEnv('COLORTERM', ''); vi.stubEnv('TERM', 'xterm-256color'); expect(detectColorMode()).toBe('256'); });
+  it('falls back to named', () => { vi.stubEnv('COLORTERM', ''); vi.stubEnv('TERM', 'dumb'); expect(detectColorMode()).toBe('named'); });
+});
+
+describe('createColors', () => {
+  it('wraps text with named ANSI codes', () => {
+    const c = createColors('named');
+    expect(c.cyan('test')).toBe('\x1b[36mtest\x1b[0m');
+    expect(c.red('err')).toBe('\x1b[31merr\x1b[0m');
+  });
+  it('creates 256-color output', () => {
+    const c = createColors('256');
+    expect(c.orange('warn')).toContain('\x1b[38;5;208m');
+  });
+});
+
+describe('getContextColor', () => {
+  it('returns green for <50%', () => { expect(getContextColor(30)).toBe('green'); });
+  it('returns yellow for 50-64%', () => { expect(getContextColor(55)).toBe('yellow'); });
+  it('returns orange for 65-79%', () => { expect(getContextColor(70)).toBe('orange'); });
+  it('returns blinkRed for >=80%', () => { expect(getContextColor(85)).toBe('blinkRed'); });
+});
+
+describe('getQuotaColor', () => {
+  it('returns yellow for 50-69%', () => { expect(getQuotaColor(55)).toBe('yellow'); });
+  it('returns orange for 70-84%', () => { expect(getQuotaColor(75)).toBe('orange'); });
+  it('returns blinkRed for >=85%', () => { expect(getQuotaColor(90)).toBe('blinkRed'); });
+});

--- a/tests/render/colors.test.ts
+++ b/tests/render/colors.test.ts
@@ -11,10 +11,9 @@ describe('stripAnsi', () => {
 });
 
 describe('detectColorMode', () => {
-  afterEach(() => { vi.unstubAllEnvs(); });
-  it('detects truecolor from COLORTERM', () => { vi.stubEnv('COLORTERM', 'truecolor'); expect(detectColorMode()).toBe('truecolor'); });
-  it('detects 256 from TERM', () => { vi.stubEnv('COLORTERM', ''); vi.stubEnv('TERM', 'xterm-256color'); expect(detectColorMode()).toBe('256'); });
-  it('falls back to named', () => { vi.stubEnv('COLORTERM', ''); vi.stubEnv('TERM', 'dumb'); expect(detectColorMode()).toBe('named'); });
+  it('always returns named by default (respects terminal theme)', () => {
+    expect(detectColorMode()).toBe('named');
+  });
 });
 
 describe('createColors', () => {

--- a/tests/render/icons.test.ts
+++ b/tests/render/icons.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { ICONS } from '../../src/render/icons.js';
+
+describe('ICONS', () => {
+  it('exports all required icon codepoints', () => {
+    expect(ICONS.model).toBe('\uEE0D');
+    expect(ICONS.branch).toBe('\uE725');
+    expect(ICONS.folder).toBe('\uF07C');
+    expect(ICONS.fire).toBe('\uF06D');
+    expect(ICONS.skull).toBe('\uEE15');
+    expect(ICONS.comment).toBe('\uF075');
+    expect(ICONS.clock).toBe('\uF017');
+    expect(ICONS.bolt).toBe('\uF0E7');
+    expect(ICONS.tree).toBe('\uF1BB');
+    expect(ICONS.cubes).toBe('\uF1B3');
+    expect(ICONS.hammer).toBe('\uEEFF');
+    expect(ICONS.warning).toBe('\uF071');
+    expect(ICONS.barFull).toBe('\u2588');
+    expect(ICONS.barEmpty).toBe('\u2591');
+    expect(ICONS.ellipsis).toBe('\u2026');
+    expect(ICONS.dash).toBe('\u2014');
+  });
+});

--- a/tests/render/index.test.ts
+++ b/tests/render/index.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '../../src/render/index.js';
+import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, type RenderContext } from '../../src/types.js';
+
+function makeCtx(ov: Partial<RenderContext> = {}): RenderContext {
+  return { input: { model: 'Opus', session_id: 't', context_window: { used_percentage: 50, remaining_percentage: 50 }, cost: { total_cost_usd: 1, total_duration_ms: 60000 }, workspace: { current_dir: '/p' } } as never, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT, tokenSpeed: null, memory: null, gsd: null, cols: 120, config: { ...DEFAULT_CONFIG }, ...ov };
+}
+
+describe('render', () => {
+  it('multi-line at 120 cols', () => { expect(render(makeCtx()).split('\n').length).toBeGreaterThanOrEqual(2); });
+  it('minimal when forced', () => { expect(render(makeCtx({ config: { ...DEFAULT_CONFIG, layout: 'minimal' } })).split('\n').length).toBeLessThanOrEqual(2); });
+  it('auto-minimal at <70 cols', () => { expect(render(makeCtx({ cols: 60 })).split('\n').length).toBeLessThanOrEqual(2); });
+});

--- a/tests/render/line1.test.ts
+++ b/tests/render/line1.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { renderLine1 } from '../../src/render/line1.js';
+import { createColors } from '../../src/render/colors.js';
+import { stripAnsi } from '../../src/render/colors.js';
+import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_DISPLAY } from '../../src/types.js';
+import type { ClaudeCodeInput, GitStatus } from '../../src/types.js';
+
+const c = createColors('named');
+
+const baseInput: ClaudeCodeInput = {
+  model: 'Claude Opus 4',
+  session_id: 'test-123',
+  context_window: { used_percentage: 50, remaining_percentage: 50 },
+  cost: { total_cost_usd: 1.0, total_duration_ms: 60000, total_lines_added: 100, total_lines_removed: 20 },
+  workspace: { current_dir: '/home/user/project' },
+  version: '2.0.0',
+};
+
+const git: GitStatus = { branch: 'main', staged: 1, modified: 2, untracked: 3 };
+
+describe('renderLine1', () => {
+  it('shows model name', () => {
+    const out = stripAnsi(renderLine1(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('Claude Opus 4');
+  });
+
+  it('shows branch', () => {
+    const out = stripAnsi(renderLine1(baseInput, git, EMPTY_TRANSCRIPT, c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('main');
+  });
+
+  it('shows git changes', () => {
+    const out = stripAnsi(renderLine1(baseInput, git, EMPTY_TRANSCRIPT, c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('+1');
+    expect(out).toContain('~2');
+    expect(out).toContain('?3');
+  });
+
+  it('shows directory', () => {
+    const out = stripAnsi(renderLine1(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('project');
+  });
+
+  it('hides model when toggled off', () => {
+    const display = { ...DEFAULT_DISPLAY, model: false };
+    const out = stripAnsi(renderLine1(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, c, display, 120));
+    expect(out).not.toContain('Claude Opus 4');
+  });
+
+  it('hides branch when toggled off', () => {
+    const display = { ...DEFAULT_DISPLAY, branch: false };
+    const out = stripAnsi(renderLine1(baseInput, git, EMPTY_TRANSCRIPT, c, display, 120));
+    expect(out).not.toContain('main');
+  });
+
+  it('shows active task from todos', () => {
+    const transcript = { ...EMPTY_TRANSCRIPT, todos: [{ id: '1', content: 'Fix the bug', status: 'in_progress' as const }] };
+    const out = stripAnsi(renderLine1(baseInput, EMPTY_GIT, transcript, c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('Fix the bug');
+  });
+
+  it('shows version', () => {
+    const out = stripAnsi(renderLine1(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('v2.0.0');
+  });
+
+  it('shows lines changed', () => {
+    const out = stripAnsi(renderLine1(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('+100');
+    expect(out).toContain('-20');
+  });
+
+  it('handles object model with display_name', () => {
+    const input = { ...baseInput, model: { display_name: 'Sonnet 3.7' } };
+    const out = stripAnsi(renderLine1(input, EMPTY_GIT, EMPTY_TRANSCRIPT, c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('Sonnet 3.7');
+  });
+});

--- a/tests/render/line1.test.ts
+++ b/tests/render/line1.test.ts
@@ -32,7 +32,7 @@ describe('renderLine1', () => {
   it('shows git changes', () => {
     const out = stripAnsi(renderLine1(baseInput, git, EMPTY_TRANSCRIPT, c, DEFAULT_DISPLAY, 120));
     expect(out).toContain('+1');
-    expect(out).toContain('~2');
+    expect(out).toContain('!2');
     expect(out).toContain('?3');
   });
 

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { renderLine2 } from '../../src/render/line2.js';
+import { createColors, stripAnsi } from '../../src/render/colors.js';
+import { DEFAULT_DISPLAY } from '../../src/types.js';
+import type { ClaudeCodeInput } from '../../src/types.js';
+
+const c = createColors('named');
+
+const baseInput: ClaudeCodeInput = {
+  model: 'Claude Opus 4',
+  session_id: 'test-123',
+  context_window: {
+    used_percentage: 55,
+    remaining_percentage: 45,
+    total_input_tokens: 131000,
+    total_output_tokens: 25000,
+  },
+  cost: { total_cost_usd: 1.31, total_duration_ms: 2106000 },
+  workspace: { current_dir: '/home/user/project' },
+};
+
+describe('renderLine2', () => {
+  it('shows context bar with percentage', () => {
+    const out = stripAnsi(renderLine2(baseInput, null, '', c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('55%');
+  });
+
+  it('shows tokens', () => {
+    const out = stripAnsi(renderLine2(baseInput, null, '', c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('131k');
+    expect(out).toContain('25k');
+  });
+
+  it('shows cost', () => {
+    const out = stripAnsi(renderLine2(baseInput, null, '', c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('$1.31');
+  });
+
+  it('shows burn rate when duration > 60s', () => {
+    const out = stripAnsi(renderLine2(baseInput, null, '', c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('/h');
+  });
+
+  it('does not show burn rate when duration <= 60s', () => {
+    const input = { ...baseInput, cost: { ...baseInput.cost, total_duration_ms: 30000 } };
+    const out = stripAnsi(renderLine2(input, null, '', c, DEFAULT_DISPLAY, 120));
+    expect(out).not.toContain('/h');
+  });
+
+  it('shows token speed when provided', () => {
+    const out = stripAnsi(renderLine2(baseInput, 142, '', c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('142');
+  });
+
+  it('does not show rate limits below 50%', () => {
+    const input = { ...baseInput, rate_limits: { five_hour: { used_percentage: 30 } } };
+    const out = stripAnsi(renderLine2(input, null, '', c, DEFAULT_DISPLAY, 120));
+    expect(out).not.toContain('5h');
+  });
+
+  it('shows rate limits at >=50%', () => {
+    const input = { ...baseInput, rate_limits: { five_hour: { used_percentage: 72 } } };
+    const out = stripAnsi(renderLine2(input, null, '', c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('72%');
+    expect(out).toContain('5h');
+  });
+
+  it('shows vim mode', () => {
+    const input = { ...baseInput, vim: { mode: 'i' } };
+    const out = stripAnsi(renderLine2(input, null, '', c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('[i]');
+  });
+
+  it('hides effort when medium', () => {
+    const out = stripAnsi(renderLine2(baseInput, null, 'medium', c, DEFAULT_DISPLAY, 120));
+    expect(out).not.toContain('^medium');
+  });
+
+  it('shows effort when high', () => {
+    const out = stripAnsi(renderLine2(baseInput, null, 'high', c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('^high');
+  });
+
+  it('shows effort when low', () => {
+    const out = stripAnsi(renderLine2(baseInput, null, 'low', c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('^low');
+  });
+});

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -85,4 +85,12 @@ describe('renderLine2', () => {
     const out = stripAnsi(renderLine2(baseInput, null, 'low', c, DEFAULT_DISPLAY, 120));
     expect(out).toContain('^low');
   });
+
+  it('shows memory percentage when provided', () => {
+    const memory = { usedBytes: 8e9, totalBytes: 16e9, percentage: 50 };
+    const line = renderLine2(baseInput, null, '', c, DEFAULT_DISPLAY, 120, memory);
+    const plain = stripAnsi(line);
+    expect(plain).toContain('50%');
+    expect(plain).toContain('mem');
+  });
 });

--- a/tests/render/line3.test.ts
+++ b/tests/render/line3.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { renderLine3 } from '../../src/render/line3.js';
+import { createColors, stripAnsi } from '../../src/render/colors.js';
+import type { ToolEntry, TodoEntry } from '../../src/types.js';
+
+const c = createColors('named');
+
+const completedTool = (name: string): ToolEntry => ({
+  id: name, name, status: 'completed', startTime: new Date(), endTime: new Date(),
+});
+
+const runningTool = (name: string, target?: string): ToolEntry => ({
+  id: name, name, target, status: 'running', startTime: new Date(),
+});
+
+const todo = (id: string, content: string, status: 'pending' | 'in_progress' | 'completed'): TodoEntry => ({
+  id, content, status,
+});
+
+describe('renderLine3', () => {
+  it('returns empty string when no tools and no todos', () => {
+    expect(renderLine3([], [], c)).toBe('');
+  });
+
+  it('shows running tools', () => {
+    const out = stripAnsi(renderLine3([runningTool('Bash', 'npm test')], [], c));
+    expect(out).toContain('Bash');
+    expect(out).toContain('npm test');
+  });
+
+  it('shows completed tools with counts', () => {
+    const tools = [completedTool('Read'), completedTool('Read'), completedTool('Edit')];
+    const out = stripAnsi(renderLine3(tools, [], c));
+    expect(out).toContain('Read');
+    expect(out).toContain('×2');
+    expect(out).toContain('Edit');
+  });
+
+  it('excludes TodoWrite from display', () => {
+    const tools = [completedTool('TodoWrite'), completedTool('Read')];
+    const out = stripAnsi(renderLine3(tools, [], c));
+    expect(out).not.toContain('TodoWrite');
+    expect(out).toContain('Read');
+  });
+
+  it('shows todos progress bar', () => {
+    const todos = [
+      todo('1', 'Task 1', 'completed'),
+      todo('2', 'Task 2', 'in_progress'),
+      todo('3', 'Task 3', 'pending'),
+    ];
+    const out = stripAnsi(renderLine3([], todos, c));
+    expect(out).toContain('1/3');
+    expect(out).toContain('1'); // in_progress count
+  });
+
+  it('shows tools and todos together', () => {
+    const tools = [completedTool('Read')];
+    const todos = [todo('1', 'Task', 'completed')];
+    const out = stripAnsi(renderLine3(tools, todos, c));
+    expect(out).toContain('Read');
+    expect(out).toContain('1/1');
+  });
+});

--- a/tests/render/line4.test.ts
+++ b/tests/render/line4.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { renderLine4 } from '../../src/render/line4.js';
+import { createColors, stripAnsi } from '../../src/render/colors.js';
+import type { GsdInfo } from '../../src/types.js';
+
+const c = createColors('named');
+
+describe('renderLine4', () => {
+  it('returns empty string when gsd is null', () => {
+    expect(renderLine4(null, c)).toBe('');
+  });
+
+  it('returns empty string when no task and no update', () => {
+    const gsd: GsdInfo = { currentTask: undefined, updateAvailable: false };
+    expect(renderLine4(gsd, c)).toBe('');
+  });
+
+  it('shows current task', () => {
+    const gsd: GsdInfo = { currentTask: 'Fix critical bug' };
+    const out = stripAnsi(renderLine4(gsd, c));
+    expect(out).toContain('GSD');
+    expect(out).toContain('Fix critical bug');
+  });
+
+  it('shows update available warning', () => {
+    const gsd: GsdInfo = { updateAvailable: true };
+    const out = stripAnsi(renderLine4(gsd, c));
+    expect(out).toContain('GSD update available');
+  });
+
+  it('shows both task and update', () => {
+    const gsd: GsdInfo = { currentTask: 'My task', updateAvailable: true };
+    const out = stripAnsi(renderLine4(gsd, c));
+    expect(out).toContain('My task');
+    expect(out).toContain('GSD update available');
+  });
+});

--- a/tests/render/minimal.test.ts
+++ b/tests/render/minimal.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { renderMinimal } from '../../src/render/minimal.js';
+import { createColors, stripAnsi } from '../../src/render/colors.js';
+import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_DISPLAY } from '../../src/types.js';
+import type { ClaudeCodeInput, GitStatus } from '../../src/types.js';
+
+const c = createColors('named');
+
+const baseInput: ClaudeCodeInput = {
+  model: 'Claude Opus 4',
+  session_id: 'test-123',
+  context_window: {
+    used_percentage: 55,
+    remaining_percentage: 45,
+    total_input_tokens: 131000,
+    total_output_tokens: 25000,
+  },
+  cost: { total_cost_usd: 1.31, total_duration_ms: 2106000 },
+  workspace: { current_dir: '/home/user/project' },
+  version: '2.0.0',
+};
+
+const git: GitStatus = { branch: 'main', staged: 0, modified: 1, untracked: 0 };
+
+describe('renderMinimal', () => {
+  it('shows directory', () => {
+    const out = stripAnsi(renderMinimal(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, null, null, c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('project');
+  });
+
+  it('shows branch', () => {
+    const out = stripAnsi(renderMinimal(baseInput, git, EMPTY_TRANSCRIPT, null, null, c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('main');
+  });
+
+  it('shows model', () => {
+    const out = stripAnsi(renderMinimal(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, null, null, c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('Claude Opus 4');
+  });
+
+  it('shows context bar', () => {
+    const out = stripAnsi(renderMinimal(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, null, null, c, DEFAULT_DISPLAY, 120));
+    expect(out).toContain('55%');
+  });
+
+  it('shows cost at >=60 cols', () => {
+    const out = stripAnsi(renderMinimal(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, null, null, c, DEFAULT_DISPLAY, 80));
+    expect(out).toContain('$1.31');
+  });
+
+  it('truncates branch at <60 cols', () => {
+    const git2: GitStatus = { branch: 'feature/very-long-branch-name-here', staged: 0, modified: 0, untracked: 0 };
+    const out = stripAnsi(renderMinimal(baseInput, git2, EMPTY_TRANSCRIPT, null, null, c, DEFAULT_DISPLAY, 50));
+    // Branch should be truncated to 12 chars
+    expect(out).not.toContain('feature/very-long-branch-name-here');
+  });
+
+  it('appends tools/todos as second line', () => {
+    const transcript = {
+      ...EMPTY_TRANSCRIPT,
+      tools: [{ id: '1', name: 'Read', status: 'completed' as const, startTime: new Date(), endTime: new Date() }],
+    };
+    const out = renderMinimal(baseInput, EMPTY_GIT, transcript, null, null, c, DEFAULT_DISPLAY, 120);
+    expect(out.split('\n').length).toBe(2);
+  });
+
+  it('returns single line when no tools/todos', () => {
+    const out = renderMinimal(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, null, null, c, DEFAULT_DISPLAY, 120);
+    expect(out.split('\n').length).toBe(1);
+  });
+});

--- a/tests/render/text.test.ts
+++ b/tests/render/text.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { displayWidth, truncField, truncatePath, fitSegments, padLine } from '../../src/render/text.js';
+
+describe('displayWidth', () => {
+  it('measures plain ASCII', () => { expect(displayWidth('hello')).toBe(5); });
+  it('strips ANSI codes', () => { expect(displayWidth('\x1b[36mhello\x1b[0m')).toBe(5); });
+  it('counts zero-width chars as 0', () => { expect(displayWidth('a\u200Db')).toBe(2); });
+  it('counts CJK as 2', () => { expect(displayWidth('\u4E16')).toBe(2); });
+  it('counts emoji as 2', () => { expect(displayWidth('\u{1F600}')).toBe(2); });
+  it('counts block chars as 1', () => { expect(displayWidth('\u2588\u2591')).toBe(2); });
+});
+
+describe('truncField', () => {
+  it('returns string unchanged if within limit', () => { expect(truncField('hello', 10)).toBe('hello'); });
+  it('truncates with ellipsis', () => { expect(truncField('hello world', 6)).toBe('hello\u2026'); });
+  it('handles max=1', () => { expect(truncField('hello', 1)).toBe('\u2026'); });
+});
+
+describe('truncatePath', () => {
+  it('returns short path unchanged', () => { expect(truncatePath('/a/b', 20)).toBe('/a/b'); });
+  it('truncates with .../filename', () => { expect(truncatePath('/very/long/path/to/file.ts', 15)).toBe('.../file.ts'); });
+  it('returns empty for empty input', () => { expect(truncatePath('', 20)).toBe(''); });
+});
+
+describe('fitSegments', () => {
+  it('joins left and right when they fit', () => {
+    const result = fitSegments(['A', 'B'], ['X', 'Y'], ' | ', 30);
+    expect(result).toContain('A');
+    expect(result).toContain('Y');
+  });
+  it('drops right segments when too wide', () => {
+    const result = fitSegments(['AAAA'], ['XXXX', 'YYYY', 'ZZZZ'], ' | ', 20);
+    expect(result).toContain('AAAA');
+  });
+  it('returns only left when nothing fits', () => {
+    const result = fitSegments(['LEFT'], ['RIGHT'], ' | ', 10);
+    expect(result).toContain('LEFT');
+  });
+});
+
+describe('padLine', () => {
+  it('pads between left and right to fill cols', () => {
+    const result = padLine('left', 'right', 20);
+    expect(displayWidth(result)).toBe(20);
+  });
+});

--- a/tests/stdin.test.ts
+++ b/tests/stdin.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { Readable } from 'node:stream';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { readStdin } from '../src/stdin.js';
+
+const FIXTURES = join(import.meta.dirname, 'fixtures');
+
+describe('readStdin', () => {
+  it('parses valid JSON', async () => {
+    const json = readFileSync(join(FIXTURES, 'sample-input.json'), 'utf8');
+    const result = await readStdin(Readable.from([json]));
+    expect(result.model).toBe('Opus 4.6 (1M context)');
+    expect(result.context_window.used_percentage).toBe(5.2);
+  });
+  it('throws on invalid JSON', async () => { await expect(readStdin(Readable.from(['not json']))).rejects.toThrow(); });
+  it('throws on timeout', async () => { await expect(readStdin(new Readable({ read() {} }), 50)).rejects.toThrow(); });
+});

--- a/tests/utils/cache.test.ts
+++ b/tests/utils/cache.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync, statSync, utimesSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { readTtlCache, writeTtlCache, isMtimeFresh } from '../../src/utils/cache.js';
+
+describe('TTL cache', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'claude-cc-test-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('returns null for missing cache', () => {
+    expect(readTtlCache<{ x: number }>('nonexistent', dir)).toBeNull();
+  });
+  it('writes and reads fresh cache', () => {
+    writeTtlCache('test-key', { value: 42 }, dir);
+    const result = readTtlCache<{ value: number }>('test-key', dir, 5000);
+    expect(result).toEqual({ value: 42 });
+  });
+  it('returns null for expired cache', () => {
+    const filePath = join(dir, 'claude-cc-test-key.json');
+    writeFileSync(filePath, JSON.stringify({ value: 42 }), { mode: 0o600 });
+    const past = new Date(Date.now() - 10_000);
+    utimesSync(filePath, past, past);
+    const result = readTtlCache<{ value: number }>('test-key', dir, 5000);
+    expect(result).toBeNull();
+  });
+});
+
+describe('isMtimeFresh', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'claude-cc-test-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('returns false for non-existent file', () => {
+    expect(isMtimeFresh('/nonexistent/file', { mtime: 0, size: 0 })).toBe(false);
+  });
+  it('returns true when mtime and size match', () => {
+    const filePath = join(dir, 'test.jsonl');
+    writeFileSync(filePath, 'hello');
+    const stat = statSync(filePath);
+    expect(isMtimeFresh(filePath, { mtime: stat.mtimeMs, size: stat.size })).toBe(true);
+  });
+  it('returns false when file has changed', () => {
+    const filePath = join(dir, 'test.jsonl');
+    writeFileSync(filePath, 'hello');
+    expect(isMtimeFresh(filePath, { mtime: 0, size: 0 })).toBe(false);
+  });
+});

--- a/tests/utils/exec.test.ts
+++ b/tests/utils/exec.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { safeExec } from '../../src/utils/exec.js';
+
+describe('safeExec', () => {
+  it('returns trimmed stdout on success', async () => {
+    const result = await safeExec('echo', ['hello world']);
+    expect(result).toBe('hello world');
+  });
+  it('returns empty string on command failure', async () => {
+    const result = await safeExec('false', []);
+    expect(result).toBe('');
+  });
+  it('returns empty string on non-existent command', async () => {
+    const result = await safeExec('nonexistent-command-xyz', []);
+    expect(result).toBe('');
+  });
+  it('respects timeout', async () => {
+    const result = await safeExec('sleep', ['10'], { timeoutMs: 100 });
+    expect(result).toBe('');
+  });
+  it('passes cwd option', async () => {
+    const result = await safeExec('pwd', [], { cwd: '/tmp' });
+    expect(result).toBe('/tmp');
+  });
+});

--- a/tests/utils/format.test.ts
+++ b/tests/utils/format.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { formatTokens, formatDuration, formatCost, formatBurnRate } from '../../src/utils/format.js';
+
+describe('formatTokens', () => {
+  it('returns empty string for null/undefined', () => {
+    expect(formatTokens(null as unknown as number)).toBe('');
+    expect(formatTokens(undefined as unknown as number)).toBe('');
+  });
+  it('formats millions', () => {
+    expect(formatTokens(1_234_567)).toBe('1.2M');
+    expect(formatTokens(2_000_000)).toBe('2.0M');
+  });
+  it('formats thousands', () => {
+    expect(formatTokens(131_000)).toBe('131k');
+    expect(formatTokens(1_500)).toBe('2k');
+  });
+  it('formats small numbers as-is', () => {
+    expect(formatTokens(456)).toBe('456');
+    expect(formatTokens(0)).toBe('0');
+  });
+});
+
+describe('formatDuration', () => {
+  it('returns empty string for null/undefined', () => {
+    expect(formatDuration(null as unknown as number)).toBe('');
+  });
+  it('formats hours and minutes', () => {
+    expect(formatDuration(3_723_000)).toBe('1h02m');
+    expect(formatDuration(7_200_000)).toBe('2h00m');
+  });
+  it('formats minutes and seconds', () => {
+    expect(formatDuration(125_000)).toBe('2m05s');
+    expect(formatDuration(60_000)).toBe('1m00s');
+  });
+  it('formats seconds only', () => {
+    expect(formatDuration(45_000)).toBe('45s');
+    expect(formatDuration(0)).toBe('0s');
+  });
+});
+
+describe('formatCost', () => {
+  it('returns empty string for null/undefined', () => {
+    expect(formatCost(null as unknown as number)).toBe('');
+  });
+  it('formats costs >= $0.01 with 2 decimals', () => {
+    expect(formatCost(1.31)).toBe('$1.31');
+    expect(formatCost(0.05)).toBe('$0.05');
+  });
+  it('formats costs < $0.01 with 4 decimals', () => {
+    expect(formatCost(0.0012)).toBe('$0.0012');
+    expect(formatCost(0.001)).toBe('$0.0010');
+  });
+});
+
+describe('formatBurnRate', () => {
+  it('returns null if duration <= 60s', () => {
+    expect(formatBurnRate(1.0, 30_000)).toBeNull();
+    expect(formatBurnRate(1.0, 60_000)).toBeNull();
+  });
+  it('calculates $/h for durations > 60s', () => {
+    expect(formatBurnRate(1.0, 1_800_000)).toBe('$2.00/h');
+  });
+  it('returns null for zero cost', () => {
+    expect(formatBurnRate(0, 120_000)).toBeNull();
+  });
+});

--- a/tests/utils/terminal.test.ts
+++ b/tests/utils/terminal.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getTermCols, getLayoutCols } from '../../src/utils/terminal.js';
+
+describe('getTermCols', () => {
+  afterEach(() => { vi.unstubAllEnvs(); });
+
+  it('returns a positive number', () => {
+    expect(getTermCols()).toBeGreaterThan(0);
+  });
+});
+
+describe('getLayoutCols', () => {
+  it('returns raw cols when TTY', () => { expect(getLayoutCols(120, true)).toBe(120); });
+  it('applies 0.7 reduction when not TTY', () => { expect(getLayoutCols(120, false)).toBe(84); });
+  it('applies custom reduction factor', () => { expect(getLayoutCols(100, false, 0.5)).toBe(50); });
+  it('clamps factor between 0.3 and 1.0', () => {
+    expect(getLayoutCols(100, false, 0.1)).toBe(30);
+    expect(getLayoutCols(100, false, 2.0)).toBe(100);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "declaration": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Full TypeScript statusline plugin for Claude Code, migrated from JS + claude-hud features
- 19 implementation tasks completed with TDD (136 tests)
- Modular architecture: stdin → parsers → RenderContext → render → stdout
- Zero runtime dependencies, DI for testability

## Features
- 3-line custom mode + 1-line minimal mode (auto <70 cols)
- Git status with 5s TTL cache, transcript parsing (tools/agents/todos)
- Token speed calculation, rate limit display, cost burn rate
- 3-tier color system (named/256/truecolor), config file + CLI flags
- Nerd Font icons, progressive truncation, GSD support

## Test plan
- [x] 136 unit/integration tests passing
- [x] Clean TypeScript strict build
- [x] Smoke test: `cat sample-input.json | node dist/index.js`
- [x] Live test: running as Claude Code statusline via settings.json