### PR TITLE
feat: Phase 2-4 architecture refactor, features, and test hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GSD integration — current task from todos, update availability check
 - 3-tier color system: named ANSI (default), 256-color, truecolor — named by default to respect terminal themes
 - Nerd Font icons: fa-robot, dev-git-branch, fa-folder-open, fa-fire, fa-skull, fa-comment, fa-clock, fa-bolt, fa-tree, fa-cubes, fa-hammer, fa-warning
-- Config file support (`~/.config/ccpulse/config.json`) with 22 display toggles
+- Config file support (`~/.config/lumira/config.json`) with 22 display toggles
 - CLI flags: `--minimal` (force minimal mode), `--gsd` (enable GSD features)
 - Dependency injection for full testability
 - Unicode-aware display width calculation (CJK, emoji, combining marks, zero-width joiners)
@@ -48,5 +48,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GSD session IDs sanitized against path traversal
 - `execFile` used instead of `exec` to prevent shell injection (except terminal width detection where shell redirect is required with procfs-sourced paths)
 
-[Unreleased]: https://github.com/cativo23/ccpulse/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/cativo23/ccpulse/releases/tag/v0.1.0
+[Unreleased]: https://github.com/cativo23/lumira/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/cativo23/lumira/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -23,20 +23,26 @@ Real-time statusline plugin for [Claude Code](https://code.claude.com).
 
 ## Install
 
+Quick setup (auto-configures Claude Code):
+
+```bash
+npx lumira install
+```
+
+Or install globally:
+
 ```bash
 npm install -g lumira
+lumira install
 ```
 
-Or clone and build:
+To uninstall:
 
 ```bash
-git clone https://github.com/cativo23/lumira.git
-cd lumira
-npm install
-npm run build
+npx lumira uninstall
 ```
 
-## Setup
+### Manual setup
 
 Add to `~/.claude/settings.json`:
 
