### PR TITLE
feat(statusline): increase branch name display length

### DIFF
--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -23,7 +23,7 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
   // Branch + git changes (prefer Qwen's native git.branch, fallback to external git)
   const branchName = input.gitBranch || git.branch;
   if (display.branch && branchName) {
-    const branchLen = cols < 60 ? 20 : cols < 80 ? 35 : cols < 100 ? 50 : cols < 120 ? 70 : 100;
+    const branchLen = cols < 60 ? 20 : cols < 80 ? 35 : cols < 100 ? 50 : cols < 120 ? 70 : 80;
     const bName = truncField(branchName, branchLen);
     let branchStr = c.magenta(`${icons.branch} ${bName}`);
 

--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -23,7 +23,7 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
   // Branch + git changes (prefer Qwen's native git.branch, fallback to external git)
   const branchName = input.gitBranch || git.branch;
   if (display.branch && branchName) {
-    const branchLen = cols < 60 ? 12 : cols < 80 ? 20 : cols < 100 ? 30 : cols < 120 ? 40 : 60;
+    const branchLen = cols < 60 ? 20 : cols < 80 ? 35 : cols < 100 ? 50 : cols < 120 ? 70 : 100;
     const bName = truncField(branchName, branchLen);
     let branchStr = c.magenta(`${icons.branch} ${bName}`);
 

--- a/src/render/text.ts
+++ b/src/render/text.ts
@@ -40,20 +40,31 @@ export function truncatePath(str: string, maxLen: number = 20): string {
 }
 
 export function fitSegments(left: string[], right: string[], sep: string, cols: number): string {
-  const safeCols = cols - 4;
-  const leftStr = left.join(sep);
-  const leftW = displayWidth(leftStr);
-  for (let r = right.length; r >= 0; r--) {
-    const rSlice = right.slice(0, r);
-    if (rSlice.length === 0) return leftStr;
-    const rightStr = rSlice.join(sep);
-    const rightW = displayWidth(rightStr);
-    if (leftW + 1 + rightW <= safeCols) {
-      const gap = Math.max(1, safeCols - leftW - rightW);
-      return leftStr + ' '.repeat(gap) + rightStr;
+  const safeCols = Math.max(1, cols - 4);
+
+  for (let l = left.length; l >= 1; l--) {
+    const lSlice = left.slice(0, l);
+    const leftStr = lSlice.join(sep);
+    const leftW = displayWidth(leftStr);
+
+    if (leftW > safeCols) continue;
+
+    for (let r = right.length; r >= 0; r--) {
+      const rSlice = right.slice(0, r);
+      if (rSlice.length === 0) return leftStr;
+      const rightStr = rSlice.join(sep);
+      const rightW = displayWidth(rightStr);
+      if (leftW + 1 + rightW <= safeCols) {
+        const gap = Math.max(1, safeCols - leftW - rightW);
+        return leftStr + ' '.repeat(gap) + rightStr;
+      }
     }
+    return leftStr;
   }
-  return leftStr;
+
+  // Last resort: even the first left segment alone exceeds safeCols.
+  // Strip ANSI before hard-truncating to avoid cutting mid-escape-sequence.
+  return truncField(stripAnsi(left[0] ?? ''), safeCols);
 }
 
 export function padLine(left: string, right: string, cols: number): string {

--- a/tests/render/line1.test.ts
+++ b/tests/render/line1.test.ts
@@ -84,4 +84,26 @@ describe('renderLine1', () => {
     const out = stripAnsi(renderLine1(makeCtx({}, inputOverride), c));
     expect(out).toContain('Sonnet 3.7');
   });
+
+  it('truncates long branch at narrow terminal (cols=59)', () => {
+    const longBranch = 'feat/ca-71-some-very-long-branch-description-that-exceeds-limit';
+    const out = stripAnsi(renderLine1(makeCtx({ git: { ...git, branch: longBranch }, cols: 59 }), c));
+    expect(out).not.toContain(longBranch);
+    expect(out).toContain('…');
+  });
+
+  it('shows more branch text at wide terminal than at narrow', () => {
+    const longBranch = 'feat/ca-71-some-long-description-that-was-truncated-before';
+    const narrow = stripAnsi(renderLine1(makeCtx({ git: { ...git, branch: longBranch }, cols: 79 }), c));
+    const wide = stripAnsi(renderLine1(makeCtx({ git: { ...git, branch: longBranch }, cols: 120 }), c));
+    const branchInNarrow = narrow.match(/feat\/[^\s]*/)?.[0] ?? '';
+    const branchInWide = wide.match(/feat\/[^\s]*/)?.[0] ?? '';
+    expect(branchInWide.length).toBeGreaterThan(branchInNarrow.length);
+  });
+
+  it('does not overflow layout at cols=120 with long model and branch', () => {
+    const longBranch = 'feat/ca-71-some-long-description-that-was-truncated-before';
+    const out = stripAnsi(renderLine1(makeCtx({ git: { ...git, branch: longBranch }, cols: 120 }), c));
+    expect(out.length).toBeLessThanOrEqual(120);
+  });
 });

--- a/tests/render/text.test.ts
+++ b/tests/render/text.test.ts
@@ -36,6 +36,33 @@ describe('fitSegments', () => {
     const result = fitSegments(['LEFT'], ['RIGHT'], ' | ', 10);
     expect(result).toContain('LEFT');
   });
+
+  it('drops tail left segment when left alone overflows', () => {
+    const model = 'A'.repeat(20);
+    const branch = 'B'.repeat(85);
+    const dir = 'C'.repeat(25);
+    const result = fitSegments([model, branch, dir], [], ' | ', 120);
+    expect(displayWidth(result)).toBeLessThanOrEqual(116);
+    expect(result).not.toContain('C'.repeat(25));
+  });
+
+  it('last-resort: truncates single oversized segment without ANSI bleed', () => {
+    const result = fitSegments(['X'.repeat(200)], [], ' | ', 50);
+    expect(displayWidth(result)).toBeLessThanOrEqual(46);
+    expect(result.endsWith('…')).toBe(true);
+  });
+
+  it('ANSI-colored left that overflows stays within displayWidth bounds', () => {
+    const colored = `\x1b[36m${'B'.repeat(90)}\x1b[0m`;
+    const result = fitSegments([colored], [], ' | ', 80);
+    expect(displayWidth(result)).toBeLessThanOrEqual(76);
+  });
+
+  it('leftW === safeCols exactly returns left unchanged', () => {
+    const left = 'A'.repeat(16); // safeCols = 20-4 = 16
+    const result = fitSegments([left], [], ' | ', 20);
+    expect(result).toBe(left);
+  });
 });
 
 describe('padLine', () => {


### PR DESCRIPTION
## Summary

- Raise branch name display caps across all terminal widths so long branch names (e.g. CA-ticket style) show more characters
- Fix layout overflow at `cols >= 120` where the original cap of 100 exceeded `safeCols` (cols - 4) when combined with model name and other left-side segments
- Rewrite `fitSegments` to drop tail left-side segments on overflow (symmetric with right-side behavior), fixing the root cause systemic bug where the left side could wrap onto a second terminal line

## Test plan

- [ ] 354 tests passing (`npm test`)
- [ ] New regression tests in `tests/render/text.test.ts`: left overflow drops tail segment, last-resort truncation, ANSI-colored overflow stays within bounds, exact boundary case
- [ ] New regression tests in `tests/render/line1.test.ts`: narrow terminal truncates long branch, wide terminal shows more than narrow, cols=120 layout stays within bounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)