### PR TITLE
fix: resolve TS2339 on isQwenInput union type access

### DIFF
--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -7,8 +7,9 @@
 import type { ClaudeCodeInput, QwenInput, RawInput } from './types.js';
 
 export function isQwenInput(input: RawInput): input is QwenInput {
-  if (!input.metrics || typeof input.metrics !== 'object' || !('models' in input.metrics)) return false;
-  const models = (input.metrics as { models?: Record<string, unknown> }).models;
+  const raw = input as unknown as Record<string, unknown>;
+  if (!raw.metrics || typeof raw.metrics !== 'object' || !('models' in raw.metrics)) return false;
+  const models = (raw.metrics as { models?: Record<string, unknown> }).models;
   if (!models || typeof models !== 'object') return false;
   const first = Object.values(models)[0];
   return first != null && typeof first === 'object' && 'api' in first;


### PR DESCRIPTION
## Summary
- Fix TypeScript build error introduced in the merge commit
- `isQwenInput` accessed `.metrics` on `RawInput` union type — `ClaudeCodeInput` doesn't have that field
- Cast via `unknown` to `Record<string, unknown>` for safe property access

CI green on branch. 296 tests passing.