@@ -44,7 +50,7 @@ Add to `~/.claude/settings.json`:
 {
   "statusLine": {
     "type": "command",
-    "command": "lumira",
+    "command": "npx lumira@latest",
     "padding": 0
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ccpulse
+# lumira
 
 Real-time statusline plugin for [Claude Code](https://code.claude.com).
 
@@ -24,14 +24,14 @@ Real-time statusline plugin for [Claude Code](https://code.claude.com).
 ## Install
 
 ```bash
-npm install -g ccpulse
+npm install -g lumira
 ```
 
 Or clone and build:
 
 ```bash
-git clone https://github.com/cativo23/ccpulse.git
-cd ccpulse
+git clone https://github.com/cativo23/lumira.git
+cd lumira
 npm install
 npm run build
 ```
@@ -44,7 +44,7 @@ Add to `~/.claude/settings.json`:
 {
   "statusLine": {
     "type": "command",
-    "command": "ccpulse",
+    "command": "lumira",
     "padding": 0
   }
 }
@@ -80,7 +80,7 @@ my-project |  main | Opus 4.6 | ████░░░░░░░░░░░░
 
 ## Configuration
 
-Create `~/.config/ccpulse/config.json`:
+Create `~/.config/lumira/config.json`:
 
 ```json
 {
@@ -121,8 +121,8 @@ All fields are optional — defaults are shown above.
 ### CLI Flags
 
 ```bash
-ccpulse --minimal    # Force minimal mode
-ccpulse --gsd        # Enable GSD integration
+lumira --minimal    # Force minimal mode
+lumira --gsd        # Enable GSD integration
 ```
 
 ## Architecture

--- a/docs/superpowers/plans/2026-04-09-installer.md
+++ b/docs/superpowers/plans/2026-04-09-installer.md
@@ -1,0 +1,441 @@
+# Lumira Installer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `npx lumira install` and `npx lumira uninstall` commands that auto-configure Claude Code's settings.json with backup/restore support.
+
+**Architecture:** Single new file `src/installer.ts` with pure functions for install/uninstall logic (DI for paths and I/O). Entry point in `src/index.ts` intercepts `install`/`uninstall` argv before stdin reading. All output uses raw ANSI codes — no new dependencies.
+
+**Tech Stack:** Node.js fs, readline, ANSI escape codes
+
+---
+
+### File Map
+
+- **Create:** `src/installer.ts` — install/uninstall logic with styled output
+- **Create:** `tests/installer.test.ts` — all 8 test cases
+- **Modify:** `src/index.ts` — intercept install/uninstall subcommands before stdin
+
+---
+
+### Task 1: Installer core — install logic
+
+**Files:**
+- Create: `src/installer.ts`
+- Create: `tests/installer.test.ts`
+
+- [ ] **Step 1: Write failing tests for install scenarios**
+
+Create `tests/installer.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { install } from '../src/installer.js';
+
+describe('install', () => {
+  let dir: string;
+  let settingsPath: string;
+  let backupPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'lumira-test-'));
+    settingsPath = join(dir, 'settings.json');
+    backupPath = join(dir, 'settings.json.lumira.bak');
+  });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('creates settings file when none exists', async () => {
+    const output = await install({ settingsPath, confirm: async () => true });
+    expect(existsSync(settingsPath)).toBe(true);
+    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    expect(data.statusLine.command).toBe('npx lumira@latest');
+    expect(output).toContain('Configured');
+  });
+
+  it('adds statusLine when settings exists without one', async () => {
+    writeFileSync(settingsPath, JSON.stringify({ hooks: {} }, null, 2));
+    const output = await install({ settingsPath, confirm: async () => true });
+    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    expect(data.statusLine.command).toBe('npx lumira@latest');
+    expect(data.hooks).toEqual({});
+    expect(existsSync(backupPath)).toBe(false);
+  });
+
+  it('backs up and replaces existing statusLine after confirmation', async () => {
+    const original = { statusLine: { type: 'command', command: 'other-tool', padding: 0 } };
+    writeFileSync(settingsPath, JSON.stringify(original, null, 2));
+    const output = await install({ settingsPath, confirm: async () => true });
+    expect(existsSync(backupPath)).toBe(true);
+    const backup = JSON.parse(readFileSync(backupPath, 'utf8'));
+    expect(backup.statusLine.command).toBe('other-tool');
+    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    expect(data.statusLine.command).toBe('npx lumira@latest');
+    expect(output).toContain('Backed up');
+  });
+
+  it('skips when already configured with lumira', async () => {
+    const existing = { statusLine: { type: 'command', command: 'npx lumira@latest', padding: 0 } };
+    writeFileSync(settingsPath, JSON.stringify(existing, null, 2));
+    const output = await install({ settingsPath, confirm: async () => true });
+    expect(output).toContain('already configured');
+    expect(existsSync(backupPath)).toBe(false);
+  });
+
+  it('aborts when user declines replacement', async () => {
+    const original = { statusLine: { type: 'command', command: 'other-tool', padding: 0 } };
+    writeFileSync(settingsPath, JSON.stringify(original, null, 2));
+    const output = await install({ settingsPath, confirm: async () => false });
+    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    expect(data.statusLine.command).toBe('other-tool');
+    expect(output).toContain('Aborted');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/installer.test.ts`
+Expected: FAIL — module `../src/installer.js` not found
+
+- [ ] **Step 3: Implement install function**
+
+Create `src/installer.ts`:
+
+```ts
+import { readFileSync, writeFileSync, existsSync, copyFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+import { createInterface } from 'node:readline';
+
+// ── ANSI helpers ────────────────────────────────────────────────────
+const RST = '\x1b[0m';
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const CYAN = '\x1b[36m';
+const DIM = '\x1b[2m';
+
+const ok = (msg: string) => `${GREEN}✓${RST} ${msg}`;
+const warn = (msg: string) => `${YELLOW}⚠${RST} ${msg}`;
+const header = () => `\n${CYAN} lumira installer${RST}\n`;
+
+// ── StatusLine value ────────────────────────────────────────────────
+const LUMIRA_STATUSLINE = {
+  type: 'command' as const,
+  command: 'npx lumira@latest',
+  padding: 0,
+};
+
+// ── Install options (DI for testing) ────────────────────────────────
+export interface InstallerOptions {
+  settingsPath?: string;
+  confirm?: (prompt: string) => Promise<boolean>;
+}
+
+function defaultSettingsPath(): string {
+  return join(homedir(), '.claude', 'settings.json');
+}
+
+function isLumira(statusLine: unknown): boolean {
+  if (!statusLine || typeof statusLine !== 'object') return false;
+  const sl = statusLine as Record<string, unknown>;
+  return typeof sl.command === 'string' && sl.command.includes('lumira');
+}
+
+// ── Prompt helper ───────────────────────────────────────────────────
+export function promptYN(question: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(`${question} (y/N) `, (answer) => {
+      rl.close();
+      resolve(answer.trim().toLowerCase() === 'y');
+    });
+  });
+}
+
+// ── Install ─────────────────────────────────────────────────────────
+export async function install(opts: InstallerOptions = {}): Promise<string> {
+  const settingsPath = opts.settingsPath ?? defaultSettingsPath();
+  const backupPath = settingsPath + '.lumira.bak';
+  const confirm = opts.confirm ?? promptYN;
+  const lines: string[] = [header()];
+
+  let settings: Record<string, unknown> = {};
+
+  if (existsSync(settingsPath)) {
+    try {
+      settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    } catch {
+      lines.push(warn('Could not parse existing settings.json, creating fresh'));
+      settings = {};
+    }
+  }
+
+  if (settings.statusLine) {
+    if (isLumira(settings.statusLine)) {
+      lines.push(ok('lumira is already configured as your statusline'));
+      return lines.join('\n') + '\n';
+    }
+
+    const current = (settings.statusLine as Record<string, unknown>).command ?? 'unknown';
+    lines.push(warn(`Current statusline: ${YELLOW}${current}${RST}`));
+    const accepted = await confirm('Replace with lumira?');
+    if (!accepted) {
+      lines.push(`\n  Aborted. No changes made.\n`);
+      return lines.join('\n') + '\n';
+    }
+
+    copyFileSync(settingsPath, backupPath);
+    lines.push(ok(`Backed up existing settings → ${DIM}settings.json.lumira.bak${RST}`));
+  }
+
+  settings.statusLine = { ...LUMIRA_STATUSLINE };
+  writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', { mode: 0o600 });
+  lines.push(ok('Configured lumira as statusline'));
+  lines.push(`\n  Restart Claude Code to see your statusline.\n`);
+  return lines.join('\n') + '\n';
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/installer.test.ts`
+Expected: all 5 install tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/installer.ts tests/installer.test.ts
+git commit -m "feat: add install command with backup support"
+```
+
+---
+
+### Task 2: Uninstall logic
+
+**Files:**
+- Modify: `src/installer.ts`
+- Modify: `tests/installer.test.ts`
+
+- [ ] **Step 1: Write failing tests for uninstall scenarios**
+
+Append to `tests/installer.test.ts`:
+
+```ts
+import { install, uninstall } from '../src/installer.js';
+
+// ... (update the import at top of file)
+
+describe('uninstall', () => {
+  let dir: string;
+  let settingsPath: string;
+  let backupPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'lumira-test-'));
+    settingsPath = join(dir, 'settings.json');
+    backupPath = join(dir, 'settings.json.lumira.bak');
+  });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('restores from backup when backup exists', () => {
+    const backup = { statusLine: { type: 'command', command: 'old-tool', padding: 0 }, hooks: {} };
+    const current = { statusLine: { type: 'command', command: 'npx lumira@latest', padding: 0 }, hooks: {} };
+    writeFileSync(backupPath, JSON.stringify(backup, null, 2));
+    writeFileSync(settingsPath, JSON.stringify(current, null, 2));
+    const output = uninstall({ settingsPath });
+    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    expect(data.statusLine.command).toBe('old-tool');
+    expect(existsSync(backupPath)).toBe(false);
+    expect(output).toContain('Restored');
+  });
+
+  it('removes statusLine key when no backup exists', () => {
+    const current = { statusLine: { type: 'command', command: 'npx lumira@latest', padding: 0 }, hooks: {} };
+    writeFileSync(settingsPath, JSON.stringify(current, null, 2));
+    const output = uninstall({ settingsPath });
+    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    expect(data.statusLine).toBeUndefined();
+    expect(data.hooks).toEqual({});
+    expect(output).toContain('Removed');
+  });
+
+  it('prints message when no settings file exists', () => {
+    const output = uninstall({ settingsPath });
+    expect(output).toContain('Nothing to uninstall');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/installer.test.ts`
+Expected: FAIL — `uninstall` is not exported
+
+- [ ] **Step 3: Implement uninstall function**
+
+Add to `src/installer.ts`:
+
+```ts
+// ── Uninstall ───────────────────────────────────────────────────────
+export function uninstall(opts: InstallerOptions = {}): string {
+  const settingsPath = opts.settingsPath ?? defaultSettingsPath();
+  const backupPath = settingsPath + '.lumira.bak';
+  const lines: string[] = [header()];
+
+  if (!existsSync(settingsPath)) {
+    lines.push(ok('Nothing to uninstall — no settings.json found'));
+    return lines.join('\n') + '\n';
+  }
+
+  if (existsSync(backupPath)) {
+    copyFileSync(backupPath, settingsPath);
+    unlinkSync(backupPath);
+    lines.push(ok('Restored previous settings from backup'));
+    lines.push(`\n  Restart Claude Code to apply changes.\n`);
+    return lines.join('\n') + '\n';
+  }
+
+  try {
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    delete settings.statusLine;
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', { mode: 0o600 });
+    lines.push(ok('Removed lumira statusline from settings'));
+  } catch {
+    lines.push(warn('Could not parse settings.json'));
+  }
+
+  lines.push(`\n  Restart Claude Code to apply changes.\n`);
+  return lines.join('\n') + '\n';
+}
+```
+
+Also add `unlinkSync` to the import at the top of `src/installer.ts`:
+
+```ts
+import { readFileSync, writeFileSync, existsSync, copyFileSync, unlinkSync } from 'node:fs';
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/installer.test.ts`
+Expected: all 8 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/installer.ts tests/installer.test.ts
+git commit -m "feat: add uninstall command with backup restore"
+```
+
+---
+
+### Task 3: Wire into index.ts entry point
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Add subcommand detection to index.ts**
+
+Add import at top of `src/index.ts`:
+
+```ts
+import { install, uninstall } from './installer.js';
+```
+
+Replace the bottom section (the "Run when invoked directly" block) with:
+
+```ts
+// Run when invoked directly
+const __filename = fileURLToPath(import.meta.url);
+if (process.argv[1] && (__filename === process.argv[1] || __filename === process.argv[1] + '.js')) {
+  const cmd = process.argv[2];
+  if (cmd === 'install') {
+    install().then(o => process.stdout.write(o)).catch(e => process.stderr.write(`Install error: ${e.message}\n`));
+  } else if (cmd === 'uninstall') {
+    const o = uninstall();
+    process.stdout.write(o);
+  } else {
+    main().then(o => process.stdout.write(o)).catch(e => { if (!(e instanceof SyntaxError)) process.stderr.write(`Statusline error: ${e.message}\n`); });
+  }
+}
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `npm run build`
+Expected: compiles with no errors
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `npm test`
+Expected: all tests pass (136 existing + 8 new = 144)
+
+- [ ] **Step 4: Manual smoke test**
+
+Run: `node dist/installer.js` — should not crash (no-op since not invoked via index)
+Run: `node dist/index.js install` in a temp environment or inspect the output
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat: wire install/uninstall subcommands into entry point"
+```
+
+---
+
+### Task 4: Update README with install instructions
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Update the Install section of README.md**
+
+Replace the current Install section with:
+
+```markdown
+## Install
+
+Quick setup (auto-configures Claude Code):
+
+```bash
+npx lumira install
+```
+
+Or install globally:
+
+```bash
+npm install -g lumira
+lumira install
+```
+
+To uninstall:
+
+```bash
+npx lumira uninstall
+```
+
+### Manual setup
+
+Add to `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "npx lumira@latest",
+    "padding": 0
+  }
+}
+```
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: update README with npx lumira install instructions"
+```

--- a/docs/superpowers/specs/2026-04-09-installer-design.md
+++ b/docs/superpowers/specs/2026-04-09-installer-design.md
@@ -1,0 +1,114 @@
+# Lumira Installer Design
+
+## Overview
+
+Interactive installer/uninstaller for lumira that configures Claude Code's `~/.claude/settings.json` automatically, with backup/restore support.
+
+## Entry Point
+
+Subcommands detected in `src/index.ts` before stdin reading:
+- `lumira install` → delegates to installer
+- `lumira uninstall` → delegates to uninstaller
+
+No separate bin entry needed — single entry point handles both modes.
+
+## New File: `src/installer.ts`
+
+Exports: `runInstall()`, `runUninstall()`
+
+### Install Flow
+
+1. Resolve `~/.claude/settings.json`
+2. If file doesn't exist: create with `{ "statusLine": ... }` and done
+3. If file exists, parse JSON:
+   a. If no `statusLine` key: add it, write back
+   b. If `statusLine` exists and already is lumira: print "already configured", exit
+   c. If `statusLine` exists with something else:
+      - Print current command in yellow
+      - Prompt `Replace with lumira? (y/N)` via stdin
+      - If yes: backup to `settings.json.lumira.bak`, replace, write
+      - If no: abort with message
+4. Print success summary with green checkmarks
+
+### Uninstall Flow
+
+1. If `settings.json.lumira.bak` exists: restore it over `settings.json`, delete backup
+2. If no backup: read `settings.json`, delete `statusLine` key, write back
+3. If no `settings.json`: print "nothing to uninstall"
+4. Print summary
+
+### StatusLine Value Written
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "npx lumira@latest",
+    "padding": 0
+  }
+}
+```
+
+### Styled Output
+
+ANSI codes used directly (no dependencies):
+- `\x1b[32m` green for checkmarks (✓)
+- `\x1b[33m` yellow for warnings/current config
+- `\x1b[36m` cyan for headers
+- `\x1b[2m` dim for paths
+- `\x1b[0m` reset
+
+Example output:
+```
+ lumira installer
+
+✓ Backed up existing settings → settings.json.lumira.bak
+✓ Configured lumira as statusline
+
+  Restart Claude Code to see your statusline.
+```
+
+### Prompt (y/N)
+
+Simple stdin readline — no dependencies:
+```ts
+import { createInterface } from 'node:readline';
+```
+
+Default is No (capital N) — safe by default.
+
+### JSON Handling
+
+- Read with `readFileSync` + `JSON.parse`
+- Write with `JSON.stringify(data, null, 2)` to preserve readable formatting
+- Preserve all existing keys — only touch `statusLine`
+
+## Changes to `src/index.ts`
+
+Before the stdin reading logic, check `process.argv`:
+```ts
+if (process.argv.includes('install')) { runInstall(); }
+else if (process.argv.includes('uninstall')) { runUninstall(); }
+else { /* existing statusline logic */ }
+```
+
+## Testing (`tests/installer.test.ts`)
+
+All tests use a temp directory (no real `~/.claude`):
+
+1. Install — no settings file exists → creates file with statusLine
+2. Install — settings exists, no statusLine → adds statusLine
+3. Install — settings has different statusLine → prompts, backs up, replaces
+4. Install — already lumira → prints "already configured", no changes
+5. Install — user declines prompt → no changes
+6. Uninstall — backup exists → restores backup
+7. Uninstall — no backup, has statusLine → removes key
+8. Uninstall — no settings file → prints "nothing to uninstall"
+
+## Scope Exclusions
+
+- No post-install config wizard
+- No theme picker
+- No skill/hook installation
+- No `jq` or external tool dependency
+- No `lumira-install` separate bin

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "ccpulse",
+  "name": "lumira",
   "version": "0.1.0",
-  "description": "ccpulse — real-time statusline plugin for Claude Code",
+  "description": "lumira — real-time statusline for Claude Code",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "ccpulse": "dist/index.js"
+    "lumira": "dist/index.js"
   },
   "scripts": {
     "build": "tsc",
@@ -28,7 +28,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cativo23/ccpulse.git"
+    "url": "https://github.com/cativo23/lumira.git"
   },
   "keywords": [
     "claude-code",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cativo23/lumira.git"
+    "url": "git+https://github.com/cativo23/lumira.git"
   },
   "keywords": [
     "claude-code",

--- a/skills/lumira/SKILL.md
+++ b/skills/lumira/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: lumira
+description: Configure the lumira statusline HUD via natural language
+---
+
+# /lumira — Statusline Configuration Skill
+
+You are configuring **lumira**, a terminal statusline/HUD for Claude Code.
+
+## Config File
+
+Location: `~/.config/lumira/config.json`
+
+Read the current config before making changes. If the file doesn't exist, create it with just the fields the user wants to change.
+
+## Available Settings
+
+### Presets (`preset`)
+- `"full"` — all widgets, multi-line layout
+- `"balanced"` — essential widgets, auto layout (hides burn rate, duration, token speed, lines changed, session name, style, version, memory)
+- `"minimal"` — compact single-line (model, branch, directory, context bar, cost)
+
+### Layout (`layout`)
+Internal render mode. Prefer setting `preset` instead.
+- `"multiline"` — full multi-line renderer
+- `"singleline"` — compact single-line renderer
+- `"auto"` — switches based on terminal width
+
+### Icons (`icons`)
+- `"nerd"` — Nerd Font icons (default, requires a Nerd Font)
+- `"emoji"` — Unicode emoji icons
+- `"none"` — no icons, ASCII fallbacks
+
+### Theme (`theme`)
+Named color themes (requires truecolor terminal):
+- `"dracula"`, `"nord"`, `"tokyo-night"`, `"catppuccin"`, `"monokai"`
+
+### Display Toggles (`display`)
+Each is a boolean (`true`/`false`):
+`model`, `branch`, `gitChanges`, `directory`, `contextBar`, `contextTokens`, `tokens`, `cost`, `burnRate`, `duration`, `tokenSpeed`, `rateLimits`, `tools`, `todos`, `vim`, `effort`, `worktree`, `agent`, `sessionName`, `style`, `version`, `linesChanged`, `memory`
+
+### Colors (`colors.mode`)
+- `"auto"` — detect from terminal
+- `"named"` — basic ANSI
+- `"256"` — 256-color
+- `"truecolor"` — 24-bit RGB
+
+### GSD Integration (`gsd`)
+- `true` — show GSD task info
+- `false` — hide GSD section
+
+## Example Configs
+
+Minimal with emoji icons:
+```json
+{
+  "preset": "minimal",
+  "icons": "emoji"
+}
+```
+
+Full with Dracula theme:
+```json
+{
+  "preset": "full",
+  "theme": "dracula",
+  "colors": { "mode": "truecolor" }
+}
+```
+
+Custom — hide cost and tokens, keep everything else:
+```json
+{
+  "display": {
+    "cost": false,
+    "tokens": false
+  }
+}
+```
+
+## Rules
+
+1. Always read the existing config first
+2. Merge changes — don't overwrite the entire file
+3. Preset sets defaults; explicit display toggles override preset
+4. Theme requires `colors.mode: "truecolor"` to take effect
+5. After writing, tell the user to restart their Claude Code session

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@ export function loadConfig(configDir: string = join(homedir(), '.config', 'lumir
 }
 
 function mergeConfig(raw: Record<string, unknown>): HudConfig {
-  const layout = (['custom', 'minimal', 'auto'] as const).includes(raw.layout as never) ? raw.layout as HudConfig['layout'] : DEFAULT_CONFIG.layout;
+  const layout = (['full', 'minimal', 'auto'] as const).includes(raw.layout as never) ? raw.layout as HudConfig['layout'] : DEFAULT_CONFIG.layout;
   const display = { ...DEFAULT_DISPLAY };
   if (raw.display && typeof raw.display === 'object') {
     for (const k of Object.keys(DEFAULT_DISPLAY) as (keyof DisplayToggles)[]) {
@@ -27,20 +27,34 @@ function mergeConfig(raw: Record<string, unknown>): HudConfig {
   }
   const result: HudConfig = { layout, gsd: typeof raw.gsd === 'boolean' ? raw.gsd : DEFAULT_CONFIG.gsd, display, colors };
   const validPresets = ['full', 'balanced', 'minimal'] as const;
-  if (validPresets.includes(raw.preset as never)) result.preset = raw.preset as HudConfig['preset'];
+  if (validPresets.includes(raw.preset as never)) applyPreset(result, raw.preset as NonNullable<HudConfig['preset']>);
   if (typeof raw.theme === 'string' && raw.theme.length > 0) result.theme = raw.theme;
   const validIcons = ['nerd', 'emoji', 'none'] as const;
   if (validIcons.includes(raw.icons as never)) result.icons = raw.icons as HudConfig['icons'];
   return result;
 }
 
+const PRESET_TO_LAYOUT: Record<string, HudConfig['layout']> = {
+  full: 'full',
+  balanced: 'auto',
+  minimal: 'minimal',
+};
+
+function applyPreset(r: HudConfig, preset: NonNullable<HudConfig['preset']>): void {
+  r.preset = preset;
+  r.layout = PRESET_TO_LAYOUT[preset];
+}
+
 export function mergeCliFlags(config: HudConfig, argv: string[]): HudConfig {
   const r = { ...config, display: { ...config.display }, colors: { ...config.colors } };
-  if (argv.includes('--minimal')) r.layout = 'minimal';
   if (argv.includes('--gsd')) r.gsd = true;
+  // Shorthand flags
+  if (argv.includes('--minimal')) applyPreset(r, 'minimal');
+  if (argv.includes('--balanced')) applyPreset(r, 'balanced');
+  if (argv.includes('--full')) applyPreset(r, 'full');
   for (const arg of argv) {
     const presetMatch = arg.match(/^--preset[= ]?(full|balanced|minimal)$/);
-    if (presetMatch) { r.preset = presetMatch[1] as HudConfig['preset']; continue; }
+    if (presetMatch) { applyPreset(r, presetMatch[1] as NonNullable<HudConfig['preset']>); continue; }
     const iconsMatch = arg.match(/^--icons[= ]?(nerd|emoji|none)$/);
     if (iconsMatch) { r.icons = iconsMatch[1] as HudConfig['icons']; continue; }
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,35 +14,89 @@ export function loadConfig(configDir: string = join(homedir(), '.config', 'lumir
 
 function mergeConfig(raw: Record<string, unknown>): HudConfig {
   const layout = (['multiline', 'singleline', 'auto'] as const).includes(raw.layout as never) ? raw.layout as HudConfig['layout'] : DEFAULT_CONFIG.layout;
-  const display = { ...DEFAULT_DISPLAY };
-  if (raw.display && typeof raw.display === 'object') {
-    for (const k of Object.keys(DEFAULT_DISPLAY) as (keyof DisplayToggles)[]) {
-      if (typeof (raw.display as Record<string, unknown>)[k] === 'boolean') display[k] = (raw.display as Record<string, boolean>)[k];
-    }
-  }
   const colors: ColorConfig = { ...DEFAULT_CONFIG.colors };
   if (raw.colors && typeof raw.colors === 'object') {
     const m = (raw.colors as Record<string, unknown>).mode;
     if (['auto', 'named', '256', 'truecolor'].includes(m as string)) colors.mode = m as ColorConfig['mode'];
   }
-  const result: HudConfig = { layout, gsd: typeof raw.gsd === 'boolean' ? raw.gsd : DEFAULT_CONFIG.gsd, display, colors };
+  const result: HudConfig = { layout, gsd: typeof raw.gsd === 'boolean' ? raw.gsd : DEFAULT_CONFIG.gsd, display: { ...DEFAULT_DISPLAY }, colors };
+
+  // Apply preset FIRST (sets layout + display defaults)
   const validPresets = ['full', 'balanced', 'minimal'] as const;
   if (validPresets.includes(raw.preset as never)) applyPreset(result, raw.preset as NonNullable<HudConfig['preset']>);
+
+  // Then overlay user's explicit display toggles (user wins over preset)
+  if (raw.display && typeof raw.display === 'object') {
+    for (const k of Object.keys(DEFAULT_DISPLAY) as (keyof DisplayToggles)[]) {
+      if (typeof (raw.display as Record<string, unknown>)[k] === 'boolean') result.display[k] = (raw.display as Record<string, boolean>)[k];
+    }
+  }
+
   if (typeof raw.theme === 'string' && raw.theme.length > 0) result.theme = raw.theme;
   const validIcons = ['nerd', 'emoji', 'none'] as const;
   if (validIcons.includes(raw.icons as never)) result.icons = raw.icons as HudConfig['icons'];
   return result;
 }
 
-const PRESET_TO_LAYOUT: Record<string, HudConfig['layout']> = {
-  full: 'multiline',
-  balanced: 'auto',
-  minimal: 'singleline',
+// ── Preset definitions ─────────────────────────────────────────────
+// Each preset defines a layout + display toggle overrides.
+// Toggles not listed here stay at their current value.
+
+interface PresetDef {
+  layout: HudConfig['layout'];
+  display: Partial<DisplayToggles>;
+}
+
+const PRESET_DEFS: Record<NonNullable<HudConfig['preset']>, PresetDef> = {
+  full: {
+    layout: 'multiline',
+    display: {}, // all defaults (everything on)
+  },
+  balanced: {
+    layout: 'auto',
+    display: {
+      burnRate: false,
+      duration: false,
+      tokenSpeed: false,
+      linesChanged: false,
+      sessionName: false,
+      style: false,
+      version: false,
+      memory: false,
+      contextTokens: false,
+    },
+  },
+  minimal: {
+    layout: 'singleline',
+    display: {
+      tokens: false,
+      burnRate: false,
+      duration: false,
+      tokenSpeed: false,
+      rateLimits: false,
+      tools: false,
+      todos: false,
+      vim: false,
+      effort: false,
+      worktree: false,
+      agent: false,
+      sessionName: false,
+      style: false,
+      version: false,
+      linesChanged: false,
+      memory: false,
+      contextTokens: false,
+    },
+  },
 };
 
 function applyPreset(r: HudConfig, preset: NonNullable<HudConfig['preset']>): void {
+  const def = PRESET_DEFS[preset];
   r.preset = preset;
-  r.layout = PRESET_TO_LAYOUT[preset];
+  r.layout = def.layout;
+  for (const [k, v] of Object.entries(def.display)) {
+    r.display[k as keyof DisplayToggles] = v as boolean;
+  }
 }
 
 export function mergeCliFlags(config: HudConfig, argv: string[]): HudConfig {

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { DEFAULT_CONFIG, DEFAULT_DISPLAY, type HudConfig, type DisplayToggles, type ColorConfig } from './types.js';
 
-export function loadConfig(configDir: string = join(homedir(), '.config', 'ccpulse')): HudConfig {
+export function loadConfig(configDir: string = join(homedir(), '.config', 'lumira')): HudConfig {
   const p = join(configDir, 'config.json');
   if (!existsSync(p)) return { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } };
   try {

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,12 +25,24 @@ function mergeConfig(raw: Record<string, unknown>): HudConfig {
     const m = (raw.colors as Record<string, unknown>).mode;
     if (['auto', 'named', '256', 'truecolor'].includes(m as string)) colors.mode = m as ColorConfig['mode'];
   }
-  return { layout, gsd: typeof raw.gsd === 'boolean' ? raw.gsd : DEFAULT_CONFIG.gsd, display, colors };
+  const result: HudConfig = { layout, gsd: typeof raw.gsd === 'boolean' ? raw.gsd : DEFAULT_CONFIG.gsd, display, colors };
+  const validPresets = ['full', 'balanced', 'minimal'] as const;
+  if (validPresets.includes(raw.preset as never)) result.preset = raw.preset as HudConfig['preset'];
+  if (typeof raw.theme === 'string' && raw.theme.length > 0) result.theme = raw.theme;
+  const validIcons = ['nerd', 'emoji', 'none'] as const;
+  if (validIcons.includes(raw.icons as never)) result.icons = raw.icons as HudConfig['icons'];
+  return result;
 }
 
 export function mergeCliFlags(config: HudConfig, argv: string[]): HudConfig {
   const r = { ...config, display: { ...config.display }, colors: { ...config.colors } };
   if (argv.includes('--minimal')) r.layout = 'minimal';
   if (argv.includes('--gsd')) r.gsd = true;
+  for (const arg of argv) {
+    const presetMatch = arg.match(/^--preset[= ]?(full|balanced|minimal)$/);
+    if (presetMatch) { r.preset = presetMatch[1] as HudConfig['preset']; continue; }
+    const iconsMatch = arg.match(/^--icons[= ]?(nerd|emoji|none)$/);
+    if (iconsMatch) { r.icons = iconsMatch[1] as HudConfig['icons']; continue; }
+  }
   return r;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,6 +64,7 @@ const PRESET_DEFS: Record<NonNullable<HudConfig['preset']>, PresetDef> = {
       version: false,
       memory: false,
       contextTokens: false,
+      cacheMetrics: false,
     },
   },
   minimal: {
@@ -86,6 +87,8 @@ const PRESET_DEFS: Record<NonNullable<HudConfig['preset']>, PresetDef> = {
       linesChanged: false,
       memory: false,
       contextTokens: false,
+      cacheMetrics: false,
+      mcp: false,
     },
   },
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@ export function loadConfig(configDir: string = join(homedir(), '.config', 'lumir
 }
 
 function mergeConfig(raw: Record<string, unknown>): HudConfig {
-  const layout = (['full', 'minimal', 'auto'] as const).includes(raw.layout as never) ? raw.layout as HudConfig['layout'] : DEFAULT_CONFIG.layout;
+  const layout = (['multiline', 'singleline', 'auto'] as const).includes(raw.layout as never) ? raw.layout as HudConfig['layout'] : DEFAULT_CONFIG.layout;
   const display = { ...DEFAULT_DISPLAY };
   if (raw.display && typeof raw.display === 'object') {
     for (const k of Object.keys(DEFAULT_DISPLAY) as (keyof DisplayToggles)[]) {
@@ -35,9 +35,9 @@ function mergeConfig(raw: Record<string, unknown>): HudConfig {
 }
 
 const PRESET_TO_LAYOUT: Record<string, HudConfig['layout']> = {
-  full: 'full',
+  full: 'multiline',
   balanced: 'auto',
-  minimal: 'minimal',
+  minimal: 'singleline',
 };
 
 function applyPreset(r: HudConfig, preset: NonNullable<HudConfig['preset']>): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { getGsdInfo } from './parsers/gsd.js';
 import { getTermCols, getLayoutCols } from './utils/terminal.js';
 import { loadConfig, mergeCliFlags } from './config.js';
 import { render } from './render/index.js';
+import { resolveIcons } from './render/icons.js';
 import { install, uninstall } from './installer.js';
 import type { Dependencies, RenderContext } from './types.js';
 import { EMPTY_TRANSCRIPT } from './types.js';
@@ -42,7 +43,8 @@ export async function main(overrides: Partial<Dependencies> = {}): Promise<strin
   const rawCols = deps.getTermCols();
   const isTTY = !!(process.stdout.columns || process.stderr.columns);
   const cols = getLayoutCols(rawCols, isTTY);
-  return render({ input, git, transcript, tokenSpeed, memory, gsd, cols, config } as RenderContext);
+  const icons = resolveIcons(config.icons);
+  return render({ input, git, transcript, tokenSpeed, memory, gsd, cols, config, icons });
 }
 
 // Run when invoked directly

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { fileURLToPath } from 'node:url';
+import { realpathSync } from 'node:fs';
 import { readStdin as defaultReadStdin } from './stdin.js';
 import { parseGitStatus } from './parsers/git.js';
 import { parseTranscript } from './parsers/transcript.js';
@@ -50,9 +51,20 @@ export async function main(overrides: Partial<Dependencies> = {}): Promise<strin
   return render({ input, git, transcript, tokenSpeed, memory, gsd, mcp, cols, config, icons });
 }
 
-// Run when invoked directly
-const __filename = fileURLToPath(import.meta.url);
-if (process.argv[1] && (__filename === process.argv[1] || __filename === process.argv[1] + '.js')) {
+// Run when invoked directly.
+// Resolve through realpath to handle npx symlinks.
+function isDirectRun(): boolean {
+  if (!process.argv[1]) return false;
+  try {
+    const self = realpathSync(fileURLToPath(import.meta.url)).replace(/\.js$/, '');
+    const invoked = realpathSync(process.argv[1]).replace(/\.js$/, '');
+    return self === invoked;
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectRun()) {
   const cmd = process.argv[2];
   if (cmd === 'install') {
     install().then(o => process.stdout.write(o)).catch(e => process.stderr.write(`Install error: ${e.message}\n`));

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,8 @@ const defaultDeps: Dependencies = {
 
 export async function main(overrides: Partial<Dependencies> = {}): Promise<string> {
   const deps = { ...defaultDeps, ...overrides };
-  const config = mergeCliFlags(loadConfig(), process.argv);
+  const configLoader = deps.loadConfig ?? loadConfig;
+  const config = mergeCliFlags(configLoader(), process.argv);
   const input = await deps.readStdin();
   const cwd = input.cwd || input.workspace?.current_dir || process.cwd();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { getGsdInfo } from './parsers/gsd.js';
 import { getTermCols, getLayoutCols } from './utils/terminal.js';
 import { loadConfig, mergeCliFlags } from './config.js';
 import { render } from './render/index.js';
+import { install, uninstall } from './installer.js';
 import type { Dependencies, RenderContext } from './types.js';
 import { EMPTY_TRANSCRIPT } from './types.js';
 
@@ -46,5 +47,13 @@ export async function main(overrides: Partial<Dependencies> = {}): Promise<strin
 // Run when invoked directly
 const __filename = fileURLToPath(import.meta.url);
 if (process.argv[1] && (__filename === process.argv[1] || __filename === process.argv[1] + '.js')) {
-  main().then(o => process.stdout.write(o)).catch(e => { if (!(e instanceof SyntaxError)) process.stderr.write(`Statusline error: ${e.message}\n`); });
+  const cmd = process.argv[2];
+  if (cmd === 'install') {
+    install().then(o => process.stdout.write(o)).catch(e => process.stderr.write(`Install error: ${e.message}\n`));
+  } else if (cmd === 'uninstall') {
+    const o = uninstall();
+    process.stdout.write(o);
+  } else {
+    main().then(o => process.stdout.write(o)).catch(e => { if (!(e instanceof SyntaxError)) process.stderr.write(`Statusline error: ${e.message}\n`); });
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { parseTranscript } from './parsers/transcript.js';
 import { getTokenSpeed } from './parsers/token-speed.js';
 import { getMemoryInfo } from './parsers/memory.js';
 import { getGsdInfo } from './parsers/gsd.js';
+import { getMcpInfo } from './parsers/mcp.js';
 import { getTermCols, getLayoutCols } from './utils/terminal.js';
 import { loadConfig, mergeCliFlags } from './config.js';
 import { render } from './render/index.js';
@@ -21,6 +22,7 @@ const defaultDeps: Dependencies = {
   getTokenSpeed: (ctx) => getTokenSpeed(ctx),
   getMemoryInfo: () => getMemoryInfo(),
   getGsdInfo: (session) => getGsdInfo(session),
+  getMcpInfo: (cwd) => getMcpInfo(cwd),
   getTermCols: () => getTermCols(),
 };
 
@@ -39,12 +41,13 @@ export async function main(overrides: Partial<Dependencies> = {}): Promise<strin
   const tokenSpeed = deps.getTokenSpeed(input.context_window);
   const memory = deps.getMemoryInfo();
   const gsd = config.gsd ? deps.getGsdInfo(input.session_id) : null;
+  const mcp = deps.getMcpInfo(cwd);
 
   const rawCols = deps.getTermCols();
   const isTTY = !!(process.stdout.columns || process.stderr.columns);
   const cols = getLayoutCols(rawCols, isTTY);
   const icons = resolveIcons(config.icons);
-  return render({ input, git, transcript, tokenSpeed, memory, gsd, cols, config, icons });
+  return render({ input, git, transcript, tokenSpeed, memory, gsd, mcp, cols, config, icons });
 }
 
 // Run when invoked directly

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,0 +1,93 @@
+import { readFileSync, writeFileSync, existsSync, copyFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+import { createInterface } from 'node:readline';
+
+// ── ANSI helpers ────────────────────────────────────────────────────
+const RST = '\x1b[0m';
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const CYAN = '\x1b[36m';
+const DIM = '\x1b[2m';
+
+const ok = (msg: string) => `${GREEN}✓${RST} ${msg}`;
+const warn = (msg: string) => `${YELLOW}⚠${RST} ${msg}`;
+const header = () => `\n${CYAN} lumira installer${RST}\n`;
+
+// ── StatusLine value ────────────────────────────────────────────────
+const LUMIRA_STATUSLINE = {
+  type: 'command' as const,
+  command: 'npx lumira@latest',
+  padding: 0,
+};
+
+// ── Install options (DI for testing) ────────────────────────────────
+export interface InstallerOptions {
+  settingsPath?: string;
+  confirm?: (prompt: string) => Promise<boolean>;
+}
+
+function defaultSettingsPath(): string {
+  return join(homedir(), '.claude', 'settings.json');
+}
+
+function isLumira(statusLine: unknown): boolean {
+  if (!statusLine || typeof statusLine !== 'object') return false;
+  const sl = statusLine as Record<string, unknown>;
+  return typeof sl.command === 'string' && sl.command.includes('lumira');
+}
+
+// ── Prompt helper ───────────────────────────────────────────────────
+export function promptYN(question: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(`${question} (y/N) `, (answer) => {
+      rl.close();
+      resolve(answer.trim().toLowerCase() === 'y');
+    });
+  });
+}
+
+// ── Install ─────────────────────────────────────────────────────────
+export async function install(opts: InstallerOptions = {}): Promise<string> {
+  const settingsPath = opts.settingsPath ?? defaultSettingsPath();
+  const backupPath = settingsPath + '.lumira.bak';
+  const confirm = opts.confirm ?? promptYN;
+  const lines: string[] = [header()];
+
+  let settings: Record<string, unknown> = {};
+
+  if (existsSync(settingsPath)) {
+    try {
+      settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    } catch {
+      lines.push(warn('Could not parse existing settings.json, creating fresh'));
+      settings = {};
+    }
+  }
+
+  if (settings.statusLine) {
+    if (isLumira(settings.statusLine)) {
+      lines.push(ok('lumira is already configured as your statusline'));
+      return lines.join('\n') + '\n';
+    }
+
+    const current = (settings.statusLine as Record<string, unknown>).command ?? 'unknown';
+    lines.push(warn(`Current statusline: ${YELLOW}${current}${RST}`));
+    const accepted = await confirm('Replace with lumira?');
+    if (!accepted) {
+      lines.push(`\n  Aborted. No changes made.\n`);
+      return lines.join('\n') + '\n';
+    }
+
+    copyFileSync(settingsPath, backupPath);
+    lines.push(ok(`Backed up existing settings → ${DIM}settings.json.lumira.bak${RST}`));
+  }
+
+  settings.statusLine = { ...LUMIRA_STATUSLINE };
+  mkdirSync(dirname(settingsPath), { recursive: true });
+  writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', { mode: 0o600 });
+  lines.push(ok('Configured lumira as statusline'));
+  lines.push(`\n  Restart Claude Code to see your statusline.\n`);
+  return lines.join('\n') + '\n';
+}

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -104,11 +104,17 @@ export function uninstall(opts: InstallerOptions = {}): string {
   }
 
   if (existsSync(backupPath)) {
-    copyFileSync(backupPath, settingsPath);
-    unlinkSync(backupPath);
-    lines.push(ok('Restored previous settings from backup'));
-    lines.push(`\n  Restart Claude Code to apply changes.\n`);
-    return lines.join('\n') + '\n';
+    try {
+      JSON.parse(readFileSync(backupPath, 'utf8'));
+      copyFileSync(backupPath, settingsPath);
+      unlinkSync(backupPath);
+      lines.push(ok('Restored previous settings from backup'));
+      lines.push(`\n  Restart Claude Code to apply changes.\n`);
+      return lines.join('\n') + '\n';
+    } catch {
+      lines.push(warn('Backup file is corrupt — skipping restore'));
+      unlinkSync(backupPath);
+    }
   }
 
   try {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -113,7 +113,7 @@ export function uninstall(opts: InstallerOptions = {}): string {
       return lines.join('\n') + '\n';
     } catch {
       lines.push(warn('Backup file is corrupt — skipping restore'));
-      unlinkSync(backupPath);
+      try { unlinkSync(backupPath); } catch {}
     }
   }
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync, copyFileSync, mkdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, copyFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { createInterface } from 'node:readline';
@@ -89,5 +89,37 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
   writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', { mode: 0o600 });
   lines.push(ok('Configured lumira as statusline'));
   lines.push(`\n  Restart Claude Code to see your statusline.\n`);
+  return lines.join('\n') + '\n';
+}
+
+// ── Uninstall ───────────────────────────────────────────────────────
+export function uninstall(opts: InstallerOptions = {}): string {
+  const settingsPath = opts.settingsPath ?? defaultSettingsPath();
+  const backupPath = settingsPath + '.lumira.bak';
+  const lines: string[] = [header()];
+
+  if (!existsSync(settingsPath)) {
+    lines.push(ok('Nothing to uninstall — no settings.json found'));
+    return lines.join('\n') + '\n';
+  }
+
+  if (existsSync(backupPath)) {
+    copyFileSync(backupPath, settingsPath);
+    unlinkSync(backupPath);
+    lines.push(ok('Restored previous settings from backup'));
+    lines.push(`\n  Restart Claude Code to apply changes.\n`);
+    return lines.join('\n') + '\n';
+  }
+
+  try {
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    delete settings.statusLine;
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', { mode: 0o600 });
+    lines.push(ok('Removed lumira statusline from settings'));
+  } catch {
+    lines.push(warn('Could not parse settings.json'));
+  }
+
+  lines.push(`\n  Restart Claude Code to apply changes.\n`);
   return lines.join('\n') + '\n';
 }

--- a/src/parsers/git.ts
+++ b/src/parsers/git.ts
@@ -24,10 +24,10 @@ export async function parseGitStatus(cwd: string, exec: ExecFn = safeExec): Prom
   const status = await exec('git', ['status', '--porcelain'], { cwd, timeoutMs: 2000 });
   if (status) {
     const lines = status.split('\n').filter(Boolean);
-    // staged: index status is A/D/R/C/T (not space, not ?, not M which shows as modified)
-    result.staged = lines.filter(l => l[0] !== ' ' && l[0] !== '?' && l[0] !== 'M').length;
-    // modified: M in index (col 0) or worktree (col 1)
-    result.modified = lines.filter(l => l[0] === 'M' || l[1] === 'M').length;
+    // staged: any non-space, non-? in col 0 means something is in the index
+    result.staged = lines.filter(l => l[0] !== ' ' && l[0] !== '?').length;
+    // modified: worktree changes (col 1 = M or D)
+    result.modified = lines.filter(l => l[1] === 'M' || l[1] === 'D').length;
     result.untracked = lines.filter(l => l.startsWith('??')).length;
   }
 

--- a/src/parsers/mcp.ts
+++ b/src/parsers/mcp.ts
@@ -1,0 +1,35 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import type { McpInfo, McpServerInfo } from '../types.js';
+
+/**
+ * Read MCP server configurations from .mcp.json files.
+ * Checks both cwd and ~/.claude/ for server definitions.
+ */
+export function getMcpInfo(cwd: string): McpInfo | null {
+  const servers: McpServerInfo[] = [];
+
+  const paths = [
+    join(cwd, '.mcp.json'),
+    join(homedir(), '.claude', '.mcp.json'),
+  ];
+
+  for (const p of paths) {
+    if (!existsSync(p)) continue;
+    try {
+      const raw = JSON.parse(readFileSync(p, 'utf8'));
+      const mcpServers = raw?.mcpServers ?? {};
+      for (const name of Object.keys(mcpServers)) {
+        // Avoid duplicates if same server in both files
+        if (servers.some(s => s.name === name)) continue;
+        servers.push({ name, status: 'ok' });
+      }
+    } catch {
+      // Malformed JSON — skip
+    }
+  }
+
+  if (servers.length === 0) return null;
+  return { servers };
+}

--- a/src/parsers/transcript.ts
+++ b/src/parsers/transcript.ts
@@ -6,9 +6,7 @@ import type { TranscriptData, ToolEntry, AgentEntry, TodoEntry, TodoStatus, Thin
 import { EMPTY_TRANSCRIPT } from '../types.js';
 import { isMtimeFresh, getMtimeState, type MtimeState } from '../utils/cache.js';
 
-let cachedResult: TranscriptData | null = null;
-let cachedMtime: MtimeState | null = null;
-let cachedPath: string | null = null;
+const transcriptCache = new Map<string, { result: TranscriptData; mtime: MtimeState }>();
 
 const MAX_LINES = 50_000;
 
@@ -43,8 +41,9 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   if (!resolved.startsWith(homedir()) && !resolved.startsWith(tmpdir())) return result;
 
   const currentMtime = getMtimeState(transcriptPath);
-  if (currentMtime && cachedPath === transcriptPath && cachedMtime && isMtimeFresh(transcriptPath, cachedMtime) && cachedResult) {
-    return cachedResult;
+  const cached = transcriptCache.get(resolved);
+  if (currentMtime && cached && isMtimeFresh(transcriptPath, cached.mtime)) {
+    return cached.result;
   }
 
   const toolMap = new Map<string, ToolEntry>();
@@ -131,8 +130,8 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   result.agents = Array.from(agentMap.values()).slice(-10);
   result.todos = todos;
   result.thinkingEffort = thinkingEffort;
-  cachedResult = result;
-  cachedMtime = currentMtime;
-  cachedPath = transcriptPath;
+  if (currentMtime) {
+    transcriptCache.set(resolved, { result, mtime: currentMtime });
+  }
   return result;
 }

--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -17,7 +17,7 @@ export interface Colors {
   bold: (s: string) => string;
 }
 
-export function createColors(mode: ColorMode): Colors {
+export function createColors(mode: ColorMode, theme?: import('../themes.js').ThemePalette | null): Colors {
   const wrap = (code: string) => (s: string) => `${code}${s}${RST}`;
 
   // Named ANSI colors as default — respects terminal theme (like the original JS).
@@ -30,6 +30,17 @@ export function createColors(mode: ColorMode): Colors {
     blinkRed: wrap('\x1b[5;31m'), gray: wrap('\x1b[90m'),
     brightBlue: wrap('\x1b[94m'), dim: wrap('\x1b[2m'), bold: wrap('\x1b[1m'),
   };
+
+  // Theme overrides (truecolor only — resolveTheme returns null otherwise)
+  if (theme && mode === 'truecolor') {
+    return {
+      ...named,
+      cyan: wrap(theme.cyan), magenta: wrap(theme.magenta),
+      yellow: wrap(theme.yellow), green: wrap(theme.green),
+      orange: wrap(theme.orange), red: wrap(theme.red),
+      brightBlue: wrap(theme.brightBlue), gray: wrap(theme.gray),
+    };
+  }
 
   if (mode === 'truecolor') {
     return {

--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -56,8 +56,11 @@ export function stripAnsi(str: string): string {
 }
 
 export function detectColorMode(): ColorMode {
-  // Default to named ANSI — respects terminal theme colors.
-  // Only upgrade if user explicitly sets colors.mode in config.
+  const colorterm = (process.env['COLORTERM'] ?? '').toLowerCase();
+  if (colorterm === 'truecolor' || colorterm === '24bit') return 'truecolor';
+  const term = process.env['TERM'] ?? '';
+  const termProgram = process.env['TERM_PROGRAM'] ?? '';
+  if (term.endsWith('-256color') || termProgram === 'iTerm.app' || termProgram === 'Hyper') return '256';
   return 'named';
 }
 

--- a/src/render/icons.ts
+++ b/src/render/icons.ts
@@ -1,19 +1,89 @@
-export const ICONS = {
-  model:    '\uEE0D',  // fa-robot
-  branch:   '\uE725',  // dev-git-branch
-  folder:   '\uF07C',  // fa-folder-open
-  fire:     '\uF06D',  // fa-fire (context 65-79%)
-  skull:    '\uEE15',  // fa-skull (context >=80%)
-  comment:  '\uF075',  // fa-comment (tokens)
-  clock:    '\uF017',  // fa-clock (duration)
-  bolt:     '\uF0E7',  // fa-bolt (token speed, rate limits)
-  tree:     '\uF1BB',  // fa-tree (worktree)
-  cubes:    '\uF1B3',  // fa-cubes (agent)
-  hammer:   '\uEEFF',  // fa-hammer (GSD task)
-  warning:  '\uF071',  // fa-warning (GSD update)
-  barFull:  '\u2588',  // block full
-  barEmpty: '\u2591',  // block light
-  ellipsis: '\u2026',  // ...
-  dash:     '\u2014',  // em-dash
-  checkmark: '\u2713', // checkmark
-} as const;
+export interface IconSet {
+  model: string;
+  branch: string;
+  folder: string;
+  fire: string;
+  skull: string;
+  comment: string;
+  clock: string;
+  bolt: string;
+  tree: string;
+  cubes: string;
+  hammer: string;
+  warning: string;
+  barFull: string;
+  barEmpty: string;
+  ellipsis: string;
+  dash: string;
+  checkmark: string;
+}
+
+export const NERD_ICONS: IconSet = {
+  model:     '\uEE0D',  // fa-robot
+  branch:    '\uE725',  // dev-git-branch
+  folder:    '\uF07C',  // fa-folder-open
+  fire:      '\uF06D',  // fa-fire
+  skull:     '\uEE15',  // fa-skull
+  comment:   '\uF075',  // fa-comment
+  clock:     '\uF017',  // fa-clock
+  bolt:      '\uF0E7',  // fa-bolt
+  tree:      '\uF1BB',  // fa-tree
+  cubes:     '\uF1B3',  // fa-cubes
+  hammer:    '\uEEFF',  // fa-hammer
+  warning:   '\uF071',  // fa-warning
+  barFull:   '\u2588',  // block full
+  barEmpty:  '\u2591',  // block light
+  ellipsis:  '\u2026',  // ...
+  dash:      '\u2014',  // em-dash
+  checkmark: '\u2713',  // checkmark
+};
+
+export const EMOJI_ICONS: IconSet = {
+  model:     '\u{1F916}', // 🤖
+  branch:    '\u{1F33F}', // 🌿
+  folder:    '\u{1F4C2}', // 📂
+  fire:      '\u{1F525}', // 🔥
+  skull:     '\u{1F480}', // 💀
+  comment:   '\u{1F4AC}', // 💬
+  clock:     '\u{23F1}\uFE0F',  // ⏱️
+  bolt:      '\u26A1',    // ⚡
+  tree:      '\u{1F332}', // 🌲
+  cubes:     '\u{1F4E6}', // 📦
+  hammer:    '\u{1F528}', // 🔨
+  warning:   '\u26A0\uFE0F',   // ⚠️
+  barFull:   '\u2588',
+  barEmpty:  '\u2591',
+  ellipsis:  '\u2026',
+  dash:      '\u2014',
+  checkmark: '\u2705',    // ✅
+};
+
+export const NO_ICONS: IconSet = {
+  model:     '',
+  branch:    '',
+  folder:    '',
+  fire:      '!',
+  skull:     '!!',
+  comment:   '',
+  clock:     '',
+  bolt:      '',
+  tree:      '',
+  cubes:     '',
+  hammer:    '',
+  warning:   '!',
+  barFull:   '\u2588',
+  barEmpty:  '\u2591',
+  ellipsis:  '\u2026',
+  dash:      '\u2014',
+  checkmark: '\u2713',
+};
+
+/** Resolve icon set from config value */
+export function resolveIcons(mode?: 'nerd' | 'emoji' | 'none'): IconSet {
+  if (mode === 'emoji') return EMOJI_ICONS;
+  if (mode === 'none') return NO_ICONS;
+  return NERD_ICONS;
+}
+
+// Backward compat — default export is nerd icons
+export const ICONS = NERD_ICONS;

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -4,11 +4,13 @@ import { renderLine2 } from './line2.js';
 import { renderLine3 } from './line3.js';
 import { renderLine4 } from './line4.js';
 import { renderMinimal } from './minimal.js';
+import { resolveTheme } from '../themes.js';
 import type { RenderContext } from '../types.js';
 
 export function render(ctx: RenderContext): string {
   const colorMode: ColorMode = ctx.config.colors.mode === 'auto' ? detectColorMode() : ctx.config.colors.mode;
-  const c = createColors(colorMode);
+  const theme = resolveTheme(ctx.config.theme, colorMode);
+  const c = createColors(colorMode, theme);
 
   if (ctx.config.layout === 'singleline' || (ctx.config.layout === 'auto' && ctx.cols < 70)) {
     return renderMinimal(ctx, c);

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -18,7 +18,7 @@ export function render(ctx: RenderContext): string {
   const lines: string[] = [];
   lines.push(renderLine1(input, git, transcript, c, config.display, cols));
   lines.push(renderLine2(input, tokenSpeed, transcript.thinkingEffort, c, config.display, cols, memory));
-  const l3 = renderLine3(transcript.tools, transcript.todos, c);
+  const l3 = renderLine3(transcript.tools, transcript.todos, c, config.display);
   if (l3) lines.push(l3);
   if (config.gsd) { const l4 = renderLine4(gsd, c); if (l4) lines.push(l4); }
   return lines.filter(Boolean).join('\n');

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -10,7 +10,7 @@ export function render(ctx: RenderContext): string {
   const colorMode: ColorMode = ctx.config.colors.mode === 'auto' ? detectColorMode() : ctx.config.colors.mode;
   const c = createColors(colorMode);
 
-  if (ctx.config.layout === 'minimal' || (ctx.config.layout === 'auto' && ctx.cols < 70)) {
+  if (ctx.config.layout === 'singleline' || (ctx.config.layout === 'auto' && ctx.cols < 70)) {
     return renderMinimal(ctx, c);
   }
 

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -7,19 +7,18 @@ import { renderMinimal } from './minimal.js';
 import type { RenderContext } from '../types.js';
 
 export function render(ctx: RenderContext): string {
-  const { input, git, transcript, tokenSpeed, memory, gsd, cols, config } = ctx;
-  const colorMode: ColorMode = config.colors.mode === 'auto' ? detectColorMode() : config.colors.mode;
+  const colorMode: ColorMode = ctx.config.colors.mode === 'auto' ? detectColorMode() : ctx.config.colors.mode;
   const c = createColors(colorMode);
 
-  if (config.layout === 'minimal' || (config.layout === 'auto' && cols < 70)) {
-    return renderMinimal(input, git, transcript, tokenSpeed, gsd, c, config.display, cols);
+  if (ctx.config.layout === 'minimal' || (ctx.config.layout === 'auto' && ctx.cols < 70)) {
+    return renderMinimal(ctx, c);
   }
 
   const lines: string[] = [];
-  lines.push(renderLine1(input, git, transcript, c, config.display, cols));
-  lines.push(renderLine2(input, tokenSpeed, transcript.thinkingEffort, c, config.display, cols, memory));
-  const l3 = renderLine3(transcript.tools, transcript.todos, c, config.display);
+  lines.push(renderLine1(ctx, c));
+  lines.push(renderLine2(ctx, c));
+  const l3 = renderLine3(ctx, c);
   if (l3) lines.push(l3);
-  if (config.gsd) { const l4 = renderLine4(gsd, c); if (l4) lines.push(l4); }
+  if (ctx.config.gsd) { const l4 = renderLine4(ctx, c); if (l4) lines.push(l4); }
   return lines.filter(Boolean).join('\n');
 }

--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -1,5 +1,4 @@
 import { basename } from 'node:path';
-import { ICONS } from './icons.js';
 import { fitSegments, truncField } from './text.js';
 import { getModelName, formatGitChanges, SEP } from './shared.js';
 import type { Colors } from './colors.js';
@@ -11,21 +10,21 @@ function getActiveTodo(transcript: TranscriptData): string | undefined {
 }
 
 export function renderLine1(ctx: RenderContext, c: Colors): string {
-  const { input, git, transcript, config: { display }, cols } = ctx;
+  const { input, git, transcript, config: { display }, cols, icons } = ctx;
   const left: string[] = [];
   const right: string[] = [];
 
   // Model
   if (display.model) {
     const modelName = getModelName(input.model);
-    if (modelName) left.push(c.cyan(`${ICONS.model} ${modelName}`));
+    if (modelName) left.push(c.cyan(`${icons.model} ${modelName}`));
   }
 
   // Branch + git changes
   if (display.branch && git.branch) {
     const branchLen = cols < 60 ? 12 : cols < 80 ? 20 : cols < 100 ? 30 : cols < 120 ? 40 : 60;
     const branchName = truncField(git.branch, branchLen);
-    let branchStr = c.magenta(`${ICONS.branch} ${branchName}`);
+    let branchStr = c.magenta(`${icons.branch} ${branchName}`);
 
     if (display.gitChanges) {
       const parts = formatGitChanges(git, c);
@@ -40,7 +39,7 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
     if (cwd) {
       const dirName = basename(cwd) || cwd;
       const dirLen = cols < 80 ? 12 : cols < 120 ? 20 : 30;
-      left.push(c.brightBlue(`${ICONS.folder} ${truncField(dirName, dirLen)}`));
+      left.push(c.brightBlue(`${icons.folder} ${truncField(dirName, dirLen)}`));
     }
   }
 
@@ -61,12 +60,12 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
 
   // Worktree
   if (display.worktree && input.worktree?.name) {
-    right.push(c.gray(`${ICONS.tree} ${truncField(input.worktree.name, 15)}`));
+    right.push(c.gray(`${icons.tree} ${truncField(input.worktree.name, 15)}`));
   }
 
   // Agent
   if (display.agent && input.agent?.name) {
-    right.push(c.gray(`${ICONS.cubes} ${truncField(input.agent.name, 15)}`));
+    right.push(c.gray(`${icons.cubes} ${truncField(input.agent.name, 15)}`));
   }
 
   // Session name

--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -1,16 +1,9 @@
 import { basename } from 'node:path';
 import { ICONS } from './icons.js';
 import { fitSegments, truncField } from './text.js';
+import { getModelName, formatGitChanges, SEP } from './shared.js';
 import type { Colors } from './colors.js';
 import type { ClaudeCodeInput, GitStatus, TranscriptData, DisplayToggles } from '../types.js';
-
-const SEP = ` \x1b[90m│\x1b[0m `;
-
-function getModelName(model: ClaudeCodeInput['model']): string {
-  if (typeof model === 'string') return model;
-  if (model && typeof model === 'object' && 'display_name' in model) return model.display_name;
-  return '';
-}
 
 function getActiveTodo(transcript: TranscriptData): string | undefined {
   const inProgress = transcript.todos.filter(t => t.status === 'in_progress');
@@ -41,10 +34,7 @@ export function renderLine1(
     let branchStr = c.magenta(`${ICONS.branch} ${branchName}`);
 
     if (display.gitChanges) {
-      const parts: string[] = [];
-      if (git.staged > 0) parts.push(c.green(`+${git.staged}`));
-      if (git.modified > 0) parts.push(c.yellow(`!${git.modified}`));
-      if (git.untracked > 0) parts.push(c.gray(`?${git.untracked}`));
+      const parts = formatGitChanges(git, c);
       if (parts.length > 0) branchStr += ' ' + parts.join(' ');
     }
     left.push(branchStr);

--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -3,21 +3,15 @@ import { ICONS } from './icons.js';
 import { fitSegments, truncField } from './text.js';
 import { getModelName, formatGitChanges, SEP } from './shared.js';
 import type { Colors } from './colors.js';
-import type { ClaudeCodeInput, GitStatus, TranscriptData, DisplayToggles } from '../types.js';
+import type { RenderContext, TranscriptData } from '../types.js';
 
 function getActiveTodo(transcript: TranscriptData): string | undefined {
   const inProgress = transcript.todos.filter(t => t.status === 'in_progress');
   return inProgress[0]?.content;
 }
 
-export function renderLine1(
-  input: ClaudeCodeInput,
-  git: GitStatus,
-  transcript: TranscriptData,
-  c: Colors,
-  display: DisplayToggles,
-  cols: number
-): string {
+export function renderLine1(ctx: RenderContext, c: Colors): string {
+  const { input, git, transcript, config: { display }, cols } = ctx;
   const left: string[] = [];
   const right: string[] = [];
 

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -1,22 +1,9 @@
 import { ICONS } from './icons.js';
 import { padLine, displayWidth } from './text.js';
-import { getContextColor, getQuotaColor, type Colors } from './colors.js';
+import { getQuotaColor, type Colors } from './colors.js';
+import { buildContextBar, SEP } from './shared.js';
 import { formatTokens, formatDuration, formatCost, formatBurnRate } from '../utils/format.js';
 import type { ClaudeCodeInput, DisplayToggles, ThinkingEffort, MemoryInfo } from '../types.js';
-
-const SEP = ` \x1b[90m│\x1b[0m `;
-
-function buildContextBar(pct: number, c: Colors): string {
-  const SEGMENTS = 20;
-  const filled = Math.round((pct / 100) * SEGMENTS);
-  const colorFn = c[getContextColor(pct)];
-  const bar = colorFn(ICONS.barFull.repeat(filled)) + c.dim(ICONS.barEmpty.repeat(SEGMENTS - filled));
-  let icon = '';
-  if (pct >= 80) icon = c.blinkRed(ICONS.skull);
-  else if (pct >= 65) icon = c.orange(ICONS.fire);
-  const pctStr = colorFn(`${pct < 10 ? pct.toFixed(1) : pct.toFixed(0)}%`);
-  return `[${bar}] ${pctStr}${icon ? ' ' + icon : ''}`;
-}
 
 export function formatCountdown(resetsAt: number): string {
   const resetsAtMs = resetsAt < 1e12 ? resetsAt * 1000 : resetsAt;

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -18,8 +18,9 @@ function buildContextBar(pct: number, c: Colors): string {
   return `[${bar}] ${pctStr}${icon ? ' ' + icon : ''}`;
 }
 
-function formatCountdown(resetsAt: number): string {
-  const diffMs = resetsAt - Date.now();
+export function formatCountdown(resetsAt: number): string {
+  const resetsAtMs = resetsAt < 1e12 ? resetsAt * 1000 : resetsAt;
+  const diffMs = resetsAtMs - Date.now();
   if (diffMs <= 0) return '';
   const totalSec = Math.floor(diffMs / 1000);
   const h = Math.floor(totalSec / 3600);

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -1,4 +1,3 @@
-import { ICONS } from './icons.js';
 import { padLine, displayWidth } from './text.js';
 import { getQuotaColor, type Colors } from './colors.js';
 import { buildContextBar, SEP } from './shared.js';
@@ -19,14 +18,14 @@ export function formatCountdown(resetsAt: number): string {
 }
 
 export function renderLine2(ctx: RenderContext, c: Colors): string {
-  const { input, tokenSpeed, transcript: { thinkingEffort }, config: { display }, cols, memory } = ctx;
+  const { input, tokenSpeed, transcript: { thinkingEffort }, config: { display }, cols, memory, icons } = ctx;
   const leftParts: string[] = [];
   const rightParts: string[] = [];
 
   // Context bar
   if (display.contextBar) {
     const pct = input.context_window.used_percentage;
-    leftParts.push(buildContextBar(pct, c));
+    leftParts.push(buildContextBar(pct, c, { iconSet: icons }));
   }
 
   // Tokens
@@ -36,7 +35,7 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
     const parts: string[] = [];
     if (inTokens != null) parts.push(`${formatTokens(inTokens)}↑`);
     if (outTokens != null) parts.push(`${formatTokens(outTokens)}↓`);
-    if (parts.length > 0) leftParts.push(`${ICONS.comment} ${parts.join(' ')}`);
+    if (parts.length > 0) leftParts.push(`${icons.comment} ${parts.join(' ')}`);
   }
 
   // Cost + burn rate
@@ -52,7 +51,7 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
 
   // Duration
   if (display.duration && input.cost) {
-    leftParts.push(`${ICONS.clock} ${formatDuration(input.cost.total_duration_ms)}`);
+    leftParts.push(`${icons.clock} ${formatDuration(input.cost.total_duration_ms)}`);
   }
 
   // Memory
@@ -62,7 +61,7 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
 
   // Token speed
   if (display.tokenSpeed && tokenSpeed != null) {
-    leftParts.push(c.dim(`${ICONS.bolt}${tokenSpeed} tok/s`));
+    leftParts.push(c.dim(`${icons.bolt}${tokenSpeed} tok/s`));
   }
 
   // Rate limits (only show if >=50%)
@@ -74,7 +73,7 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
     for (const [label, win] of limits) {
       if (!win || win.used_percentage < 50) continue;
       const colorFn = c[getQuotaColor(win.used_percentage)];
-      let limitStr = colorFn(`${ICONS.bolt} ${win.used_percentage.toFixed(0)}%(${label})`);
+      let limitStr = colorFn(`${icons.bolt} ${win.used_percentage.toFixed(0)}%(${label})`);
       if (win.used_percentage >= 70 && win.resets_at) {
         const countdown = formatCountdown(win.resets_at);
         if (countdown) limitStr += c.dim(` ${countdown}`);

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -18,7 +18,7 @@ export function formatCountdown(resetsAt: number): string {
 }
 
 export function renderLine2(ctx: RenderContext, c: Colors): string {
-  const { input, tokenSpeed, transcript: { thinkingEffort }, config: { display }, cols, memory, icons } = ctx;
+  const { input, tokenSpeed, transcript: { thinkingEffort }, config: { display }, cols, memory, mcp, icons } = ctx;
   const leftParts: string[] = [];
   const rightParts: string[] = [];
 
@@ -26,6 +26,13 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
   if (display.contextBar) {
     const pct = input.context_window.used_percentage;
     leftParts.push(buildContextBar(pct, c, { iconSet: icons }));
+  }
+
+  // Context tokens (estimated used/capacity from percentage)
+  if (display.contextTokens && input.context_window.total_input_tokens != null && input.context_window.used_percentage > 0) {
+    const used = input.context_window.total_input_tokens;
+    const capacity = Math.round(used / (input.context_window.used_percentage / 100));
+    leftParts.push(c.dim(`${formatTokens(used)}/${formatTokens(capacity)}`));
   }
 
   // Tokens
@@ -36,6 +43,16 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
     if (inTokens != null) parts.push(`${formatTokens(inTokens)}↑`);
     if (outTokens != null) parts.push(`${formatTokens(outTokens)}↓`);
     if (parts.length > 0) leftParts.push(`${icons.comment} ${parts.join(' ')}`);
+  }
+
+  // Cache metrics (hit rate)
+  if (display.cacheMetrics) {
+    const cacheRead = input.context_window.cache_read_input_tokens;
+    const totalIn = input.context_window.total_input_tokens;
+    if (cacheRead != null && totalIn != null && totalIn > 0) {
+      const hitRate = Math.round((cacheRead / totalIn) * 100);
+      leftParts.push(c.dim(`cache ${hitRate}%`));
+    }
   }
 
   // Cost + burn rate
@@ -57,6 +74,17 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
   // Memory
   if (display.memory && memory) {
     leftParts.push(c.dim(`${memory.percentage}% mem`));
+  }
+
+  // MCP servers
+  if (display.mcp && mcp) {
+    const total = mcp.servers.length;
+    const errors = mcp.servers.filter(s => s.status === 'error').length;
+    if (errors > 0) {
+      leftParts.push(c.red(`MCP ${total - errors}/${total}`));
+    } else {
+      leftParts.push(c.dim(`MCP ${total}`));
+    }
   }
 
   // Token speed

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -3,7 +3,7 @@ import { padLine, displayWidth } from './text.js';
 import { getQuotaColor, type Colors } from './colors.js';
 import { buildContextBar, SEP } from './shared.js';
 import { formatTokens, formatDuration, formatCost, formatBurnRate } from '../utils/format.js';
-import type { ClaudeCodeInput, DisplayToggles, ThinkingEffort, MemoryInfo } from '../types.js';
+import type { RenderContext } from '../types.js';
 
 export function formatCountdown(resetsAt: number): string {
   const resetsAtMs = resetsAt < 1e12 ? resetsAt * 1000 : resetsAt;
@@ -18,15 +18,8 @@ export function formatCountdown(resetsAt: number): string {
   return `${s}s`;
 }
 
-export function renderLine2(
-  input: ClaudeCodeInput,
-  tokenSpeed: number | null,
-  thinkingEffort: ThinkingEffort,
-  c: Colors,
-  display: DisplayToggles,
-  cols: number,
-  memory: MemoryInfo | null = null
-): string {
+export function renderLine2(ctx: RenderContext, c: Colors): string {
+  const { input, tokenSpeed, transcript: { thinkingEffort }, config: { display }, cols, memory } = ctx;
   const leftParts: string[] = [];
   const rightParts: string[] = [];
 

--- a/src/render/line3.ts
+++ b/src/render/line3.ts
@@ -1,25 +1,23 @@
-import { ICONS } from './icons.js';
 import { truncField } from './text.js';
 import { SEP } from './shared.js';
+import type { IconSet } from './icons.js';
 import type { Colors } from './colors.js';
 import type { RenderContext, ToolEntry, TodoEntry } from '../types.js';
 
 const EXCLUDED_TOOLS = new Set(['TodoWrite', 'TaskCreate', 'TaskUpdate']);
 
-function buildToolsPart(tools: ToolEntry[], c: Colors): string {
+function buildToolsPart(tools: ToolEntry[], c: Colors, ic: IconSet): string {
   const relevant = tools.filter(t => !EXCLUDED_TOOLS.has(t.name));
   if (relevant.length === 0) return '';
 
   const parts: string[] = [];
 
-  // Running tools (last 2)
   const running = relevant.filter(t => t.status === 'running').slice(-2);
   for (const tool of running) {
     const target = tool.target ? `: ${truncField(tool.target, 20)}` : '';
     parts.push(c.yellow(`◐ ${tool.name}${target}`));
   }
 
-  // Completed tools grouped by name (top 4 groups)
   const completed = relevant.filter(t => t.status === 'completed');
   const groups = new Map<string, number>();
   for (const tool of completed) {
@@ -32,13 +30,13 @@ function buildToolsPart(tools: ToolEntry[], c: Colors): string {
 
   for (const [name, count] of topGroups) {
     const countStr = count > 1 ? ` ×${count}` : '';
-    parts.push(c.dim(`${ICONS.checkmark} ${name}${countStr}`));
+    parts.push(c.dim(`${ic.checkmark} ${name}${countStr}`));
   }
 
   return parts.join(' ');
 }
 
-function buildTodosPart(todos: TodoEntry[], c: Colors): string {
+function buildTodosPart(todos: TodoEntry[], c: Colors, ic: IconSet): string {
   if (todos.length === 0) return '';
 
   const total = todos.length;
@@ -46,10 +44,9 @@ function buildTodosPart(todos: TodoEntry[], c: Colors): string {
   const inProgress = todos.filter(t => t.status === 'in_progress').length;
   const pending = todos.filter(t => t.status === 'pending').length;
 
-  // Progress bar (10 segments)
   const SEGMENTS = 10;
   const filledCount = Math.round((completed / total) * SEGMENTS);
-  const bar = c.green(ICONS.barFull.repeat(filledCount)) + c.dim(ICONS.barEmpty.repeat(SEGMENTS - filledCount));
+  const bar = c.green(ic.barFull.repeat(filledCount)) + c.dim(ic.barEmpty.repeat(SEGMENTS - filledCount));
   let str = `${bar} ${completed}/${total}`;
 
   if (inProgress > 0) str += ` ${c.yellow(`◐ ${inProgress}`)}`;
@@ -59,9 +56,9 @@ function buildTodosPart(todos: TodoEntry[], c: Colors): string {
 }
 
 export function renderLine3(ctx: RenderContext, c: Colors): string {
-  const { transcript: { tools, todos }, config: { display } } = ctx;
-  const toolsPart = display.tools === false ? '' : buildToolsPart(tools, c);
-  const todosPart = display.todos === false ? '' : buildTodosPart(todos, c);
+  const { transcript: { tools, todos }, config: { display }, icons } = ctx;
+  const toolsPart = display.tools === false ? '' : buildToolsPart(tools, c, icons);
+  const todosPart = display.todos === false ? '' : buildTodosPart(todos, c, icons);
 
   if (!toolsPart && !todosPart) return '';
   if (!toolsPart) return todosPart;

--- a/src/render/line3.ts
+++ b/src/render/line3.ts
@@ -1,10 +1,10 @@
 import { ICONS } from './icons.js';
 import { truncField } from './text.js';
+import { SEP } from './shared.js';
 import type { Colors } from './colors.js';
 import type { ToolEntry, TodoEntry, DisplayToggles } from '../types.js';
 
 const EXCLUDED_TOOLS = new Set(['TodoWrite', 'TaskCreate', 'TaskUpdate']);
-const SEP_GRAY = ` \x1b[90m│\x1b[0m `;
 
 function buildToolsPart(tools: ToolEntry[], c: Colors): string {
   const relevant = tools.filter(t => !EXCLUDED_TOOLS.has(t.name));
@@ -70,5 +70,5 @@ export function renderLine3(
   if (!toolsPart && !todosPart) return '';
   if (!toolsPart) return todosPart;
   if (!todosPart) return toolsPart;
-  return toolsPart + SEP_GRAY + todosPart;
+  return toolsPart + SEP + todosPart;
 }

--- a/src/render/line3.ts
+++ b/src/render/line3.ts
@@ -2,7 +2,7 @@ import { ICONS } from './icons.js';
 import { truncField } from './text.js';
 import { SEP } from './shared.js';
 import type { Colors } from './colors.js';
-import type { ToolEntry, TodoEntry, DisplayToggles } from '../types.js';
+import type { RenderContext, ToolEntry, TodoEntry } from '../types.js';
 
 const EXCLUDED_TOOLS = new Set(['TodoWrite', 'TaskCreate', 'TaskUpdate']);
 
@@ -58,14 +58,10 @@ function buildTodosPart(todos: TodoEntry[], c: Colors): string {
   return str;
 }
 
-export function renderLine3(
-  tools: ToolEntry[],
-  todos: TodoEntry[],
-  c: Colors,
-  display?: DisplayToggles
-): string {
-  const toolsPart = display?.tools === false ? '' : buildToolsPart(tools, c);
-  const todosPart = display?.todos === false ? '' : buildTodosPart(todos, c);
+export function renderLine3(ctx: RenderContext, c: Colors): string {
+  const { transcript: { tools, todos }, config: { display } } = ctx;
+  const toolsPart = display.tools === false ? '' : buildToolsPart(tools, c);
+  const todosPart = display.todos === false ? '' : buildTodosPart(todos, c);
 
   if (!toolsPart && !todosPart) return '';
   if (!toolsPart) return todosPart;

--- a/src/render/line3.ts
+++ b/src/render/line3.ts
@@ -1,7 +1,7 @@
 import { ICONS } from './icons.js';
 import { truncField } from './text.js';
 import type { Colors } from './colors.js';
-import type { ToolEntry, TodoEntry } from '../types.js';
+import type { ToolEntry, TodoEntry, DisplayToggles } from '../types.js';
 
 const EXCLUDED_TOOLS = new Set(['TodoWrite', 'TaskCreate', 'TaskUpdate']);
 const SEP_GRAY = ` \x1b[90m│\x1b[0m `;
@@ -61,10 +61,11 @@ function buildTodosPart(todos: TodoEntry[], c: Colors): string {
 export function renderLine3(
   tools: ToolEntry[],
   todos: TodoEntry[],
-  c: Colors
+  c: Colors,
+  display?: DisplayToggles
 ): string {
-  const toolsPart = buildToolsPart(tools, c);
-  const todosPart = buildTodosPart(todos, c);
+  const toolsPart = display?.tools === false ? '' : buildToolsPart(tools, c);
+  const todosPart = display?.todos === false ? '' : buildTodosPart(todos, c);
 
   if (!toolsPart && !todosPart) return '';
   if (!toolsPart) return todosPart;

--- a/src/render/line4.ts
+++ b/src/render/line4.ts
@@ -1,21 +1,20 @@
-import { ICONS } from './icons.js';
 import { truncField } from './text.js';
 import type { Colors } from './colors.js';
 import type { RenderContext } from '../types.js';
 
 export function renderLine4(ctx: RenderContext, c: Colors): string {
-  const { gsd } = ctx;
+  const { gsd, icons } = ctx;
   if (!gsd) return '';
   if (!gsd.currentTask && !gsd.updateAvailable) return '';
 
   const parts: string[] = [c.dim('GSD')];
 
   if (gsd.currentTask) {
-    parts.push(c.bold(`${ICONS.hammer} ${truncField(gsd.currentTask, 40)}`));
+    parts.push(c.bold(`${icons.hammer} ${truncField(gsd.currentTask, 40)}`));
   }
 
   if (gsd.updateAvailable) {
-    parts.push(c.yellow(`${ICONS.warning} GSD update available`));
+    parts.push(c.yellow(`${icons.warning} GSD update available`));
   }
 
   return parts.join(' ');

--- a/src/render/line4.ts
+++ b/src/render/line4.ts
@@ -1,12 +1,10 @@
 import { ICONS } from './icons.js';
 import { truncField } from './text.js';
 import type { Colors } from './colors.js';
-import type { GsdInfo } from '../types.js';
+import type { RenderContext } from '../types.js';
 
-export function renderLine4(
-  gsd: GsdInfo | null,
-  c: Colors
-): string {
+export function renderLine4(ctx: RenderContext, c: Colors): string {
+  const { gsd } = ctx;
   if (!gsd) return '';
   if (!gsd.currentTask && !gsd.updateAvailable) return '';
 

--- a/src/render/minimal.ts
+++ b/src/render/minimal.ts
@@ -1,26 +1,11 @@
 import { basename } from 'node:path';
 import { ICONS } from './icons.js';
 import { truncField } from './text.js';
-import { getContextColor, type Colors } from './colors.js';
+import { getModelName, buildContextBar, formatGitChanges, SEP_MINIMAL } from './shared.js';
+import type { Colors } from './colors.js';
 import { formatTokens, formatDuration, formatCost } from '../utils/format.js';
 import { renderLine3 } from './line3.js';
 import type { ClaudeCodeInput, GitStatus, TranscriptData, DisplayToggles, GsdInfo } from '../types.js';
-
-const SEP = ` \x1b[90m|\x1b[0m `;
-
-function getModelName(model: ClaudeCodeInput['model']): string {
-  if (typeof model === 'string') return model;
-  if (model && typeof model === 'object' && 'display_name' in model) return model.display_name;
-  return '';
-}
-
-function buildContextBar(pct: number, c: Colors): string {
-  const SEGMENTS = 10;
-  const filled = Math.round((pct / 100) * SEGMENTS);
-  const colorFn = c[getContextColor(pct)];
-  const bar = colorFn(ICONS.barFull.repeat(filled)) + c.dim(ICONS.barEmpty.repeat(SEGMENTS - filled));
-  return `[${bar} ${colorFn(`${pct.toFixed(0)}%`)}]`;
-}
 
 export function renderMinimal(
   input: ClaudeCodeInput,
@@ -47,10 +32,7 @@ export function renderMinimal(
     const branchLen = cols < 60 ? 12 : cols < 80 ? 20 : git.branch.length;
     let branchStr = c.magenta(truncField(git.branch, branchLen));
     if (display.gitChanges) {
-      const changeParts: string[] = [];
-      if (git.staged > 0) changeParts.push(c.green(`+${git.staged}`));
-      if (git.modified > 0) changeParts.push(c.yellow(`~${git.modified}`));
-      if (git.untracked > 0) changeParts.push(c.gray(`?${git.untracked}`));
+      const changeParts = formatGitChanges(git, c);
       if (changeParts.length > 0) branchStr += ' ' + changeParts.join(' ');
     }
     parts.push(branchStr);
@@ -64,7 +46,7 @@ export function renderMinimal(
 
   // Context bar
   if (display.contextBar) {
-    parts.push(buildContextBar(input.context_window.used_percentage, c));
+    parts.push(buildContextBar(input.context_window.used_percentage, c, { segments: 10, pctInsideBar: true }));
   }
 
   // Only add these if cols >= 60
@@ -129,7 +111,7 @@ export function renderMinimal(
     }
   }
 
-  const mainLine = parts.join(SEP);
+  const mainLine = parts.join(SEP_MINIMAL);
 
   // Append tools/todos as extra line
   const l3 = renderLine3(transcript.tools, transcript.todos, c);

--- a/src/render/minimal.ts
+++ b/src/render/minimal.ts
@@ -1,5 +1,4 @@
 import { basename } from 'node:path';
-import { ICONS } from './icons.js';
 import { truncField } from './text.js';
 import { getModelName, buildContextBar, formatGitChanges, SEP_MINIMAL } from './shared.js';
 import type { Colors } from './colors.js';
@@ -8,7 +7,7 @@ import { renderLine3 } from './line3.js';
 import type { RenderContext } from '../types.js';
 
 export function renderMinimal(ctx: RenderContext, c: Colors): string {
-  const { input, git, transcript, tokenSpeed, gsd, config: { display }, cols } = ctx;
+  const { input, git, transcript, tokenSpeed, gsd, config: { display }, cols, icons } = ctx;
   const parts: string[] = [];
 
   // Directory
@@ -38,7 +37,7 @@ export function renderMinimal(ctx: RenderContext, c: Colors): string {
 
   // Context bar
   if (display.contextBar) {
-    parts.push(buildContextBar(input.context_window.used_percentage, c, { segments: 10, pctInsideBar: true }));
+    parts.push(buildContextBar(input.context_window.used_percentage, c, { segments: 10, pctInsideBar: true, iconSet: icons }));
   }
 
   // Only add these if cols >= 60
@@ -94,12 +93,12 @@ export function renderMinimal(ctx: RenderContext, c: Colors): string {
 
     // Worktree
     if (display.worktree && input.worktree?.name) {
-      parts.push(c.dim(`${ICONS.tree} ${truncField(input.worktree.name, 12)}`));
+      parts.push(c.dim(`${icons.tree} ${truncField(input.worktree.name, 12)}`));
     }
 
     // Agent
     if (display.agent && input.agent?.name) {
-      parts.push(c.dim(`${ICONS.cubes} ${truncField(input.agent.name, 12)}`));
+      parts.push(c.dim(`${icons.cubes} ${truncField(input.agent.name, 12)}`));
     }
   }
 

--- a/src/render/minimal.ts
+++ b/src/render/minimal.ts
@@ -5,18 +5,10 @@ import { getModelName, buildContextBar, formatGitChanges, SEP_MINIMAL } from './
 import type { Colors } from './colors.js';
 import { formatTokens, formatDuration, formatCost } from '../utils/format.js';
 import { renderLine3 } from './line3.js';
-import type { ClaudeCodeInput, GitStatus, TranscriptData, DisplayToggles, GsdInfo } from '../types.js';
+import type { RenderContext } from '../types.js';
 
-export function renderMinimal(
-  input: ClaudeCodeInput,
-  git: GitStatus,
-  transcript: TranscriptData,
-  tokenSpeed: number | null,
-  gsd: GsdInfo | null,
-  c: Colors,
-  display: DisplayToggles,
-  cols: number
-): string {
+export function renderMinimal(ctx: RenderContext, c: Colors): string {
+  const { input, git, transcript, tokenSpeed, gsd, config: { display }, cols } = ctx;
   const parts: string[] = [];
 
   // Directory
@@ -114,7 +106,7 @@ export function renderMinimal(
   const mainLine = parts.join(SEP_MINIMAL);
 
   // Append tools/todos as extra line
-  const l3 = renderLine3(transcript.tools, transcript.todos, c);
+  const l3 = renderLine3(ctx, c);
   if (l3) return mainLine + '\n' + l3;
   return mainLine;
 }

--- a/src/render/shared.ts
+++ b/src/render/shared.ts
@@ -1,0 +1,49 @@
+import { ICONS } from './icons.js';
+import { getContextColor, type Colors } from './colors.js';
+import type { ClaudeCodeInput, GitStatus } from '../types.js';
+
+export const SEP = ` \x1b[90m\u2502\x1b[0m `;
+export const SEP_MINIMAL = ` \x1b[90m|\x1b[0m `;
+
+export function getModelName(model: ClaudeCodeInput['model']): string {
+  if (typeof model === 'string') return model;
+  if (model && typeof model === 'object' && 'display_name' in model) return model.display_name;
+  return '';
+}
+
+export interface ContextBarOpts {
+  segments?: number;
+  icons?: boolean;
+  pctInsideBar?: boolean;
+}
+
+export function buildContextBar(pct: number, c: Colors, opts?: ContextBarOpts): string {
+  const segments = opts?.segments ?? 20;
+  const showIcons = opts?.icons ?? true;
+  const pctInsideBar = opts?.pctInsideBar ?? false;
+
+  const filled = Math.round((pct / 100) * segments);
+  const colorFn = c[getContextColor(pct)];
+  const bar = colorFn(ICONS.barFull.repeat(filled)) + c.dim(ICONS.barEmpty.repeat(segments - filled));
+
+  let icon = '';
+  if (showIcons) {
+    if (pct >= 80) icon = c.blinkRed(ICONS.skull);
+    else if (pct >= 65) icon = c.orange(ICONS.fire);
+  }
+
+  const pctStr = colorFn(`${pct < 10 ? pct.toFixed(1) : pct.toFixed(0)}%`);
+
+  if (pctInsideBar) {
+    return `[${bar} ${pctStr}${icon ? ' ' + icon : ''}]`;
+  }
+  return `[${bar}] ${pctStr}${icon ? ' ' + icon : ''}`;
+}
+
+export function formatGitChanges(git: GitStatus, c: Colors): string[] {
+  const parts: string[] = [];
+  if (git.staged > 0) parts.push(c.green(`+${git.staged}`));
+  if (git.modified > 0) parts.push(c.yellow(`!${git.modified}`));
+  if (git.untracked > 0) parts.push(c.gray(`?${git.untracked}`));
+  return parts;
+}

--- a/src/render/shared.ts
+++ b/src/render/shared.ts
@@ -1,4 +1,4 @@
-import { ICONS } from './icons.js';
+import { NERD_ICONS, type IconSet } from './icons.js';
 import { getContextColor, type Colors } from './colors.js';
 import type { ClaudeCodeInput, GitStatus } from '../types.js';
 
@@ -13,23 +13,25 @@ export function getModelName(model: ClaudeCodeInput['model']): string {
 
 export interface ContextBarOpts {
   segments?: number;
-  icons?: boolean;
+  showIcons?: boolean;
   pctInsideBar?: boolean;
+  iconSet?: IconSet;
 }
 
 export function buildContextBar(pct: number, c: Colors, opts?: ContextBarOpts): string {
   const segments = opts?.segments ?? 20;
-  const showIcons = opts?.icons ?? true;
+  const showIcons = opts?.showIcons ?? true;
   const pctInsideBar = opts?.pctInsideBar ?? false;
+  const ic = opts?.iconSet ?? NERD_ICONS;
 
   const filled = Math.round((pct / 100) * segments);
   const colorFn = c[getContextColor(pct)];
-  const bar = colorFn(ICONS.barFull.repeat(filled)) + c.dim(ICONS.barEmpty.repeat(segments - filled));
+  const bar = colorFn(ic.barFull.repeat(filled)) + c.dim(ic.barEmpty.repeat(segments - filled));
 
   let icon = '';
   if (showIcons) {
-    if (pct >= 80) icon = c.blinkRed(ICONS.skull);
-    else if (pct >= 65) icon = c.orange(ICONS.fire);
+    if (pct >= 80) icon = c.blinkRed(ic.skull);
+    else if (pct >= 65) icon = c.orange(ic.fire);
   }
 
   const pctStr = colorFn(`${pct < 10 ? pct.toFixed(1) : pct.toFixed(0)}%`);

--- a/src/render/shared.ts
+++ b/src/render/shared.ts
@@ -37,9 +37,9 @@ export function buildContextBar(pct: number, c: Colors, opts?: ContextBarOpts): 
   const pctStr = colorFn(`${pct < 10 ? pct.toFixed(1) : pct.toFixed(0)}%`);
 
   if (pctInsideBar) {
-    return `[${bar} ${pctStr}${icon ? ' ' + icon : ''}]`;
+    return `${bar} ${pctStr}${icon ? ' ' + icon : ''}`;
   }
-  return `[${bar}] ${pctStr}${icon ? ' ' + icon : ''}`;
+  return `${bar} ${pctStr}${icon ? ' ' + icon : ''}`;
 }
 
 export function formatGitChanges(git: GitStatus, c: Colors): string[] {

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -1,0 +1,85 @@
+import type { ColorMode } from './render/colors.js';
+
+/**
+ * A theme defines truecolor overrides for each named color.
+ * At runtime, if the user selects a theme AND their terminal supports
+ * truecolor/256, these values replace the defaults in createColors.
+ */
+export interface ThemePalette {
+  cyan: string;
+  magenta: string;
+  yellow: string;
+  green: string;
+  orange: string;
+  red: string;
+  brightBlue: string;
+  gray: string;
+}
+
+function rgb(r: number, g: number, b: number): string {
+  return `\x1b[38;2;${r};${g};${b}m`;
+}
+
+export const THEMES: Record<string, ThemePalette> = {
+  dracula: {
+    cyan: rgb(139, 233, 253),
+    magenta: rgb(255, 121, 198),
+    yellow: rgb(241, 250, 140),
+    green: rgb(80, 250, 123),
+    orange: rgb(255, 184, 108),
+    red: rgb(255, 85, 85),
+    brightBlue: rgb(189, 147, 249),
+    gray: rgb(98, 114, 164),
+  },
+  nord: {
+    cyan: rgb(136, 192, 208),
+    magenta: rgb(180, 142, 173),
+    yellow: rgb(235, 203, 139),
+    green: rgb(163, 190, 140),
+    orange: rgb(208, 135, 112),
+    red: rgb(191, 97, 106),
+    brightBlue: rgb(129, 161, 193),
+    gray: rgb(76, 86, 106),
+  },
+  'tokyo-night': {
+    cyan: rgb(125, 207, 255),
+    magenta: rgb(187, 154, 247),
+    yellow: rgb(224, 175, 104),
+    green: rgb(158, 206, 106),
+    orange: rgb(255, 158, 100),
+    red: rgb(247, 118, 142),
+    brightBlue: rgb(122, 162, 247),
+    gray: rgb(86, 95, 137),
+  },
+  catppuccin: {
+    cyan: rgb(137, 220, 235),
+    magenta: rgb(245, 194, 231),
+    yellow: rgb(249, 226, 175),
+    green: rgb(166, 227, 161),
+    orange: rgb(250, 179, 135),
+    red: rgb(243, 139, 168),
+    brightBlue: rgb(137, 180, 250),
+    gray: rgb(108, 112, 134),
+  },
+  monokai: {
+    cyan: rgb(102, 217, 239),
+    magenta: rgb(249, 38, 114),
+    yellow: rgb(230, 219, 116),
+    green: rgb(166, 226, 46),
+    orange: rgb(253, 151, 31),
+    red: rgb(249, 38, 114),
+    brightBlue: rgb(102, 217, 239),
+    gray: rgb(117, 113, 94),
+  },
+};
+
+export function getThemeNames(): string[] {
+  return Object.keys(THEMES);
+}
+
+export function resolveTheme(name: string | undefined, mode: ColorMode): ThemePalette | null {
+  if (!name) return null;
+  // Themes only apply in truecolor mode — they use RGB values
+  if (mode !== 'truecolor') return null;
+  return THEMES[name.toLowerCase()] ?? null;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,6 +122,7 @@ export interface RenderContext {
   gsd: GsdInfo | null;
   cols: number;
   config: HudConfig;
+  icons: import('./render/icons.js').IconSet;
 }
 
 // ── Config ──────────────────────────────────────────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,7 +127,7 @@ export interface RenderContext {
 // ── Config ──────────────────────────────────────────────────────────
 
 export interface HudConfig {
-  layout: 'custom' | 'minimal' | 'auto';
+  layout: 'full' | 'minimal' | 'auto';
   gsd: boolean;
   display: DisplayToggles;
   colors: ColorConfig;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export interface ClaudeCodeInput {
     remaining_percentage: number;
     total_input_tokens?: number;
     total_output_tokens?: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
     current_usage?: { output_tokens: number };
   };
   cost: {
@@ -111,6 +113,15 @@ export interface MemoryInfo {
   percentage: number;
 }
 
+export interface McpServerInfo {
+  name: string;
+  status: 'ok' | 'error' | 'unknown';
+}
+
+export interface McpInfo {
+  servers: McpServerInfo[];
+}
+
 // ── Render context ──────────────────────────────────────────────────
 
 export interface RenderContext {
@@ -120,6 +131,7 @@ export interface RenderContext {
   tokenSpeed: number | null;
   memory: MemoryInfo | null;
   gsd: GsdInfo | null;
+  mcp: McpInfo | null;
   cols: number;
   config: HudConfig;
   icons: import('./render/icons.js').IconSet;
@@ -172,6 +184,8 @@ export interface DisplayToggles {
   version: boolean;
   linesChanged: boolean;
   memory: boolean;
+  cacheMetrics: boolean;
+  mcp: boolean;
 }
 
 export interface ColorConfig {
@@ -202,6 +216,8 @@ export const DEFAULT_DISPLAY: DisplayToggles = {
   version: true,
   linesChanged: true,
   memory: true,
+  cacheMetrics: true,
+  mcp: true,
 };
 
 export const DEFAULT_CONFIG: HudConfig = {
@@ -220,6 +236,7 @@ export interface Dependencies {
   getTokenSpeed: (contextWindow: ClaudeCodeInput['context_window']) => number | null;
   getMemoryInfo: () => MemoryInfo | null;
   getGsdInfo: (session: string) => GsdInfo | null;
+  getMcpInfo: (cwd: string) => McpInfo | null;
   getTermCols: () => number;
   loadConfig?: () => HudConfig;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,6 +131,9 @@ export interface HudConfig {
   gsd: boolean;
   display: DisplayToggles;
   colors: ColorConfig;
+  preset?: 'full' | 'balanced' | 'minimal';
+  theme?: string;
+  icons?: 'nerd' | 'emoji' | 'none';
 }
 
 export interface DisplayToggles {
@@ -139,6 +142,7 @@ export interface DisplayToggles {
   gitChanges: boolean;
   directory: boolean;
   contextBar: boolean;
+  contextTokens: boolean;
   tokens: boolean;
   cost: boolean;
   burnRate: boolean;
@@ -168,6 +172,7 @@ export const DEFAULT_DISPLAY: DisplayToggles = {
   gitChanges: true,
   directory: true,
   contextBar: true,
+  contextTokens: true,
   tokens: true,
   cost: true,
   burnRate: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,4 +209,5 @@ export interface Dependencies {
   getMemoryInfo: () => MemoryInfo | null;
   getGsdInfo: (session: string) => GsdInfo | null;
   getTermCols: () => number;
+  loadConfig?: () => HudConfig;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,10 +127,21 @@ export interface RenderContext {
 // ── Config ──────────────────────────────────────────────────────────
 
 export interface HudConfig {
-  layout: 'full' | 'minimal' | 'auto';
+  /**
+   * Internal render mode — controls which renderer is used.
+   * Derived from `preset` via applyPreset(). Users should set `preset` instead.
+   *   multiline  → full multi-line renderer (line1+line2+line3+line4)
+   *   singleline → compact single-line renderer
+   *   auto       → pick based on terminal width (<70 cols → singleline)
+   */
+  layout: 'multiline' | 'singleline' | 'auto';
   gsd: boolean;
   display: DisplayToggles;
   colors: ColorConfig;
+  /**
+   * User-facing preset — drives layout + display toggles (Phase 3).
+   * CLI: --full | --balanced | --minimal | --preset=<value>
+   */
   preset?: 'full' | 'balanced' | 'minimal';
   theme?: string;
   icons?: 'nerd' | 'emoji' | 'none';

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -2,7 +2,7 @@ import { readFileSync, statSync, unlinkSync, openSync, writeSync, closeSync } fr
 import { join } from 'node:path';
 
 export function readTtlCache<T>(key: string, dir: string, ttlMs: number = 5000): T | null {
-  const filePath = join(dir, `ccpulse-${key}.json`);
+  const filePath = join(dir, `lumira-${key}.json`);
   try {
     const stat = statSync(filePath);
     if (Date.now() - stat.mtimeMs > ttlMs) return null;
@@ -11,7 +11,7 @@ export function readTtlCache<T>(key: string, dir: string, ttlMs: number = 5000):
 }
 
 export function writeTtlCache(key: string, data: unknown, dir: string): void {
-  const filePath = join(dir, `ccpulse-${key}.json`);
+  const filePath = join(dir, `lumira-${key}.json`);
   try {
     // Remove existing file first (prevents symlink following)
     try { unlinkSync(filePath); } catch {}

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,14 +1,18 @@
 import { readFileSync, statSync, unlinkSync, openSync, writeSync, closeSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 
+function cacheDirPath(dir: string): string {
+  return join(dir, `lumira-${process.getuid?.() ?? 'default'}`);
+}
+
 function ensureCacheDir(dir: string): string {
-  const cacheDir = join(dir, `lumira-${process.getuid?.() ?? 'default'}`);
+  const cacheDir = cacheDirPath(dir);
   mkdirSync(cacheDir, { recursive: true, mode: 0o700 });
   return cacheDir;
 }
 
 export function readTtlCache<T>(key: string, dir: string, ttlMs: number = 5000): T | null {
-  const cacheDir = ensureCacheDir(dir);
+  const cacheDir = cacheDirPath(dir);
   const filePath = join(cacheDir, `${key}.json`);
   try {
     const stat = statSync(filePath);

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,8 +1,15 @@
-import { readFileSync, statSync, unlinkSync, openSync, writeSync, closeSync } from 'node:fs';
+import { readFileSync, statSync, unlinkSync, openSync, writeSync, closeSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 
+function ensureCacheDir(dir: string): string {
+  const cacheDir = join(dir, `lumira-${process.getuid?.() ?? 'default'}`);
+  mkdirSync(cacheDir, { recursive: true, mode: 0o700 });
+  return cacheDir;
+}
+
 export function readTtlCache<T>(key: string, dir: string, ttlMs: number = 5000): T | null {
-  const filePath = join(dir, `lumira-${key}.json`);
+  const cacheDir = ensureCacheDir(dir);
+  const filePath = join(cacheDir, `${key}.json`);
   try {
     const stat = statSync(filePath);
     if (Date.now() - stat.mtimeMs > ttlMs) return null;
@@ -11,7 +18,8 @@ export function readTtlCache<T>(key: string, dir: string, ttlMs: number = 5000):
 }
 
 export function writeTtlCache(key: string, data: unknown, dir: string): void {
-  const filePath = join(dir, `lumira-${key}.json`);
+  const cacheDir = ensureCacheDir(dir);
+  const filePath = join(cacheDir, `${key}.json`);
   try {
     // Remove existing file first (prevents symlink following)
     try { unlinkSync(filePath); } catch {}

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -9,7 +9,7 @@ function getTermColsFromProcTree(): number {
       for (const fd of fds) {
         try {
           const link = readlinkSync(`/proc/${pid}/fd/${fd}`);
-          if (/^\/dev\/(pts\/\d+|tty\w*)$/.test(link)) {
+          if (/^\/dev\/(pts\/\d+|tty[a-zA-Z0-9]*)$/.test(link)) {
             const out = execSync(`stty size < ${link}`, { shell: '/bin/sh', timeout: 500, encoding: 'utf8' }).trim();
             const cols = parseInt(out.split(/\s+/)[1], 10);
             if (cols > 0) return cols;

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -9,9 +9,7 @@ function getTermColsFromProcTree(): number {
       for (const fd of fds) {
         try {
           const link = readlinkSync(`/proc/${pid}/fd/${fd}`);
-          if (link.startsWith('/dev/pts/') || link === '/dev/tty') {
-            // SECURITY NOTE: `link` comes from reading /proc/{pid}/fd symlinks (kernel-controlled),
-            // never from user input. Shell is required for the stdin redirect syntax `< /dev/pts/N`.
+          if (/^\/dev\/(pts\/\d+|tty\w*)$/.test(link)) {
             const out = execSync(`stty size < ${link}`, { shell: '/bin/sh', timeout: 500, encoding: 'utf8' }).trim();
             const cols = parseInt(out.split(/\s+/)[1], 10);
             if (cols > 0) return cols;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -51,10 +51,32 @@ describe('loadConfig', () => {
 });
 
 describe('mergeCliFlags', () => {
-  it('overrides layout to minimal', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--minimal']).layout).toBe('minimal'); });
+  it('--minimal sets preset and layout', () => {
+    const r = mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--minimal']);
+    expect(r.preset).toBe('minimal');
+    expect(r.layout).toBe('minimal');
+  });
+  it('--balanced sets preset and layout=auto', () => {
+    const r = mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--balanced']);
+    expect(r.preset).toBe('balanced');
+    expect(r.layout).toBe('auto');
+  });
+  it('--full sets preset and layout=full', () => {
+    const r = mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--full']);
+    expect(r.preset).toBe('full');
+    expect(r.layout).toBe('full');
+  });
   it('enables gsd', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--gsd']).gsd).toBe(true); });
   it('no flags = unchanged', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i'])).toEqual(DEFAULT_CONFIG); });
-  it('parses --preset=balanced', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--preset=balanced']).preset).toBe('balanced'); });
-  it('parses --preset=minimal', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--preset=minimal']).preset).toBe('minimal'); });
+  it('--preset=balanced drives layout', () => {
+    const r = mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--preset=balanced']);
+    expect(r.preset).toBe('balanced');
+    expect(r.layout).toBe('auto');
+  });
+  it('--preset=minimal drives layout', () => {
+    const r = mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--preset=minimal']);
+    expect(r.preset).toBe('minimal');
+    expect(r.layout).toBe('minimal');
+  });
   it('parses --icons=none', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--icons=none']).icons).toBe('none'); });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -20,10 +20,53 @@ describe('loadConfig', () => {
     expect(c.display.branch).toBe(true);
   });
 
-  it('parses preset from config', () => {
+  it('preset balanced disables burnRate, duration, etc.', () => {
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, 'config.json'), '{"preset":"balanced"}');
-    expect(loadConfig(dir).preset).toBe('balanced');
+    const c = loadConfig(dir);
+    expect(c.preset).toBe('balanced');
+    expect(c.layout).toBe('auto');
+    expect(c.display.burnRate).toBe(false);
+    expect(c.display.duration).toBe(false);
+    expect(c.display.version).toBe(false);
+    // core toggles stay on
+    expect(c.display.model).toBe(true);
+    expect(c.display.cost).toBe(true);
+    expect(c.display.contextBar).toBe(true);
+  });
+
+  it('preset minimal disables most toggles', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"preset":"minimal"}');
+    const c = loadConfig(dir);
+    expect(c.preset).toBe('minimal');
+    expect(c.layout).toBe('singleline');
+    expect(c.display.tokens).toBe(false);
+    expect(c.display.tools).toBe(false);
+    expect(c.display.todos).toBe(false);
+    // essentials stay on
+    expect(c.display.model).toBe(true);
+    expect(c.display.branch).toBe(true);
+    expect(c.display.cost).toBe(true);
+  });
+
+  it('user display overrides win over preset', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"preset":"minimal","display":{"tokens":true}}');
+    const c = loadConfig(dir);
+    expect(c.preset).toBe('minimal');
+    // preset says false, user says true → user wins
+    expect(c.display.tokens).toBe(true);
+  });
+
+  it('preset full keeps all toggles on', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"preset":"full"}');
+    const c = loadConfig(dir);
+    expect(c.preset).toBe('full');
+    expect(c.layout).toBe('multiline');
+    expect(c.display.burnRate).toBe(true);
+    expect(c.display.version).toBe(true);
   });
   it('ignores invalid preset', () => {
     mkdirSync(dir, { recursive: true });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -13,9 +13,9 @@ describe('loadConfig', () => {
   it('returns defaults when no config', () => { expect(loadConfig(join(dir, 'nope'))).toEqual(DEFAULT_CONFIG); });
   it('merges partial config', () => {
     mkdirSync(dir, { recursive: true });
-    writeFileSync(join(dir, 'config.json'), '{"layout":"minimal","display":{"model":false}}');
+    writeFileSync(join(dir, 'config.json'), '{"layout":"singleline","display":{"model":false}}');
     const c = loadConfig(dir);
-    expect(c.layout).toBe('minimal');
+    expect(c.layout).toBe('singleline');
     expect(c.display.model).toBe(false);
     expect(c.display.branch).toBe(true);
   });
@@ -54,17 +54,17 @@ describe('mergeCliFlags', () => {
   it('--minimal sets preset and layout', () => {
     const r = mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--minimal']);
     expect(r.preset).toBe('minimal');
-    expect(r.layout).toBe('minimal');
+    expect(r.layout).toBe('singleline');
   });
   it('--balanced sets preset and layout=auto', () => {
     const r = mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--balanced']);
     expect(r.preset).toBe('balanced');
     expect(r.layout).toBe('auto');
   });
-  it('--full sets preset and layout=full', () => {
+  it('--full sets preset and layout=multiline', () => {
     const r = mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--full']);
     expect(r.preset).toBe('full');
-    expect(r.layout).toBe('full');
+    expect(r.layout).toBe('multiline');
   });
   it('enables gsd', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--gsd']).gsd).toBe(true); });
   it('no flags = unchanged', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i'])).toEqual(DEFAULT_CONFIG); });
@@ -76,7 +76,7 @@ describe('mergeCliFlags', () => {
   it('--preset=minimal drives layout', () => {
     const r = mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--preset=minimal']);
     expect(r.preset).toBe('minimal');
-    expect(r.layout).toBe('minimal');
+    expect(r.layout).toBe('singleline');
   });
   it('parses --icons=none', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--icons=none']).icons).toBe('none'); });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -19,10 +19,42 @@ describe('loadConfig', () => {
     expect(c.display.model).toBe(false);
     expect(c.display.branch).toBe(true);
   });
+
+  it('parses preset from config', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"preset":"balanced"}');
+    expect(loadConfig(dir).preset).toBe('balanced');
+  });
+  it('ignores invalid preset', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"preset":"fancy"}');
+    expect(loadConfig(dir).preset).toBeUndefined();
+  });
+  it('parses theme string', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"theme":"catppuccin"}');
+    expect(loadConfig(dir).theme).toBe('catppuccin');
+  });
+  it('parses valid icons value', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"icons":"emoji"}');
+    expect(loadConfig(dir).icons).toBe('emoji');
+  });
+  it('ignores invalid icons value', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"icons":"sparkles"}');
+    expect(loadConfig(dir).icons).toBeUndefined();
+  });
+  it('includes contextTokens in display defaults', () => {
+    expect(loadConfig(join(dir, 'nope')).display.contextTokens).toBe(true);
+  });
 });
 
 describe('mergeCliFlags', () => {
   it('overrides layout to minimal', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--minimal']).layout).toBe('minimal'); });
   it('enables gsd', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--gsd']).gsd).toBe(true); });
   it('no flags = unchanged', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i'])).toEqual(DEFAULT_CONFIG); });
+  it('parses --preset=balanced', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--preset=balanced']).preset).toBe('balanced'); });
+  it('parses --preset=minimal', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--preset=minimal']).preset).toBe('minimal'); });
+  it('parses --icons=none', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--icons=none']).icons).toBe('none'); });
 });

--- a/tests/fixtures/transcript-effort.jsonl
+++ b/tests/fixtures/transcript-effort.jsonl
@@ -1,0 +1,3 @@
+{"timestamp":"2026-04-08T10:00:00Z","message":{"content":[{"type":"text","text":"Set model to claude-opus-4-6 with high effort"}]}}
+{"timestamp":"2026-04-08T10:00:05Z","message":{"content":[{"type":"tool_use","id":"tu1","name":"Read","input":{"file_path":"/src/index.ts"}}]}}
+{"timestamp":"2026-04-08T10:00:06Z","message":{"content":[{"type":"tool_result","tool_use_id":"tu1","content":"file contents"}]}}

--- a/tests/fixtures/transcript-todowrite.jsonl
+++ b/tests/fixtures/transcript-todowrite.jsonl
@@ -1,0 +1,4 @@
+{"timestamp":"2026-04-08T10:00:00Z","message":{"content":[{"type":"tool_use","id":"tu1","name":"TodoWrite","input":{"todos":[{"id":"a","content":"Task A","status":"pending"},{"id":"b","content":"Task B","status":"in_progress"}]}}]}}
+{"timestamp":"2026-04-08T10:00:01Z","message":{"content":[{"type":"tool_result","tool_use_id":"tu1","content":"ok"}]}}
+{"timestamp":"2026-04-08T10:00:02Z","message":{"content":[{"type":"tool_use","id":"tu2","name":"TodoWrite","input":{"todos":[{"id":"a","content":"Task A","status":"completed"},{"id":"b","content":"Task B","status":"in_progress"},{"id":"c","content":"Task C","status":"pending"}]}}]}}
+{"timestamp":"2026-04-08T10:00:03Z","message":{"content":[{"type":"tool_result","tool_use_id":"tu2","content":"ok"}]}}

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { install } from '../src/installer.js';
+
+describe('install', () => {
+  let dir: string;
+  let settingsPath: string;
+  let backupPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'lumira-test-'));
+    settingsPath = join(dir, 'settings.json');
+    backupPath = join(dir, 'settings.json.lumira.bak');
+  });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('creates settings file when none exists', async () => {
+    const output = await install({ settingsPath, confirm: async () => true });
+    expect(existsSync(settingsPath)).toBe(true);
+    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    expect(data.statusLine.command).toBe('npx lumira@latest');
+    expect(output).toContain('Configured');
+  });
+
+  it('adds statusLine when settings exists without one', async () => {
+    writeFileSync(settingsPath, JSON.stringify({ hooks: {} }, null, 2));
+    const output = await install({ settingsPath, confirm: async () => true });
+    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    expect(data.statusLine.command).toBe('npx lumira@latest');
+    expect(data.hooks).toEqual({});
+    expect(existsSync(backupPath)).toBe(false);
+  });
+
+  it('backs up and replaces existing statusLine after confirmation', async () => {
+    const original = { statusLine: { type: 'command', command: 'other-tool', padding: 0 } };
+    writeFileSync(settingsPath, JSON.stringify(original, null, 2));
+    const output = await install({ settingsPath, confirm: async () => true });
+    expect(existsSync(backupPath)).toBe(true);
+    const backup = JSON.parse(readFileSync(backupPath, 'utf8'));
+    expect(backup.statusLine.command).toBe('other-tool');
+    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    expect(data.statusLine.command).toBe('npx lumira@latest');
+    expect(output).toContain('Backed up');
+  });
+
+  it('skips when already configured with lumira', async () => {
+    const existing = { statusLine: { type: 'command', command: 'npx lumira@latest', padding: 0 } };
+    writeFileSync(settingsPath, JSON.stringify(existing, null, 2));
+    const output = await install({ settingsPath, confirm: async () => true });
+    expect(output).toContain('already configured');
+    expect(existsSync(backupPath)).toBe(false);
+  });
+
+  it('aborts when user declines replacement', async () => {
+    const original = { statusLine: { type: 'command', command: 'other-tool', padding: 0 } };
+    writeFileSync(settingsPath, JSON.stringify(original, null, 2));
+    const output = await install({ settingsPath, confirm: async () => false });
+    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    expect(data.statusLine.command).toBe('other-tool');
+    expect(output).toContain('Aborted');
+  });
+
+  it('recovers from malformed settings.json and creates fresh settings', async () => {
+    writeFileSync(settingsPath, 'this is { not valid JSON!!');
+    const output = await install({ settingsPath, confirm: async () => true });
+    expect(output).toContain('Could not parse');
+    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    expect(data.statusLine.command).toBe('npx lumira@latest');
+    expect(output).toContain('Configured');
+  });
+
+  it('creates parent directory when it does not exist', async () => {
+    const nestedSettingsPath = join(dir, 'nested', 'deep', 'settings.json');
+    const output = await install({ settingsPath: nestedSettingsPath, confirm: async () => true });
+    expect(existsSync(nestedSettingsPath)).toBe(true);
+    const data = JSON.parse(readFileSync(nestedSettingsPath, 'utf8'));
+    expect(data.statusLine.command).toBe('npx lumira@latest');
+    expect(output).toContain('Configured');
+  });
+});

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -119,4 +119,16 @@ describe('uninstall', () => {
     const output = uninstall({ settingsPath });
     expect(output).toContain('Nothing to uninstall');
   });
+
+  it('warns and skips restore when backup is corrupt', () => {
+    const current = { statusLine: { type: 'command', command: 'npx lumira@latest', padding: 0 } };
+    writeFileSync(settingsPath, JSON.stringify(current, null, 2));
+    writeFileSync(backupPath, 'this is not valid JSON!!!');
+    const output = uninstall({ settingsPath });
+    expect(output).toContain('corrupt');
+    expect(existsSync(backupPath)).toBe(false);
+    // Should fall through to removing statusLine key
+    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    expect(data.statusLine).toBeUndefined();
+  });
 });

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { install } from '../src/installer.js';
+import { install, uninstall } from '../src/installer.js';
 
 describe('install', () => {
   let dir: string;
@@ -78,5 +78,45 @@ describe('install', () => {
     const data = JSON.parse(readFileSync(nestedSettingsPath, 'utf8'));
     expect(data.statusLine.command).toBe('npx lumira@latest');
     expect(output).toContain('Configured');
+  });
+});
+
+describe('uninstall', () => {
+  let dir: string;
+  let settingsPath: string;
+  let backupPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'lumira-test-'));
+    settingsPath = join(dir, 'settings.json');
+    backupPath = join(dir, 'settings.json.lumira.bak');
+  });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('restores from backup when backup exists', () => {
+    const backup = { statusLine: { type: 'command', command: 'old-tool', padding: 0 }, hooks: {} };
+    const current = { statusLine: { type: 'command', command: 'npx lumira@latest', padding: 0 }, hooks: {} };
+    writeFileSync(backupPath, JSON.stringify(backup, null, 2));
+    writeFileSync(settingsPath, JSON.stringify(current, null, 2));
+    const output = uninstall({ settingsPath });
+    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    expect(data.statusLine.command).toBe('old-tool');
+    expect(existsSync(backupPath)).toBe(false);
+    expect(output).toContain('Restored');
+  });
+
+  it('removes statusLine key when no backup exists', () => {
+    const current = { statusLine: { type: 'command', command: 'npx lumira@latest', padding: 0 }, hooks: {} };
+    writeFileSync(settingsPath, JSON.stringify(current, null, 2));
+    const output = uninstall({ settingsPath });
+    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    expect(data.statusLine).toBeUndefined();
+    expect(data.hooks).toEqual({});
+    expect(output).toContain('Removed');
+  });
+
+  it('prints message when no settings file exists', () => {
+    const output = uninstall({ settingsPath });
+    expect(output).toContain('Nothing to uninstall');
   });
 });

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -41,4 +41,53 @@ describe('main', () => {
     // Minimal layout produces at most 2 lines (main + optional tools/todos)
     expect(output.split('\n').length).toBeLessThanOrEqual(2);
   });
+
+  it('includes GSD info when enabled', async () => {
+    const sample = JSON.parse(readFileSync(join(import.meta.dirname, 'fixtures', 'sample-input.json'), 'utf8'));
+    const output = await main({
+      readStdin: async () => sample,
+      parseGit: async () => ({ branch: 'main', staged: 0, modified: 0, untracked: 0 }),
+      parseTranscript: async () => EMPTY_TRANSCRIPT,
+      getTokenSpeed: () => null,
+      getMemoryInfo: () => null,
+      getGsdInfo: () => ({ currentTask: 'Building feature', updateAvailable: false }),
+      getMcpInfo: () => null,
+      getTermCols: () => 120,
+      loadConfig: () => ({ ...DEFAULT_CONFIG, gsd: true, display: { ...DEFAULT_DISPLAY } }),
+    });
+    const plain = stripAnsi(output);
+    expect(plain).toContain('Building feature');
+  });
+
+  it('auto-switches to minimal at narrow cols', async () => {
+    const sample = JSON.parse(readFileSync(join(import.meta.dirname, 'fixtures', 'sample-input.json'), 'utf8'));
+    const output = await main({
+      readStdin: async () => sample,
+      parseGit: async () => ({ branch: 'main', staged: 0, modified: 0, untracked: 0 }),
+      parseTranscript: async () => EMPTY_TRANSCRIPT,
+      getTokenSpeed: () => null,
+      getMemoryInfo: () => null,
+      getGsdInfo: () => null,
+      getMcpInfo: () => null,
+      getTermCols: () => 60,
+    });
+    // auto layout at <70 cols should produce at most 2 lines
+    expect(output.split('\n').length).toBeLessThanOrEqual(2);
+  });
+
+  it('falls back to workspace dir when cwd is missing', async () => {
+    const sample = JSON.parse(readFileSync(join(import.meta.dirname, 'fixtures', 'sample-input.json'), 'utf8'));
+    delete sample.cwd;
+    const output = await main({
+      readStdin: async () => sample,
+      parseGit: async () => ({ branch: 'main', staged: 0, modified: 0, untracked: 0 }),
+      parseTranscript: async () => EMPTY_TRANSCRIPT,
+      getTokenSpeed: () => null,
+      getMemoryInfo: () => null,
+      getGsdInfo: () => null,
+      getMcpInfo: () => null,
+      getTermCols: () => 120,
+    });
+    expect(output.length).toBeGreaterThan(0);
+  });
 });

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { main } from '../src/index.js';
-import { EMPTY_TRANSCRIPT } from '../src/types.js';
+import { EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '../src/types.js';
 import { stripAnsi } from '../src/render/colors.js';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -22,5 +22,21 @@ describe('main', () => {
     expect(plain).toContain('main');
     expect(plain).toContain('$1.31');
     expect(output.split('\n').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('uses injected loadConfig for minimal layout', async () => {
+    const sample = JSON.parse(readFileSync(join(import.meta.dirname, 'fixtures', 'sample-input.json'), 'utf8'));
+    const output = await main({
+      readStdin: async () => sample,
+      parseGit: async () => ({ branch: 'main', staged: 0, modified: 0, untracked: 0 }),
+      parseTranscript: async () => EMPTY_TRANSCRIPT,
+      getTokenSpeed: () => null,
+      getMemoryInfo: () => null,
+      getGsdInfo: () => null,
+      getTermCols: () => 120,
+      loadConfig: () => ({ ...DEFAULT_CONFIG, layout: 'minimal', display: { ...DEFAULT_DISPLAY } }),
+    });
+    // Minimal layout produces at most 2 lines (main + optional tools/todos)
+    expect(output.split('\n').length).toBeLessThanOrEqual(2);
   });
 });

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -34,7 +34,7 @@ describe('main', () => {
       getMemoryInfo: () => null,
       getGsdInfo: () => null,
       getTermCols: () => 120,
-      loadConfig: () => ({ ...DEFAULT_CONFIG, layout: 'minimal', display: { ...DEFAULT_DISPLAY } }),
+      loadConfig: () => ({ ...DEFAULT_CONFIG, layout: 'singleline', display: { ...DEFAULT_DISPLAY } }),
     });
     // Minimal layout produces at most 2 lines (main + optional tools/todos)
     expect(output.split('\n').length).toBeLessThanOrEqual(2);

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -15,6 +15,7 @@ describe('main', () => {
       getTokenSpeed: () => 142,
       getMemoryInfo: () => ({ usedBytes: 8e9, totalBytes: 16e9, percentage: 50 }),
       getGsdInfo: () => null,
+      getMcpInfo: () => null,
       getTermCols: () => 120,
     });
     const plain = stripAnsi(output);
@@ -33,6 +34,7 @@ describe('main', () => {
       getTokenSpeed: () => null,
       getMemoryInfo: () => null,
       getGsdInfo: () => null,
+      getMcpInfo: () => null,
       getTermCols: () => 120,
       loadConfig: () => ({ ...DEFAULT_CONFIG, layout: 'singleline', display: { ...DEFAULT_DISPLAY } }),
     });

--- a/tests/parsers/git.test.ts
+++ b/tests/parsers/git.test.ts
@@ -9,8 +9,18 @@ describe('parseGitStatus', () => {
       .mockResolvedValueOnce('M  file.ts\n?? new.ts\nA  added.ts');
     const result = await parseGitStatus('/test', exec);
     expect(result.branch).toBe('main');
-    expect(result.staged).toBe(1);
-    expect(result.modified).toBe(1);
+    expect(result.staged).toBe(2);   // M + A in col 0
+    expect(result.modified).toBe(0); // no worktree changes (col 1)
+    expect(result.untracked).toBe(1);
+  });
+
+  it('counts MM as both staged and modified', async () => {
+    const exec = vi.fn()
+      .mockResolvedValueOnce('dev')
+      .mockResolvedValueOnce('MM file.ts\nA  added.ts\n M only-worktree.ts\nD  deleted.ts\n?? new.ts');
+    const result = await parseGitStatus('/test2', exec);
+    expect(result.staged).toBe(3);    // MM, A, D in col 0
+    expect(result.modified).toBe(2);  // MM (col1=M), ' M' (col1=M)
     expect(result.untracked).toBe(1);
   });
   it('returns empty on git failure', async () => {

--- a/tests/parsers/gsd.test.ts
+++ b/tests/parsers/gsd.test.ts
@@ -18,4 +18,24 @@ describe('getGsdInfo', () => {
     writeFileSync(join(dir, 'todos', 's-agent-1.json'), JSON.stringify([{ status: 'in_progress', activeForm: 'Building X' }]));
     expect(getGsdInfo('s', dir)?.currentTask).toBe('Building X');
   });
+
+  it('sanitizes session ID with special characters', () => {
+    writeFileSync(join(dir, 'todos', 'abc-agent-1.json'), JSON.stringify([{ status: 'in_progress', activeForm: 'Task' }]));
+    // ../evil gets sanitized to empty or safe string — should not match
+    expect(getGsdInfo('../evil', dir)).toBeNull();
+  });
+
+  it('sanitizes session ID with slashes', () => {
+    expect(getGsdInfo('../../etc/passwd', dir)).toBeNull();
+  });
+
+  it('handles malformed JSON in cache file', () => {
+    writeFileSync(join(dir, 'cache', 'gsd-update-check.json'), 'not json');
+    expect(getGsdInfo('s', dir)).toBeNull();
+  });
+
+  it('handles malformed JSON in todos file', () => {
+    writeFileSync(join(dir, 'todos', 's-agent-1.json'), 'broken json');
+    expect(getGsdInfo('s', dir)).toBeNull();
+  });
 });

--- a/tests/parsers/mcp.test.ts
+++ b/tests/parsers/mcp.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getMcpInfo } from '../../src/parsers/mcp.js';
+import * as fs from 'node:fs';
+
+vi.mock('node:fs');
+
+const mockedExistsSync = vi.mocked(fs.existsSync);
+const mockedReadFileSync = vi.mocked(fs.readFileSync);
+
+beforeEach(() => { vi.resetAllMocks(); });
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe('getMcpInfo', () => {
+  it('returns null when no .mcp.json files exist', () => {
+    mockedExistsSync.mockReturnValue(false);
+    expect(getMcpInfo('/project')).toBeNull();
+  });
+
+  it('reads servers from cwd .mcp.json', () => {
+    mockedExistsSync.mockImplementation((p) => String(p).includes('/project/'));
+    mockedReadFileSync.mockReturnValue(JSON.stringify({
+      mcpServers: { 'my-server': { command: 'node', args: ['server.js'] } },
+    }));
+    const result = getMcpInfo('/project');
+    expect(result).not.toBeNull();
+    expect(result!.servers).toHaveLength(1);
+    expect(result!.servers[0].name).toBe('my-server');
+    expect(result!.servers[0].status).toBe('ok');
+  });
+
+  it('deduplicates servers across files', () => {
+    mockedExistsSync.mockReturnValue(true);
+    mockedReadFileSync.mockReturnValue(JSON.stringify({
+      mcpServers: { 'shared-server': { command: 'node' } },
+    }));
+    const result = getMcpInfo('/project');
+    expect(result!.servers).toHaveLength(1);
+  });
+
+  it('handles malformed JSON gracefully', () => {
+    mockedExistsSync.mockReturnValue(true);
+    mockedReadFileSync.mockReturnValue('not valid json');
+    expect(getMcpInfo('/project')).toBeNull();
+  });
+
+  it('handles missing mcpServers key', () => {
+    mockedExistsSync.mockImplementation((p) => String(p).includes('/project/'));
+    mockedReadFileSync.mockReturnValue(JSON.stringify({ other: 'data' }));
+    expect(getMcpInfo('/project')).toBeNull();
+  });
+});

--- a/tests/parsers/token-speed.test.ts
+++ b/tests/parsers/token-speed.test.ts
@@ -22,4 +22,20 @@ describe('getTokenSpeed', () => {
     const speed = getTokenSpeed(ctx2, dir);
     if (speed !== null) expect(speed).toBeGreaterThan(0);
   });
+
+  it('returns null for NaN output_tokens', () => {
+    expect(getTokenSpeed({ used_percentage: 50, remaining_percentage: 50, current_usage: { output_tokens: NaN } }, dir)).toBeNull();
+  });
+
+  it('returns null for Infinity output_tokens', () => {
+    expect(getTokenSpeed({ used_percentage: 50, remaining_percentage: 50, current_usage: { output_tokens: Infinity } }, dir)).toBeNull();
+  });
+
+  it('returns null when tokens decrease (session reset)', () => {
+    const ctx1 = { used_percentage: 50, remaining_percentage: 50, current_usage: { output_tokens: 5000 } };
+    const ctx2 = { used_percentage: 50, remaining_percentage: 50, current_usage: { output_tokens: 1000 } };
+    getTokenSpeed(ctx1, dir);
+    // Tokens went backward — should return null, not negative speed
+    expect(getTokenSpeed(ctx2, dir)).toBeNull();
+  });
 });

--- a/tests/parsers/token-speed.test.ts
+++ b/tests/parsers/token-speed.test.ts
@@ -6,7 +6,7 @@ import { getTokenSpeed } from '../../src/parsers/token-speed.js';
 
 describe('getTokenSpeed', () => {
   let dir: string;
-  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'ccpulse-speed-')); });
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'lumira-speed-')); });
   afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
 
   it('returns null on first call', () => {

--- a/tests/parsers/transcript.test.ts
+++ b/tests/parsers/transcript.test.ts
@@ -33,6 +33,28 @@ describe('parseTranscript', () => {
   it('rejects paths outside allowed directories', async () => {
     expect((await parseTranscript('/etc/passwd')).tools).toHaveLength(0);
   });
+
+  it('extracts thinkingEffort from transcript', async () => {
+    const result = await parseTranscript(join(FIXTURES, 'transcript-effort.jsonl'));
+    expect(result.thinkingEffort).toBe('high');
+  });
+
+  it('sets sessionStart from first timestamp', async () => {
+    const result = await parseTranscript(join(FIXTURES, 'transcript-basic.jsonl'));
+    expect(result.sessionStart).toBeInstanceOf(Date);
+    expect(result.sessionStart!.toISOString()).toBe('2026-04-08T10:00:00.000Z');
+  });
+
+  it('handles TodoWrite with merge semantics', async () => {
+    const result = await parseTranscript(join(FIXTURES, 'transcript-todowrite.jsonl'));
+    expect(result.todos).toHaveLength(3);
+    expect(result.todos[0].id).toBe('a');
+    expect(result.todos[0].status).toBe('completed');
+    expect(result.todos[1].id).toBe('b');
+    expect(result.todos[1].status).toBe('in_progress');
+    expect(result.todos[2].id).toBe('c');
+    expect(result.todos[2].status).toBe('pending');
+  });
 });
 
 describe('extractToolTarget', () => {

--- a/tests/render/colors.test.ts
+++ b/tests/render/colors.test.ts
@@ -11,7 +11,40 @@ describe('stripAnsi', () => {
 });
 
 describe('detectColorMode', () => {
-  it('always returns named by default (respects terminal theme)', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('returns truecolor when COLORTERM=truecolor', () => {
+    vi.stubEnv('COLORTERM', 'truecolor');
+    vi.stubEnv('TERM', '');
+    vi.stubEnv('TERM_PROGRAM', '');
+    expect(detectColorMode()).toBe('truecolor');
+  });
+
+  it('returns truecolor when COLORTERM=24bit', () => {
+    vi.stubEnv('COLORTERM', '24bit');
+    vi.stubEnv('TERM', '');
+    vi.stubEnv('TERM_PROGRAM', '');
+    expect(detectColorMode()).toBe('truecolor');
+  });
+
+  it('returns 256 when TERM ends with -256color', () => {
+    vi.stubEnv('COLORTERM', '');
+    vi.stubEnv('TERM', 'xterm-256color');
+    vi.stubEnv('TERM_PROGRAM', '');
+    expect(detectColorMode()).toBe('256');
+  });
+
+  it('returns 256 for iTerm.app', () => {
+    vi.stubEnv('COLORTERM', '');
+    vi.stubEnv('TERM', 'xterm');
+    vi.stubEnv('TERM_PROGRAM', 'iTerm.app');
+    expect(detectColorMode()).toBe('256');
+  });
+
+  it('returns named as fallback', () => {
+    vi.stubEnv('COLORTERM', '');
+    vi.stubEnv('TERM', 'xterm');
+    vi.stubEnv('TERM_PROGRAM', '');
     expect(detectColorMode()).toBe('named');
   });
 });

--- a/tests/render/icons.test.ts
+++ b/tests/render/icons.test.ts
@@ -1,23 +1,62 @@
 import { describe, it, expect } from 'vitest';
-import { ICONS } from '../../src/render/icons.js';
+import { ICONS, NERD_ICONS, EMOJI_ICONS, NO_ICONS, resolveIcons } from '../../src/render/icons.js';
 
-describe('ICONS', () => {
-  it('exports all required icon codepoints', () => {
-    expect(ICONS.model).toBe('\uEE0D');
-    expect(ICONS.branch).toBe('\uE725');
-    expect(ICONS.folder).toBe('\uF07C');
-    expect(ICONS.fire).toBe('\uF06D');
-    expect(ICONS.skull).toBe('\uEE15');
-    expect(ICONS.comment).toBe('\uF075');
-    expect(ICONS.clock).toBe('\uF017');
-    expect(ICONS.bolt).toBe('\uF0E7');
-    expect(ICONS.tree).toBe('\uF1BB');
-    expect(ICONS.cubes).toBe('\uF1B3');
-    expect(ICONS.hammer).toBe('\uEEFF');
-    expect(ICONS.warning).toBe('\uF071');
-    expect(ICONS.barFull).toBe('\u2588');
-    expect(ICONS.barEmpty).toBe('\u2591');
-    expect(ICONS.ellipsis).toBe('\u2026');
-    expect(ICONS.dash).toBe('\u2014');
+describe('ICONS (legacy export)', () => {
+  it('is the same as NERD_ICONS', () => {
+    expect(ICONS).toBe(NERD_ICONS);
+  });
+});
+
+describe('NERD_ICONS', () => {
+  it('uses nerd font codepoints', () => {
+    expect(NERD_ICONS.model).toBe('\uEE0D');
+    expect(NERD_ICONS.branch).toBe('\uE725');
+    expect(NERD_ICONS.folder).toBe('\uF07C');
+    expect(NERD_ICONS.fire).toBe('\uF06D');
+    expect(NERD_ICONS.skull).toBe('\uEE15');
+  });
+});
+
+describe('EMOJI_ICONS', () => {
+  it('uses emoji codepoints', () => {
+    expect(EMOJI_ICONS.model).toBe('\u{1F916}');
+    expect(EMOJI_ICONS.branch).toBe('\u{1F33F}');
+    expect(EMOJI_ICONS.folder).toBe('\u{1F4C2}');
+    expect(EMOJI_ICONS.fire).toBe('\u{1F525}');
+    expect(EMOJI_ICONS.skull).toBe('\u{1F480}');
+  });
+});
+
+describe('NO_ICONS', () => {
+  it('uses empty strings for decorative icons', () => {
+    expect(NO_ICONS.model).toBe('');
+    expect(NO_ICONS.branch).toBe('');
+    expect(NO_ICONS.folder).toBe('');
+    expect(NO_ICONS.clock).toBe('');
+  });
+
+  it('uses ASCII fallbacks for semantic icons', () => {
+    expect(NO_ICONS.fire).toBe('!');
+    expect(NO_ICONS.skull).toBe('!!');
+    expect(NO_ICONS.warning).toBe('!');
+  });
+});
+
+describe('resolveIcons', () => {
+  it('returns NERD_ICONS by default', () => {
+    expect(resolveIcons()).toBe(NERD_ICONS);
+    expect(resolveIcons(undefined)).toBe(NERD_ICONS);
+  });
+
+  it('returns NERD_ICONS for "nerd"', () => {
+    expect(resolveIcons('nerd')).toBe(NERD_ICONS);
+  });
+
+  it('returns EMOJI_ICONS for "emoji"', () => {
+    expect(resolveIcons('emoji')).toBe(EMOJI_ICONS);
+  });
+
+  it('returns NO_ICONS for "none"', () => {
+    expect(resolveIcons('none')).toBe(NO_ICONS);
   });
 });

--- a/tests/render/index.test.ts
+++ b/tests/render/index.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '../../src/render/index.js';
 import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, type RenderContext } from '../../src/types.js';
+import { NERD_ICONS } from '../../src/render/icons.js';
 
 function makeCtx(ov: Partial<RenderContext> = {}): RenderContext {
-  return { input: { model: 'Opus', session_id: 't', context_window: { used_percentage: 50, remaining_percentage: 50 }, cost: { total_cost_usd: 1, total_duration_ms: 60000 }, workspace: { current_dir: '/p' } } as never, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT, tokenSpeed: null, memory: null, gsd: null, cols: 120, config: { ...DEFAULT_CONFIG }, ...ov };
+  return { input: { model: 'Opus', session_id: 't', context_window: { used_percentage: 50, remaining_percentage: 50 }, cost: { total_cost_usd: 1, total_duration_ms: 60000 }, workspace: { current_dir: '/p' } } as never, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT, tokenSpeed: null, memory: null, gsd: null, cols: 120, config: { ...DEFAULT_CONFIG }, icons: NERD_ICONS, ...ov };
 }
 
 describe('render', () => {

--- a/tests/render/index.test.ts
+++ b/tests/render/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '../../src/render/index.js';
 import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, type RenderContext } from '../../src/types.js';
-import { NERD_ICONS } from '../../src/render/icons.js';
+import { NERD_ICONS, EMOJI_ICONS } from '../../src/render/icons.js';
 
 function makeCtx(ov: Partial<RenderContext> = {}): RenderContext {
   return { input: { model: 'Opus', session_id: 't', context_window: { used_percentage: 50, remaining_percentage: 50 }, cost: { total_cost_usd: 1, total_duration_ms: 60000 }, workspace: { current_dir: '/p' } } as never, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT, tokenSpeed: null, memory: null, gsd: null, mcp: null, cols: 120, config: { ...DEFAULT_CONFIG }, icons: NERD_ICONS, ...ov };
@@ -11,4 +11,12 @@ describe('render', () => {
   it('multi-line at 120 cols', () => { expect(render(makeCtx()).split('\n').length).toBeGreaterThanOrEqual(2); });
   it('singleline when forced', () => { expect(render(makeCtx({ config: { ...DEFAULT_CONFIG, layout: 'singleline' } })).split('\n').length).toBeLessThanOrEqual(2); });
   it('auto-minimal at <70 cols', () => { expect(render(makeCtx({ cols: 60 })).split('\n').length).toBeLessThanOrEqual(2); });
+  it('renders with theme config without crashing', () => {
+    const out = render(makeCtx({ config: { ...DEFAULT_CONFIG, theme: 'dracula', colors: { mode: 'truecolor' } } }));
+    expect(out.length).toBeGreaterThan(0);
+  });
+  it('renders with emoji icons without crashing', () => {
+    const out = render(makeCtx({ icons: EMOJI_ICONS }));
+    expect(out.length).toBeGreaterThan(0);
+  });
 });

--- a/tests/render/index.test.ts
+++ b/tests/render/index.test.ts
@@ -4,7 +4,7 @@ import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, type RenderContext } from 
 import { NERD_ICONS } from '../../src/render/icons.js';
 
 function makeCtx(ov: Partial<RenderContext> = {}): RenderContext {
-  return { input: { model: 'Opus', session_id: 't', context_window: { used_percentage: 50, remaining_percentage: 50 }, cost: { total_cost_usd: 1, total_duration_ms: 60000 }, workspace: { current_dir: '/p' } } as never, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT, tokenSpeed: null, memory: null, gsd: null, cols: 120, config: { ...DEFAULT_CONFIG }, icons: NERD_ICONS, ...ov };
+  return { input: { model: 'Opus', session_id: 't', context_window: { used_percentage: 50, remaining_percentage: 50 }, cost: { total_cost_usd: 1, total_duration_ms: 60000 }, workspace: { current_dir: '/p' } } as never, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT, tokenSpeed: null, memory: null, gsd: null, mcp: null, cols: 120, config: { ...DEFAULT_CONFIG }, icons: NERD_ICONS, ...ov };
 }
 
 describe('render', () => {

--- a/tests/render/index.test.ts
+++ b/tests/render/index.test.ts
@@ -8,6 +8,6 @@ function makeCtx(ov: Partial<RenderContext> = {}): RenderContext {
 
 describe('render', () => {
   it('multi-line at 120 cols', () => { expect(render(makeCtx()).split('\n').length).toBeGreaterThanOrEqual(2); });
-  it('minimal when forced', () => { expect(render(makeCtx({ config: { ...DEFAULT_CONFIG, layout: 'minimal' } })).split('\n').length).toBeLessThanOrEqual(2); });
+  it('singleline when forced', () => { expect(render(makeCtx({ config: { ...DEFAULT_CONFIG, layout: 'singleline' } })).split('\n').length).toBeLessThanOrEqual(2); });
   it('auto-minimal at <70 cols', () => { expect(render(makeCtx({ cols: 60 })).split('\n').length).toBeLessThanOrEqual(2); });
 });

--- a/tests/render/line1.test.ts
+++ b/tests/render/line1.test.ts
@@ -3,6 +3,7 @@ import { renderLine1 } from '../../src/render/line1.js';
 import { createColors, stripAnsi } from '../../src/render/colors.js';
 import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '../../src/types.js';
 import type { ClaudeCodeInput, GitStatus, RenderContext } from '../../src/types.js';
+import { NERD_ICONS } from '../../src/render/icons.js';
 
 const c = createColors('named');
 
@@ -22,6 +23,7 @@ function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
     input: baseInput, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
     tokenSpeed: null, memory: null, gsd: null, cols: 120,
     config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
+    icons: NERD_ICONS,
     ...overrides,
   };
 }

--- a/tests/render/line1.test.ts
+++ b/tests/render/line1.test.ts
@@ -21,7 +21,7 @@ const git: GitStatus = { branch: 'main', staged: 1, modified: 2, untracked: 3 };
 function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
   return {
     input: baseInput, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
-    tokenSpeed: null, memory: null, gsd: null, cols: 120,
+    tokenSpeed: null, memory: null, gsd: null, mcp: null, cols: 120,
     config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
     icons: NERD_ICONS,
     ...overrides,

--- a/tests/render/line1.test.ts
+++ b/tests/render/line1.test.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { renderLine1 } from '../../src/render/line1.js';
-import { createColors } from '../../src/render/colors.js';
-import { stripAnsi } from '../../src/render/colors.js';
-import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_DISPLAY } from '../../src/types.js';
-import type { ClaudeCodeInput, GitStatus } from '../../src/types.js';
+import { createColors, stripAnsi } from '../../src/render/colors.js';
+import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '../../src/types.js';
+import type { ClaudeCodeInput, GitStatus, RenderContext } from '../../src/types.js';
 
 const c = createColors('named');
 
@@ -18,61 +17,68 @@ const baseInput: ClaudeCodeInput = {
 
 const git: GitStatus = { branch: 'main', staged: 1, modified: 2, untracked: 3 };
 
+function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
+  return {
+    input: baseInput, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
+    tokenSpeed: null, memory: null, gsd: null, cols: 120,
+    config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
+    ...overrides,
+  };
+}
+
 describe('renderLine1', () => {
   it('shows model name', () => {
-    const out = stripAnsi(renderLine1(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine1(makeCtx(), c));
     expect(out).toContain('Claude Opus 4');
   });
 
   it('shows branch', () => {
-    const out = stripAnsi(renderLine1(baseInput, git, EMPTY_TRANSCRIPT, c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine1(makeCtx({ git }), c));
     expect(out).toContain('main');
   });
 
   it('shows git changes', () => {
-    const out = stripAnsi(renderLine1(baseInput, git, EMPTY_TRANSCRIPT, c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine1(makeCtx({ git }), c));
     expect(out).toContain('+1');
     expect(out).toContain('!2');
     expect(out).toContain('?3');
   });
 
   it('shows directory', () => {
-    const out = stripAnsi(renderLine1(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine1(makeCtx(), c));
     expect(out).toContain('project');
   });
 
   it('hides model when toggled off', () => {
-    const display = { ...DEFAULT_DISPLAY, model: false };
-    const out = stripAnsi(renderLine1(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, c, display, 120));
+    const out = stripAnsi(renderLine1(makeCtx({ config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, model: false } } }), c));
     expect(out).not.toContain('Claude Opus 4');
   });
 
   it('hides branch when toggled off', () => {
-    const display = { ...DEFAULT_DISPLAY, branch: false };
-    const out = stripAnsi(renderLine1(baseInput, git, EMPTY_TRANSCRIPT, c, display, 120));
+    const out = stripAnsi(renderLine1(makeCtx({ git, config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, branch: false } } }), c));
     expect(out).not.toContain('main');
   });
 
   it('shows active task from todos', () => {
     const transcript = { ...EMPTY_TRANSCRIPT, todos: [{ id: '1', content: 'Fix the bug', status: 'in_progress' as const }] };
-    const out = stripAnsi(renderLine1(baseInput, EMPTY_GIT, transcript, c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine1(makeCtx({ transcript }), c));
     expect(out).toContain('Fix the bug');
   });
 
   it('shows version', () => {
-    const out = stripAnsi(renderLine1(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine1(makeCtx(), c));
     expect(out).toContain('v2.0.0');
   });
 
   it('shows lines changed', () => {
-    const out = stripAnsi(renderLine1(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine1(makeCtx(), c));
     expect(out).toContain('+100');
     expect(out).toContain('-20');
   });
 
   it('handles object model with display_name', () => {
     const input = { ...baseInput, model: { display_name: 'Sonnet 3.7' } };
-    const out = stripAnsi(renderLine1(input, EMPTY_GIT, EMPTY_TRANSCRIPT, c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine1(makeCtx({ input }), c));
     expect(out).toContain('Sonnet 3.7');
   });
 });

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -3,6 +3,7 @@ import { renderLine2, formatCountdown } from '../../src/render/line2.js';
 import { createColors, stripAnsi } from '../../src/render/colors.js';
 import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '../../src/types.js';
 import type { ClaudeCodeInput, RenderContext } from '../../src/types.js';
+import { NERD_ICONS } from '../../src/render/icons.js';
 
 const c = createColors('named');
 
@@ -24,6 +25,7 @@ function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
     input: baseInput, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
     tokenSpeed: null, memory: null, gsd: null, cols: 120,
     config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
+    icons: NERD_ICONS,
     ...overrides,
   };
 }

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { renderLine2 } from '../../src/render/line2.js';
+import { describe, it, expect, vi } from 'vitest';
+import { renderLine2, formatCountdown } from '../../src/render/line2.js';
 import { createColors, stripAnsi } from '../../src/render/colors.js';
 import { DEFAULT_DISPLAY } from '../../src/types.js';
 import type { ClaudeCodeInput } from '../../src/types.js';
@@ -92,5 +92,41 @@ describe('renderLine2', () => {
     const plain = stripAnsi(line);
     expect(plain).toContain('50%');
     expect(plain).toContain('mem');
+  });
+});
+
+describe('formatCountdown', () => {
+  it('returns empty string for past timestamps', () => {
+    expect(formatCountdown(Date.now() - 10_000)).toBe('');
+  });
+
+  it('formats seconds correctly', () => {
+    const now = 1_700_000_000_000; // realistic ms timestamp
+    vi.useFakeTimers({ now });
+    expect(formatCountdown(now + 45_000)).toBe('45s');
+    vi.useRealTimers();
+  });
+
+  it('formats minutes and seconds', () => {
+    const now = 1_700_000_000_000;
+    vi.useFakeTimers({ now });
+    expect(formatCountdown(now + 125_000)).toBe('2m05s');
+    vi.useRealTimers();
+  });
+
+  it('formats hours and minutes', () => {
+    const now = 1_700_000_000_000;
+    vi.useFakeTimers({ now });
+    expect(formatCountdown(now + 3_725_000)).toBe('1h02m');
+    vi.useRealTimers();
+  });
+
+  it('treats values < 1e12 as seconds and converts to ms', () => {
+    const nowMs = 1_700_000_000_000;
+    const nowSec = nowMs / 1000; // 1_700_000_000
+    vi.useFakeTimers({ now: nowMs });
+    // resets_at in seconds, 60s from now
+    expect(formatCountdown(nowSec + 60)).toBe('1m00s');
+    vi.useRealTimers();
   });
 });

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -103,6 +103,37 @@ describe('renderLine2', () => {
     expect(out).toContain('50%');
     expect(out).toContain('mem');
   });
+
+  it('shows cache hit rate when cache_read_input_tokens present', () => {
+    const input = { ...baseInput, context_window: { ...baseInput.context_window, cache_read_input_tokens: 100000, total_input_tokens: 131000 } };
+    const out = stripAnsi(renderLine2(makeCtx({ input }), c));
+    expect(out).toContain('cache');
+    expect(out).toContain('76%');
+  });
+
+  it('hides cache metrics when toggled off', () => {
+    const input = { ...baseInput, context_window: { ...baseInput.context_window, cache_read_input_tokens: 100000 } };
+    const out = stripAnsi(renderLine2(makeCtx({ input, config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, cacheMetrics: false } } }), c));
+    expect(out).not.toContain('cache');
+  });
+
+  it('shows MCP server count', () => {
+    const mcp = { servers: [{ name: 'a', status: 'ok' as const }, { name: 'b', status: 'ok' as const }] };
+    const out = stripAnsi(renderLine2(makeCtx({ mcp }), c));
+    expect(out).toContain('MCP 2');
+  });
+
+  it('shows MCP errors in red', () => {
+    const mcp = { servers: [{ name: 'a', status: 'ok' as const }, { name: 'b', status: 'error' as const }] };
+    const out = stripAnsi(renderLine2(makeCtx({ mcp }), c));
+    expect(out).toContain('MCP 1/2');
+  });
+
+  it('shows contextTokens estimate', () => {
+    const input = { ...baseInput, context_window: { ...baseInput.context_window, used_percentage: 50, total_input_tokens: 100000 } };
+    const out = stripAnsi(renderLine2(makeCtx({ input }), c));
+    expect(out).toContain('100k/200k');
+  });
 });
 
 describe('formatCountdown', () => {

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -23,7 +23,7 @@ const baseInput: ClaudeCodeInput = {
 function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
   return {
     input: baseInput, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
-    tokenSpeed: null, memory: null, gsd: null, cols: 120,
+    tokenSpeed: null, memory: null, gsd: null, mcp: null, cols: 120,
     config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
     icons: NERD_ICONS,
     ...overrides,

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { renderLine2, formatCountdown } from '../../src/render/line2.js';
 import { createColors, stripAnsi } from '../../src/render/colors.js';
 import { DEFAULT_DISPLAY } from '../../src/types.js';
@@ -96,6 +96,8 @@ describe('renderLine2', () => {
 });
 
 describe('formatCountdown', () => {
+  afterEach(() => vi.useRealTimers());
+
   it('returns empty string for past timestamps', () => {
     expect(formatCountdown(Date.now() - 10_000)).toBe('');
   });
@@ -104,29 +106,24 @@ describe('formatCountdown', () => {
     const now = 1_700_000_000_000; // realistic ms timestamp
     vi.useFakeTimers({ now });
     expect(formatCountdown(now + 45_000)).toBe('45s');
-    vi.useRealTimers();
   });
 
   it('formats minutes and seconds', () => {
     const now = 1_700_000_000_000;
     vi.useFakeTimers({ now });
     expect(formatCountdown(now + 125_000)).toBe('2m05s');
-    vi.useRealTimers();
   });
 
   it('formats hours and minutes', () => {
     const now = 1_700_000_000_000;
     vi.useFakeTimers({ now });
     expect(formatCountdown(now + 3_725_000)).toBe('1h02m');
-    vi.useRealTimers();
   });
 
   it('treats values < 1e12 as seconds and converts to ms', () => {
     const nowMs = 1_700_000_000_000;
     const nowSec = nowMs / 1000; // 1_700_000_000
     vi.useFakeTimers({ now: nowMs });
-    // resets_at in seconds, 60s from now
     expect(formatCountdown(nowSec + 60)).toBe('1m00s');
-    vi.useRealTimers();
   });
 });

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { renderLine2, formatCountdown } from '../../src/render/line2.js';
 import { createColors, stripAnsi } from '../../src/render/colors.js';
-import { DEFAULT_DISPLAY } from '../../src/types.js';
-import type { ClaudeCodeInput } from '../../src/types.js';
+import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '../../src/types.js';
+import type { ClaudeCodeInput, RenderContext } from '../../src/types.js';
 
 const c = createColors('named');
 
@@ -19,79 +19,87 @@ const baseInput: ClaudeCodeInput = {
   workspace: { current_dir: '/home/user/project' },
 };
 
+function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
+  return {
+    input: baseInput, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
+    tokenSpeed: null, memory: null, gsd: null, cols: 120,
+    config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
+    ...overrides,
+  };
+}
+
 describe('renderLine2', () => {
   it('shows context bar with percentage', () => {
-    const out = stripAnsi(renderLine2(baseInput, null, '', c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine2(makeCtx(), c));
     expect(out).toContain('55%');
   });
 
   it('shows tokens', () => {
-    const out = stripAnsi(renderLine2(baseInput, null, '', c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine2(makeCtx(), c));
     expect(out).toContain('131k');
     expect(out).toContain('25k');
   });
 
   it('shows cost', () => {
-    const out = stripAnsi(renderLine2(baseInput, null, '', c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine2(makeCtx(), c));
     expect(out).toContain('$1.31');
   });
 
   it('shows burn rate when duration > 60s', () => {
-    const out = stripAnsi(renderLine2(baseInput, null, '', c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine2(makeCtx(), c));
     expect(out).toContain('/h');
   });
 
   it('does not show burn rate when duration <= 60s', () => {
     const input = { ...baseInput, cost: { ...baseInput.cost, total_duration_ms: 30000 } };
-    const out = stripAnsi(renderLine2(input, null, '', c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine2(makeCtx({ input }), c));
     expect(out).not.toContain('/h');
   });
 
   it('shows token speed when provided', () => {
-    const out = stripAnsi(renderLine2(baseInput, 142, '', c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine2(makeCtx({ tokenSpeed: 142 }), c));
     expect(out).toContain('142');
   });
 
   it('does not show rate limits below 50%', () => {
     const input = { ...baseInput, rate_limits: { five_hour: { used_percentage: 30 } } };
-    const out = stripAnsi(renderLine2(input, null, '', c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine2(makeCtx({ input }), c));
     expect(out).not.toContain('5h');
   });
 
   it('shows rate limits at >=50%', () => {
     const input = { ...baseInput, rate_limits: { five_hour: { used_percentage: 72 } } };
-    const out = stripAnsi(renderLine2(input, null, '', c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine2(makeCtx({ input }), c));
     expect(out).toContain('72%');
     expect(out).toContain('5h');
   });
 
   it('shows vim mode', () => {
     const input = { ...baseInput, vim: { mode: 'i' } };
-    const out = stripAnsi(renderLine2(input, null, '', c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine2(makeCtx({ input }), c));
     expect(out).toContain('[i]');
   });
 
   it('hides effort when medium', () => {
-    const out = stripAnsi(renderLine2(baseInput, null, 'medium', c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine2(makeCtx({ transcript: { ...EMPTY_TRANSCRIPT, thinkingEffort: 'medium' } }), c));
     expect(out).not.toContain('^medium');
   });
 
   it('shows effort when high', () => {
-    const out = stripAnsi(renderLine2(baseInput, null, 'high', c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine2(makeCtx({ transcript: { ...EMPTY_TRANSCRIPT, thinkingEffort: 'high' } }), c));
     expect(out).toContain('^high');
   });
 
   it('shows effort when low', () => {
-    const out = stripAnsi(renderLine2(baseInput, null, 'low', c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderLine2(makeCtx({ transcript: { ...EMPTY_TRANSCRIPT, thinkingEffort: 'low' } }), c));
     expect(out).toContain('^low');
   });
 
   it('shows memory percentage when provided', () => {
     const memory = { usedBytes: 8e9, totalBytes: 16e9, percentage: 50 };
-    const line = renderLine2(baseInput, null, '', c, DEFAULT_DISPLAY, 120, memory);
-    const plain = stripAnsi(line);
-    expect(plain).toContain('50%');
-    expect(plain).toContain('mem');
+    const out = stripAnsi(renderLine2(makeCtx({ memory }), c));
+    expect(out).toContain('50%');
+    expect(out).toContain('mem');
   });
 });
 
@@ -103,7 +111,7 @@ describe('formatCountdown', () => {
   });
 
   it('formats seconds correctly', () => {
-    const now = 1_700_000_000_000; // realistic ms timestamp
+    const now = 1_700_000_000_000;
     vi.useFakeTimers({ now });
     expect(formatCountdown(now + 45_000)).toBe('45s');
   });
@@ -122,7 +130,7 @@ describe('formatCountdown', () => {
 
   it('treats values < 1e12 as seconds and converts to ms', () => {
     const nowMs = 1_700_000_000_000;
-    const nowSec = nowMs / 1000; // 1_700_000_000
+    const nowSec = nowMs / 1000;
     vi.useFakeTimers({ now: nowMs });
     expect(formatCountdown(nowSec + 60)).toBe('1m00s');
   });

--- a/tests/render/line3.test.ts
+++ b/tests/render/line3.test.ts
@@ -3,6 +3,7 @@ import { renderLine3 } from '../../src/render/line3.js';
 import { createColors, stripAnsi } from '../../src/render/colors.js';
 import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '../../src/types.js';
 import type { ToolEntry, TodoEntry, RenderContext } from '../../src/types.js';
+import { NERD_ICONS } from '../../src/render/icons.js';
 
 const c = createColors('named');
 
@@ -31,6 +32,7 @@ function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
     input: baseInput, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
     tokenSpeed: null, memory: null, gsd: null, cols: 120,
     config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
+    icons: NERD_ICONS,
     ...overrides,
   };
 }

--- a/tests/render/line3.test.ts
+++ b/tests/render/line3.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { renderLine3 } from '../../src/render/line3.js';
 import { createColors, stripAnsi } from '../../src/render/colors.js';
+import { DEFAULT_DISPLAY } from '../../src/types.js';
 import type { ToolEntry, TodoEntry } from '../../src/types.js';
 
 const c = createColors('named');
@@ -60,5 +61,30 @@ describe('renderLine3', () => {
     const out = stripAnsi(renderLine3(tools, todos, c));
     expect(out).toContain('Read');
     expect(out).toContain('1/1');
+  });
+
+  it('hides tools when display.tools is false', () => {
+    const tools = [completedTool('Read')];
+    const todos = [todo('1', 'Task', 'completed')];
+    const display = { ...DEFAULT_DISPLAY, tools: false };
+    const out = stripAnsi(renderLine3(tools, todos, c, display));
+    expect(out).not.toContain('Read');
+    expect(out).toContain('1/1');
+  });
+
+  it('hides todos when display.todos is false', () => {
+    const tools = [completedTool('Read')];
+    const todos = [todo('1', 'Task', 'completed')];
+    const display = { ...DEFAULT_DISPLAY, todos: false };
+    const out = stripAnsi(renderLine3(tools, todos, c, display));
+    expect(out).toContain('Read');
+    expect(out).not.toContain('1/1');
+  });
+
+  it('returns empty when both toggles are false', () => {
+    const tools = [completedTool('Read')];
+    const todos = [todo('1', 'Task', 'completed')];
+    const display = { ...DEFAULT_DISPLAY, tools: false, todos: false };
+    expect(renderLine3(tools, todos, c, display)).toBe('');
   });
 });

--- a/tests/render/line3.test.ts
+++ b/tests/render/line3.test.ts
@@ -1,10 +1,18 @@
 import { describe, it, expect } from 'vitest';
 import { renderLine3 } from '../../src/render/line3.js';
 import { createColors, stripAnsi } from '../../src/render/colors.js';
-import { DEFAULT_DISPLAY } from '../../src/types.js';
-import type { ToolEntry, TodoEntry } from '../../src/types.js';
+import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '../../src/types.js';
+import type { ToolEntry, TodoEntry, RenderContext } from '../../src/types.js';
 
 const c = createColors('named');
+
+const baseInput = {
+  model: 'Claude Opus 4',
+  session_id: 'test-123',
+  context_window: { used_percentage: 50, remaining_percentage: 50 },
+  cost: { total_cost_usd: 1.0, total_duration_ms: 60000 },
+  workspace: { current_dir: '/home/user/project' },
+};
 
 const completedTool = (name: string): ToolEntry => ({
   id: name, name, status: 'completed', startTime: new Date(), endTime: new Date(),
@@ -18,20 +26,31 @@ const todo = (id: string, content: string, status: 'pending' | 'in_progress' | '
   id, content, status,
 });
 
+function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
+  return {
+    input: baseInput, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
+    tokenSpeed: null, memory: null, gsd: null, cols: 120,
+    config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
+    ...overrides,
+  };
+}
+
 describe('renderLine3', () => {
   it('returns empty string when no tools and no todos', () => {
-    expect(renderLine3([], [], c)).toBe('');
+    expect(renderLine3(makeCtx(), c)).toBe('');
   });
 
   it('shows running tools', () => {
-    const out = stripAnsi(renderLine3([runningTool('Bash', 'npm test')], [], c));
+    const transcript = { ...EMPTY_TRANSCRIPT, tools: [runningTool('Bash', 'npm test')] };
+    const out = stripAnsi(renderLine3(makeCtx({ transcript }), c));
     expect(out).toContain('Bash');
     expect(out).toContain('npm test');
   });
 
   it('shows completed tools with counts', () => {
     const tools = [completedTool('Read'), completedTool('Read'), completedTool('Edit')];
-    const out = stripAnsi(renderLine3(tools, [], c));
+    const transcript = { ...EMPTY_TRANSCRIPT, tools };
+    const out = stripAnsi(renderLine3(makeCtx({ transcript }), c));
     expect(out).toContain('Read');
     expect(out).toContain('×2');
     expect(out).toContain('Edit');
@@ -39,7 +58,8 @@ describe('renderLine3', () => {
 
   it('excludes TodoWrite from display', () => {
     const tools = [completedTool('TodoWrite'), completedTool('Read')];
-    const out = stripAnsi(renderLine3(tools, [], c));
+    const transcript = { ...EMPTY_TRANSCRIPT, tools };
+    const out = stripAnsi(renderLine3(makeCtx({ transcript }), c));
     expect(out).not.toContain('TodoWrite');
     expect(out).toContain('Read');
   });
@@ -50,7 +70,8 @@ describe('renderLine3', () => {
       todo('2', 'Task 2', 'in_progress'),
       todo('3', 'Task 3', 'pending'),
     ];
-    const out = stripAnsi(renderLine3([], todos, c));
+    const transcript = { ...EMPTY_TRANSCRIPT, todos };
+    const out = stripAnsi(renderLine3(makeCtx({ transcript }), c));
     expect(out).toContain('1/3');
     expect(out).toContain('1'); // in_progress count
   });
@@ -58,7 +79,8 @@ describe('renderLine3', () => {
   it('shows tools and todos together', () => {
     const tools = [completedTool('Read')];
     const todos = [todo('1', 'Task', 'completed')];
-    const out = stripAnsi(renderLine3(tools, todos, c));
+    const transcript = { ...EMPTY_TRANSCRIPT, tools, todos };
+    const out = stripAnsi(renderLine3(makeCtx({ transcript }), c));
     expect(out).toContain('Read');
     expect(out).toContain('1/1');
   });
@@ -66,8 +88,8 @@ describe('renderLine3', () => {
   it('hides tools when display.tools is false', () => {
     const tools = [completedTool('Read')];
     const todos = [todo('1', 'Task', 'completed')];
-    const display = { ...DEFAULT_DISPLAY, tools: false };
-    const out = stripAnsi(renderLine3(tools, todos, c, display));
+    const transcript = { ...EMPTY_TRANSCRIPT, tools, todos };
+    const out = stripAnsi(renderLine3(makeCtx({ transcript, config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, tools: false } } }), c));
     expect(out).not.toContain('Read');
     expect(out).toContain('1/1');
   });
@@ -75,8 +97,8 @@ describe('renderLine3', () => {
   it('hides todos when display.todos is false', () => {
     const tools = [completedTool('Read')];
     const todos = [todo('1', 'Task', 'completed')];
-    const display = { ...DEFAULT_DISPLAY, todos: false };
-    const out = stripAnsi(renderLine3(tools, todos, c, display));
+    const transcript = { ...EMPTY_TRANSCRIPT, tools, todos };
+    const out = stripAnsi(renderLine3(makeCtx({ transcript, config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, todos: false } } }), c));
     expect(out).toContain('Read');
     expect(out).not.toContain('1/1');
   });
@@ -84,7 +106,7 @@ describe('renderLine3', () => {
   it('returns empty when both toggles are false', () => {
     const tools = [completedTool('Read')];
     const todos = [todo('1', 'Task', 'completed')];
-    const display = { ...DEFAULT_DISPLAY, tools: false, todos: false };
-    expect(renderLine3(tools, todos, c, display)).toBe('');
+    const transcript = { ...EMPTY_TRANSCRIPT, tools, todos };
+    expect(renderLine3(makeCtx({ transcript, config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, tools: false, todos: false } } }), c)).toBe('');
   });
 });

--- a/tests/render/line3.test.ts
+++ b/tests/render/line3.test.ts
@@ -30,7 +30,7 @@ const todo = (id: string, content: string, status: 'pending' | 'in_progress' | '
 function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
   return {
     input: baseInput, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
-    tokenSpeed: null, memory: null, gsd: null, cols: 120,
+    tokenSpeed: null, memory: null, gsd: null, mcp: null, cols: 120,
     config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
     icons: NERD_ICONS,
     ...overrides,

--- a/tests/render/line4.test.ts
+++ b/tests/render/line4.test.ts
@@ -3,6 +3,7 @@ import { renderLine4 } from '../../src/render/line4.js';
 import { createColors, stripAnsi } from '../../src/render/colors.js';
 import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '../../src/types.js';
 import type { GsdInfo, RenderContext } from '../../src/types.js';
+import { NERD_ICONS } from '../../src/render/icons.js';
 
 const c = createColors('named');
 
@@ -19,6 +20,7 @@ function makeCtx(gsd: GsdInfo | null): RenderContext {
     input: baseInput, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
     tokenSpeed: null, memory: null, gsd, cols: 120,
     config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
+    icons: NERD_ICONS,
   };
 }
 

--- a/tests/render/line4.test.ts
+++ b/tests/render/line4.test.ts
@@ -18,7 +18,7 @@ const baseInput = {
 function makeCtx(gsd: GsdInfo | null): RenderContext {
   return {
     input: baseInput, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
-    tokenSpeed: null, memory: null, gsd, cols: 120,
+    tokenSpeed: null, memory: null, gsd, mcp: null, cols: 120,
     config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
     icons: NERD_ICONS,
   };

--- a/tests/render/line4.test.ts
+++ b/tests/render/line4.test.ts
@@ -1,36 +1,49 @@
 import { describe, it, expect } from 'vitest';
 import { renderLine4 } from '../../src/render/line4.js';
 import { createColors, stripAnsi } from '../../src/render/colors.js';
-import type { GsdInfo } from '../../src/types.js';
+import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '../../src/types.js';
+import type { GsdInfo, RenderContext } from '../../src/types.js';
 
 const c = createColors('named');
 
+const baseInput = {
+  model: 'Claude Opus 4',
+  session_id: 'test-123',
+  context_window: { used_percentage: 50, remaining_percentage: 50 },
+  cost: { total_cost_usd: 1.0, total_duration_ms: 60000 },
+  workspace: { current_dir: '/home/user/project' },
+};
+
+function makeCtx(gsd: GsdInfo | null): RenderContext {
+  return {
+    input: baseInput, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
+    tokenSpeed: null, memory: null, gsd, cols: 120,
+    config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
+  };
+}
+
 describe('renderLine4', () => {
   it('returns empty string when gsd is null', () => {
-    expect(renderLine4(null, c)).toBe('');
+    expect(renderLine4(makeCtx(null), c)).toBe('');
   });
 
   it('returns empty string when no task and no update', () => {
-    const gsd: GsdInfo = { currentTask: undefined, updateAvailable: false };
-    expect(renderLine4(gsd, c)).toBe('');
+    expect(renderLine4(makeCtx({ currentTask: undefined, updateAvailable: false }), c)).toBe('');
   });
 
   it('shows current task', () => {
-    const gsd: GsdInfo = { currentTask: 'Fix critical bug' };
-    const out = stripAnsi(renderLine4(gsd, c));
+    const out = stripAnsi(renderLine4(makeCtx({ currentTask: 'Fix critical bug' }), c));
     expect(out).toContain('GSD');
     expect(out).toContain('Fix critical bug');
   });
 
   it('shows update available warning', () => {
-    const gsd: GsdInfo = { updateAvailable: true };
-    const out = stripAnsi(renderLine4(gsd, c));
+    const out = stripAnsi(renderLine4(makeCtx({ updateAvailable: true }), c));
     expect(out).toContain('GSD update available');
   });
 
   it('shows both task and update', () => {
-    const gsd: GsdInfo = { currentTask: 'My task', updateAvailable: true };
-    const out = stripAnsi(renderLine4(gsd, c));
+    const out = stripAnsi(renderLine4(makeCtx({ currentTask: 'My task', updateAvailable: true }), c));
     expect(out).toContain('My task');
     expect(out).toContain('GSD update available');
   });

--- a/tests/render/minimal.test.ts
+++ b/tests/render/minimal.test.ts
@@ -78,4 +78,19 @@ describe('renderMinimal', () => {
     const out = renderMinimal(makeCtx(), c);
     expect(out.split('\n').length).toBe(1);
   });
+
+  it('hides model when toggled off', () => {
+    const out = stripAnsi(renderMinimal(makeCtx({ config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, model: false } } }), c));
+    expect(out).not.toContain('Claude Opus 4');
+  });
+
+  it('hides branch when toggled off', () => {
+    const out = stripAnsi(renderMinimal(makeCtx({ git, config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, branch: false } } }), c));
+    expect(out).not.toContain('main');
+  });
+
+  it('hides cost at <60 cols', () => {
+    const out = stripAnsi(renderMinimal(makeCtx({ cols: 50 }), c));
+    expect(out).not.toContain('$1.31');
+  });
 });

--- a/tests/render/minimal.test.ts
+++ b/tests/render/minimal.test.ts
@@ -3,6 +3,7 @@ import { renderMinimal } from '../../src/render/minimal.js';
 import { createColors, stripAnsi } from '../../src/render/colors.js';
 import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '../../src/types.js';
 import type { ClaudeCodeInput, GitStatus, RenderContext } from '../../src/types.js';
+import { NERD_ICONS } from '../../src/render/icons.js';
 
 const c = createColors('named');
 
@@ -27,6 +28,7 @@ function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
     input: baseInput, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
     tokenSpeed: null, memory: null, gsd: null, cols: 120,
     config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
+    icons: NERD_ICONS,
     ...overrides,
   };
 }

--- a/tests/render/minimal.test.ts
+++ b/tests/render/minimal.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { renderMinimal } from '../../src/render/minimal.js';
 import { createColors, stripAnsi } from '../../src/render/colors.js';
-import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_DISPLAY } from '../../src/types.js';
-import type { ClaudeCodeInput, GitStatus } from '../../src/types.js';
+import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '../../src/types.js';
+import type { ClaudeCodeInput, GitStatus, RenderContext } from '../../src/types.js';
 
 const c = createColors('named');
 
@@ -22,36 +22,44 @@ const baseInput: ClaudeCodeInput = {
 
 const git: GitStatus = { branch: 'main', staged: 0, modified: 1, untracked: 0 };
 
+function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
+  return {
+    input: baseInput, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
+    tokenSpeed: null, memory: null, gsd: null, cols: 120,
+    config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
+    ...overrides,
+  };
+}
+
 describe('renderMinimal', () => {
   it('shows directory', () => {
-    const out = stripAnsi(renderMinimal(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, null, null, c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderMinimal(makeCtx(), c));
     expect(out).toContain('project');
   });
 
   it('shows branch', () => {
-    const out = stripAnsi(renderMinimal(baseInput, git, EMPTY_TRANSCRIPT, null, null, c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderMinimal(makeCtx({ git }), c));
     expect(out).toContain('main');
   });
 
   it('shows model', () => {
-    const out = stripAnsi(renderMinimal(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, null, null, c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderMinimal(makeCtx(), c));
     expect(out).toContain('Claude Opus 4');
   });
 
   it('shows context bar', () => {
-    const out = stripAnsi(renderMinimal(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, null, null, c, DEFAULT_DISPLAY, 120));
+    const out = stripAnsi(renderMinimal(makeCtx(), c));
     expect(out).toContain('55%');
   });
 
   it('shows cost at >=60 cols', () => {
-    const out = stripAnsi(renderMinimal(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, null, null, c, DEFAULT_DISPLAY, 80));
+    const out = stripAnsi(renderMinimal(makeCtx({ cols: 80 }), c));
     expect(out).toContain('$1.31');
   });
 
   it('truncates branch at <60 cols', () => {
     const git2: GitStatus = { branch: 'feature/very-long-branch-name-here', staged: 0, modified: 0, untracked: 0 };
-    const out = stripAnsi(renderMinimal(baseInput, git2, EMPTY_TRANSCRIPT, null, null, c, DEFAULT_DISPLAY, 50));
-    // Branch should be truncated to 12 chars
+    const out = stripAnsi(renderMinimal(makeCtx({ git: git2, cols: 50 }), c));
     expect(out).not.toContain('feature/very-long-branch-name-here');
   });
 
@@ -60,12 +68,12 @@ describe('renderMinimal', () => {
       ...EMPTY_TRANSCRIPT,
       tools: [{ id: '1', name: 'Read', status: 'completed' as const, startTime: new Date(), endTime: new Date() }],
     };
-    const out = renderMinimal(baseInput, EMPTY_GIT, transcript, null, null, c, DEFAULT_DISPLAY, 120);
+    const out = renderMinimal(makeCtx({ transcript }), c);
     expect(out.split('\n').length).toBe(2);
   });
 
   it('returns single line when no tools/todos', () => {
-    const out = renderMinimal(baseInput, EMPTY_GIT, EMPTY_TRANSCRIPT, null, null, c, DEFAULT_DISPLAY, 120);
+    const out = renderMinimal(makeCtx(), c);
     expect(out.split('\n').length).toBe(1);
   });
 });

--- a/tests/render/minimal.test.ts
+++ b/tests/render/minimal.test.ts
@@ -26,7 +26,7 @@ const git: GitStatus = { branch: 'main', staged: 0, modified: 1, untracked: 0 };
 function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
   return {
     input: baseInput, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
-    tokenSpeed: null, memory: null, gsd: null, cols: 120,
+    tokenSpeed: null, memory: null, gsd: null, mcp: null, cols: 120,
     config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
     icons: NERD_ICONS,
     ...overrides,

--- a/tests/render/shared.test.ts
+++ b/tests/render/shared.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { getModelName, buildContextBar, formatGitChanges, SEP, SEP_MINIMAL } from '../../src/render/shared.js';
+import { createColors, stripAnsi } from '../../src/render/colors.js';
+import type { GitStatus } from '../../src/types.js';
+
+const c = createColors('named');
+
+describe('getModelName', () => {
+  it('returns string model as-is', () => {
+    expect(getModelName('Claude Opus 4')).toBe('Claude Opus 4');
+  });
+
+  it('extracts display_name from object model', () => {
+    expect(getModelName({ display_name: 'Sonnet 3.7' })).toBe('Sonnet 3.7');
+  });
+
+  it('returns empty string for unknown shape', () => {
+    expect(getModelName('' as never)).toBe('');
+  });
+});
+
+describe('buildContextBar', () => {
+  it('uses 20 segments by default', () => {
+    const bar = stripAnsi(buildContextBar(50, c));
+    expect(bar).toContain('50%');
+    // Default format: [bar] pct
+    expect(bar).toMatch(/\] 50%/);
+  });
+
+  it('supports custom segment count', () => {
+    const bar10 = stripAnsi(buildContextBar(50, c, { segments: 10 }));
+    const barDefault = stripAnsi(buildContextBar(50, c));
+    // 10-segment bar is shorter than 20-segment
+    expect(bar10.length).toBeLessThan(barDefault.length);
+  });
+
+  it('puts pct inside bar when pctInsideBar is true', () => {
+    const bar = stripAnsi(buildContextBar(50, c, { pctInsideBar: true }));
+    // Format: [bar pct]
+    expect(bar).toMatch(/50%\]$/);
+  });
+
+  it('shows decimal for pct < 10', () => {
+    const bar = stripAnsi(buildContextBar(5, c));
+    expect(bar).toContain('5.0%');
+  });
+
+  it('shows integer for pct >= 10', () => {
+    const bar = stripAnsi(buildContextBar(55, c));
+    expect(bar).toContain('55%');
+    expect(bar).not.toContain('55.0%');
+  });
+
+  it('shows skull icon at >=80%', () => {
+    const bar = buildContextBar(85, c);
+    expect(bar).toContain('\uEE15'); // skull icon
+  });
+
+  it('shows fire icon at 65-79%', () => {
+    const bar = buildContextBar(70, c);
+    expect(bar).toContain('\uF06D'); // fire icon
+  });
+
+  it('hides icons when icons=false', () => {
+    const bar = buildContextBar(85, c, { icons: false });
+    expect(bar).not.toContain('\uEE15');
+    const bar70 = buildContextBar(70, c, { icons: false });
+    expect(bar70).not.toContain('\uF06D');
+  });
+});
+
+describe('formatGitChanges', () => {
+  it('formats staged as +', () => {
+    const git: GitStatus = { branch: 'main', staged: 3, modified: 0, untracked: 0 };
+    const parts = formatGitChanges(git, c);
+    expect(stripAnsi(parts[0])).toBe('+3');
+  });
+
+  it('formats modified as ! (not ~)', () => {
+    const git: GitStatus = { branch: 'main', staged: 0, modified: 2, untracked: 0 };
+    const parts = formatGitChanges(git, c);
+    expect(stripAnsi(parts[0])).toBe('!2');
+  });
+
+  it('formats untracked as ?', () => {
+    const git: GitStatus = { branch: 'main', staged: 0, modified: 0, untracked: 5 };
+    const parts = formatGitChanges(git, c);
+    expect(stripAnsi(parts[0])).toBe('?5');
+  });
+
+  it('returns empty array when no changes', () => {
+    const git: GitStatus = { branch: 'main', staged: 0, modified: 0, untracked: 0 };
+    expect(formatGitChanges(git, c)).toEqual([]);
+  });
+
+  it('returns all parts in order: staged, modified, untracked', () => {
+    const git: GitStatus = { branch: 'main', staged: 1, modified: 2, untracked: 3 };
+    const parts = formatGitChanges(git, c).map(stripAnsi);
+    expect(parts).toEqual(['+1', '!2', '?3']);
+  });
+});
+
+describe('SEP constants', () => {
+  it('SEP uses Unicode pipe', () => {
+    expect(SEP).toContain('\u2502');
+  });
+
+  it('SEP_MINIMAL uses ASCII pipe', () => {
+    expect(SEP_MINIMAL).toContain('|');
+    expect(SEP_MINIMAL).not.toContain('\u2502');
+  });
+});

--- a/tests/render/shared.test.ts
+++ b/tests/render/shared.test.ts
@@ -61,10 +61,10 @@ describe('buildContextBar', () => {
     expect(bar).toContain('\uF06D'); // fire icon
   });
 
-  it('hides icons when icons=false', () => {
-    const bar = buildContextBar(85, c, { icons: false });
+  it('hides icons when showIcons=false', () => {
+    const bar = buildContextBar(85, c, { showIcons: false });
     expect(bar).not.toContain('\uEE15');
-    const bar70 = buildContextBar(70, c, { icons: false });
+    const bar70 = buildContextBar(70, c, { showIcons: false });
     expect(bar70).not.toContain('\uF06D');
   });
 });

--- a/tests/render/shared.test.ts
+++ b/tests/render/shared.test.ts
@@ -23,8 +23,8 @@ describe('buildContextBar', () => {
   it('uses 20 segments by default', () => {
     const bar = stripAnsi(buildContextBar(50, c));
     expect(bar).toContain('50%');
-    // Default format: [bar] pct
-    expect(bar).toMatch(/\] 50%/);
+    // Default format: bar pct
+    expect(bar).toMatch(/░ 50%/);
   });
 
   it('supports custom segment count', () => {
@@ -36,8 +36,8 @@ describe('buildContextBar', () => {
 
   it('puts pct inside bar when pctInsideBar is true', () => {
     const bar = stripAnsi(buildContextBar(50, c, { pctInsideBar: true }));
-    // Format: [bar pct]
-    expect(bar).toMatch(/50%\]$/);
+    // Format: bar pct (no brackets)
+    expect(bar).toMatch(/50%$/);
   });
 
   it('shows decimal for pct < 10', () => {

--- a/tests/stdin.test.ts
+++ b/tests/stdin.test.ts
@@ -15,4 +15,24 @@ describe('readStdin', () => {
   });
   it('throws on invalid JSON', async () => { await expect(readStdin(Readable.from(['not json']))).rejects.toThrow(); });
   it('throws on timeout', async () => { await expect(readStdin(new Readable({ read() {} }), 50)).rejects.toThrow(); });
+
+  it('handles chunked JSON delivery', async () => {
+    const json = readFileSync(join(FIXTURES, 'sample-input.json'), 'utf8');
+    const mid = Math.floor(json.length / 2);
+    const chunk1 = json.slice(0, mid);
+    const chunk2 = json.slice(mid);
+    const stream = new Readable({ read() {} });
+    const promise = readStdin(stream, 500, 100);
+    stream.push(chunk1);
+    setTimeout(() => { stream.push(chunk2); stream.push(null); }, 10);
+    const result = await promise;
+    expect(result.model).toBe('Opus 4.6 (1M context)');
+  });
+
+  it('rejects on stream error', async () => {
+    const stream = new Readable({ read() {} });
+    const promise = readStdin(stream, 500);
+    stream.destroy(new Error('pipe broken'));
+    await expect(promise).rejects.toThrow('pipe broken');
+  });
 });

--- a/tests/themes.test.ts
+++ b/tests/themes.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { THEMES, getThemeNames, resolveTheme } from '../src/themes.js';
+
+describe('THEMES', () => {
+  it('has at least 5 themes', () => {
+    expect(Object.keys(THEMES).length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('each theme has all required color keys', () => {
+    const requiredKeys = ['cyan', 'magenta', 'yellow', 'green', 'orange', 'red', 'brightBlue', 'gray'];
+    for (const [name, palette] of Object.entries(THEMES)) {
+      for (const key of requiredKeys) {
+        expect(palette).toHaveProperty(key);
+        expect((palette as Record<string, string>)[key]).toContain('\x1b[38;2;');
+      }
+    }
+  });
+});
+
+describe('getThemeNames', () => {
+  it('returns all theme names', () => {
+    const names = getThemeNames();
+    expect(names).toContain('dracula');
+    expect(names).toContain('nord');
+    expect(names).toContain('tokyo-night');
+    expect(names).toContain('catppuccin');
+    expect(names).toContain('monokai');
+  });
+});
+
+describe('resolveTheme', () => {
+  it('returns null when no theme specified', () => {
+    expect(resolveTheme(undefined, 'truecolor')).toBeNull();
+  });
+
+  it('returns null for non-truecolor modes', () => {
+    expect(resolveTheme('dracula', 'named')).toBeNull();
+    expect(resolveTheme('dracula', '256')).toBeNull();
+  });
+
+  it('returns palette for valid theme in truecolor mode', () => {
+    const palette = resolveTheme('dracula', 'truecolor');
+    expect(palette).not.toBeNull();
+    expect(palette!.cyan).toContain('\x1b[38;2;');
+  });
+
+  it('is case-insensitive', () => {
+    expect(resolveTheme('Dracula', 'truecolor')).not.toBeNull();
+    expect(resolveTheme('NORD', 'truecolor')).not.toBeNull();
+  });
+
+  it('returns null for unknown theme', () => {
+    expect(resolveTheme('nonexistent', 'truecolor')).toBeNull();
+  });
+});

--- a/tests/utils/cache.test.ts
+++ b/tests/utils/cache.test.ts
@@ -6,7 +6,7 @@ import { readTtlCache, writeTtlCache, isMtimeFresh } from '../../src/utils/cache
 
 describe('TTL cache', () => {
   let dir: string;
-  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'ccpulse-test-')); });
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'lumira-test-')); });
   afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
 
   it('returns null for missing cache', () => {
@@ -18,7 +18,7 @@ describe('TTL cache', () => {
     expect(result).toEqual({ value: 42 });
   });
   it('returns null for expired cache', () => {
-    const filePath = join(dir, 'ccpulse-test-key.json');
+    const filePath = join(dir, 'lumira-test-key.json');
     writeFileSync(filePath, JSON.stringify({ value: 42 }), { mode: 0o600 });
     const past = new Date(Date.now() - 10_000);
     utimesSync(filePath, past, past);
@@ -29,7 +29,7 @@ describe('TTL cache', () => {
 
 describe('isMtimeFresh', () => {
   let dir: string;
-  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'ccpulse-test-')); });
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'lumira-test-')); });
   afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
 
   it('returns false for non-existent file', () => {

--- a/tests/utils/cache.test.ts
+++ b/tests/utils/cache.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, writeFileSync, rmSync, statSync, utimesSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync, statSync, utimesSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { readTtlCache, writeTtlCache, isMtimeFresh } from '../../src/utils/cache.js';
+
+const uid = process.getuid?.() ?? 'default';
 
 describe('TTL cache', () => {
   let dir: string;
@@ -17,8 +19,15 @@ describe('TTL cache', () => {
     const result = readTtlCache<{ value: number }>('test-key', dir, 5000);
     expect(result).toEqual({ value: 42 });
   });
+  it('creates per-user subdirectory', () => {
+    writeTtlCache('test-key', { value: 1 }, dir);
+    expect(existsSync(join(dir, `lumira-${uid}`))).toBe(true);
+  });
   it('returns null for expired cache', () => {
-    const filePath = join(dir, 'lumira-test-key.json');
+    const cacheDir = join(dir, `lumira-${uid}`);
+    const { mkdirSync } = require('node:fs');
+    mkdirSync(cacheDir, { recursive: true, mode: 0o700 });
+    const filePath = join(cacheDir, 'test-key.json');
     writeFileSync(filePath, JSON.stringify({ value: 42 }), { mode: 0o600 });
     const past = new Date(Date.now() - 10_000);
     utimesSync(filePath, past, past);


### PR DESCRIPTION
## Summary

- **Phase 2 (Refactor):** Shared render utilities, unified renderer signatures, injectable config, real `detectColorMode`, preset/theme/icons config fields
- **Phase 3 (Features):** Presets system (full/balanced/minimal), icon modes (nerd/emoji/none), named themes (Dracula, Nord, Tokyo Night, Catppuccin, Monokai), context bar improvements, MCP server health display, `/lumira` AI config skill, cache metrics
- **Phase 4 (Tests):** Transcript parser gaps (thinkingEffort, sessionStart, TodoWrite merge), render edge cases (cache metrics, MCP, toggles, themes), parser edge cases (GSD sanitization, token-speed NaN/reset), integration tests (GSD, auto-switch, chunked JSON, stream errors)

**Tests:** 136 → 240 (+104)
**Files changed:** 47 files, +2309/-304

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx vitest run` — 240/240 tests pass
- [ ] Manual: verify statusline renders in Claude Code with `--minimal`, `--balanced`, `--full`
- [ ] Manual: verify `--icons=emoji` and `--icons=none` render correctly
- [ ] Manual: verify theme with `"theme": "dracula"` + `"colors": {"mode": "truecolor"}`