### PR TITLE
release: v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Interactive install wizard (`npx lumira install`): choose preset, theme, and icons with arrow-key navigation and a live preview. Pre-selects current config values when re-running.
+- ASCII banner printed on install with dynamic version from `package.json`.
+- `/lumira` skill is now installed for Qwen Code as well (when `~/.qwen/` is detected).
+- Render layer auto-switches to single-line output when the caller is Qwen Code, so Qwen users see the rich compact line regardless of their configured layout.
+
+### Changed
+- `saveConfig` writes `~/.config/lumira/config.json` atomically (tmp file + rename) with `0o600` permissions, preserving any keys the user set by hand.
+
+### Removed
+- **BREAKING:** `qwen` preset removed. It was functionally identical to `minimal`; with the render-layer auto-switch, the alias no longer serves a purpose. Existing configs with `preset: "qwen"` are silently coerced to `minimal` and a one-shot stderr warning is printed. CLI flag `--qwen` is removed; use `--minimal` instead.
+
 ## [0.3.0] - 2026-04-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-04-21
+
 ### Added
 - Interactive install wizard (`npx lumira install`): choose preset, theme, and icons with arrow-key navigation and a live preview. Pre-selects current config values when re-running.
 - ASCII banner printed on install with dynamic version from `package.json`.
@@ -15,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `saveConfig` writes `~/.config/lumira/config.json` atomically (tmp file + rename) with `0o600` permissions, preserving any keys the user set by hand.
+- Branch name display caps raised across all terminal widths — long CA-ticket style branch names now show significantly more characters before truncating.
+- `fitSegments` now drops tail left-side segments on overflow (symmetric with right-side behavior), preventing terminal line wrap when left segments collectively exceed the available width.
 
 ### Removed
 - **BREAKING:** `qwen` preset removed. It was functionally identical to `minimal`; with the render-layer auto-switch, the alias no longer serves a purpose. Existing configs with `preset: "qwen"` are silently coerced to `minimal` and a one-shot stderr warning is printed. CLI flag `--qwen` is removed; use `--minimal` instead.
@@ -137,7 +141,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GSD session IDs sanitized against path traversal
 - `execFile` used instead of `exec` to prevent shell injection (except terminal width detection where shell redirect is required with procfs-sourced paths)
 
-[Unreleased]: https://github.com/cativo23/lumira/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/cativo23/lumira/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/cativo23/lumira/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/cativo23/lumira/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/cativo23/lumira/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/cativo23/lumira/compare/v0.2.0...v0.2.1

--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ Real-time statusline plugin for [Claude Code](https://code.claude.com) and Qwen 
 
 ## Install
 
-Quick setup (auto-configures Claude Code):
+Quick setup with interactive wizard (arrow-key navigation + live preview):
 
 ```bash
 npx lumira install
 ```
+
+The installer walks you through three choices — **preset** (`full` / `balanced` / `minimal`), **theme**, and **icons** — showing a live preview of how your statusline will render at each step. Press `Esc` at any time to abort without writing anything. In non-interactive shells (piped stdin, CI), the installer skips the wizard and writes sensible defaults (`preset: balanced`, `icons: nerd`). If Qwen Code is detected (`~/.qwen/` exists), the `/lumira` skill is installed for both CLIs.
 
 Or install globally:
 
@@ -44,6 +46,8 @@ To uninstall:
 ```bash
 npx lumira uninstall
 ```
+
+Your preferences are saved to `~/.config/lumira/config.json` — hand-edited keys (e.g. custom `display` toggles) are preserved on re-install.
 
 ### Manual setup
 
@@ -130,24 +134,15 @@ All fields are optional — defaults are shown above.
 ### CLI Flags
 
 ```bash
-lumira --minimal    # Force minimal mode
+lumira --minimal    # Force single-line mode
+lumira --balanced   # Force balanced preset
+lumira --full       # Force full multi-line preset
 lumira --gsd        # Enable GSD integration
-lumira --qwen       # Force Qwen Code single-line output
 ```
 
 ### Qwen Code
 
-Lumira auto-detects the platform. For Qwen Code, use the `--qwen` preset for a single-line output with model, context bar, requests, cached tokens, and thoughts:
-
-```json
-{
-  "statusLine": {
-    "type": "command",
-    "command": "npx lumira@latest --qwen",
-    "padding": 0
-  }
-}
-```
+Lumira auto-detects the platform. In Qwen Code sessions, the renderer automatically switches to single-line output regardless of your configured layout — Qwen only displays the first statusline row, so lumira fits everything (model, branch, context bar, cost, cached tokens, thoughts) into one line. **No configuration needed:** the same `config.json` serves both Claude Code and Qwen Code.
 
 ## Architecture
 

--- a/docs/superpowers/plans/2026-04-20-install-wizard.md
+++ b/docs/superpowers/plans/2026-04-20-install-wizard.md
@@ -1,0 +1,1878 @@
+# Install Wizard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the silent `lumira install` with an interactive TUI wizard (preset / theme / icons, live preview, arrow-key navigation), fix the latent Qwen Code rendering gap, install the `/lumira` skill for Qwen Code when detected, and retire the `qwen` preset.
+
+**Architecture:** A zero-dependency TUI helper (`src/tui/select.ts`) owns raw-mode keypress handling and cleanup. The wizard (`src/installer-wizard.ts`) orchestrates three `interactiveSelect` calls with a live `buildPreview()` callback that invokes the real `render()` on mock data. The installer runs the wizard BEFORE any disk write, then atomically writes `~/.config/lumira/config.json`. Qwen gets a render-layer auto-switch to `renderMinimal`, making the `qwen` preset redundant — it's removed with a migration coercion.
+
+**Tech Stack:** TypeScript, Vitest, Node.js `readline.emitKeypressEvents`, `process.stdin.setRawMode`, ANSI escape codes. No new runtime dependencies.
+
+---
+
+## Task 1: Render layer — Qwen auto-switches to singleline
+
+**Why first:** Isolated change, unblocks the `qwen` preset removal in Task 2 by making it semantically correct. Single-file test + single-file source change.
+
+**Files:**
+- Modify: `src/render/index.ts:15`
+- Test: `tests/render/index.test.ts`
+
+- [ ] **Step 1: Read the current render/index.ts branch condition**
+
+Read `src/render/index.ts`. The branch at line 15 is:
+
+```ts
+if (ctx.config.layout === 'singleline' || (ctx.config.layout === 'auto' && ctx.cols < 70)) {
+  return renderMinimal(ctx, c);
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `tests/render/index.test.ts`:
+
+```ts
+it('forces singleline when input platform is qwen-code, even with multiline layout', () => {
+  const ctx = makeCtx({
+    config: { ...DEFAULT_CONFIG, layout: 'multiline' },
+    input: { ...makeInput(), platform: 'qwen-code' as const },
+  });
+  const out = render(ctx);
+  // singleline output is always <= 1 newline (single line or fit-on-one-row)
+  expect(out.split('\n').length).toBeLessThanOrEqual(1);
+});
+```
+
+If `makeCtx` doesn't already accept a custom `input`, read the existing helper and mirror its pattern. If it doesn't expose `input`, add an optional `input` override at the top of the file:
+
+```ts
+// in the existing test file's makeCtx or a new helper
+function makeCtxWithPlatform(platform: 'qwen-code' | 'claude-code', layout: 'multiline' | 'singleline' | 'auto' = 'multiline') {
+  const base = makeCtx({ config: { ...DEFAULT_CONFIG, layout } });
+  return { ...base, input: { ...base.input, platform } };
+}
+```
+
+Use whichever style matches the file. Verify `NormalizedInput` has `platform: 'claude-code' | 'qwen-code'` (see `src/normalize.ts:18`).
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run tests/render/index.test.ts`
+Expected: the new test FAILS with the output having multiple lines (multiline renderer kicked in).
+
+- [ ] **Step 4: Modify render/index.ts**
+
+Edit `src/render/index.ts:15` to:
+
+```ts
+const isQwen = ctx.input.platform === 'qwen-code';
+if (isQwen || ctx.config.layout === 'singleline' || (ctx.config.layout === 'auto' && ctx.cols < 70)) {
+  return renderMinimal(ctx, c);
+}
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `npx vitest run tests/render/index.test.ts`
+Expected: all tests PASS including the new one.
+
+- [ ] **Step 6: Run full test suite to verify no regression**
+
+Run: `npm test`
+Expected: all tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/render/index.ts tests/render/index.test.ts
+git commit -m "fix(render): force singleline for qwen-code platform
+
+Qwen Code only displays the first line of statusline output. Previously
+lumira used the configured layout regardless of platform, so users with
+balanced/full presets saw only a truncated line 1 in Qwen sessions.
+Now render() detects qwen-code input and routes to renderMinimal, which
+is designed to fit all essentials (including qwen-specific metrics) in
+one line.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Remove `qwen` preset with migration
+
+**Why:** Now that render auto-switches on platform, the `qwen` preset is an unused alias of `minimal`. Removal is a breaking change mitigated by a one-shot stderr warning and silent coercion to `minimal`.
+
+**Files:**
+- Modify: `src/types.ts:161`
+- Modify: `src/config.ts` (validPresets, PRESET_DEFS, CLI flags, mergeConfig migration)
+- Test: `tests/config.test.ts`
+
+- [ ] **Step 1: Read current state**
+
+Read `src/types.ts` (lines 155-165) and `src/config.ts` fully.
+
+- [ ] **Step 2: Write failing tests**
+
+Append to `tests/config.test.ts`:
+
+```ts
+describe('qwen preset migration', () => {
+  let dir: string;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'cc-cfg-qwen-'));
+    errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    errSpy.mockRestore();
+  });
+
+  it('coerces legacy preset "qwen" to "minimal"', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"preset":"qwen"}');
+    const c = loadConfig(dir);
+    expect(c.preset).toBe('minimal');
+    expect(c.layout).toBe('singleline');
+  });
+
+  it('writes a deprecation warning to stderr when "qwen" preset is seen', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"preset":"qwen"}');
+    loadConfig(dir);
+    const calls = errSpy.mock.calls.flat().join('');
+    expect(calls).toContain("'qwen' preset is removed");
+  });
+});
+```
+
+Add `vi` to the imports at top: `import { ..., vi } from 'vitest';`
+
+Also find and remove or modify any existing test referencing `qwen` preset directly. Search: grep for `'qwen'` inside `tests/config.test.ts`. If any assertion expects `preset === 'qwen'`, change it to expect `minimal` and remove now-irrelevant assertions about qwen-specific output. The test `'preset minimal disables most toggles'` already covers `minimal` — no duplication needed.
+
+- [ ] **Step 3: Run tests to verify the new ones fail**
+
+Run: `npx vitest run tests/config.test.ts`
+Expected: the two new qwen-migration tests FAIL (preset is still `undefined` — falls to default — and no stderr write happens).
+
+- [ ] **Step 4: Update types.ts**
+
+Edit `src/types.ts:161` — remove `'qwen'` from the preset union:
+
+```ts
+preset?: 'full' | 'balanced' | 'minimal';
+```
+
+- [ ] **Step 5: Update config.ts — validPresets, PRESET_DEFS, flags, migration**
+
+In `src/config.ts`:
+
+1. Remove the `qwen` entry from `PRESET_DEFS` (lines 70-93).
+2. Change `const validPresets = ['full', 'balanced', 'minimal', 'qwen'] as const;` to `const validPresets = ['full', 'balanced', 'minimal'] as const;`.
+3. Change the same array in the argv match regex: `/^--preset[= ]?(full|balanced|minimal|qwen)$/` → `/^--preset[= ]?(full|balanced|minimal)$/`.
+4. Remove `if (argv.includes('--qwen')) applyPreset(r, 'qwen');` entirely.
+5. Insert migration at the top of `mergeConfig` (right after the first line that reads `layout`):
+
+```ts
+// ── qwen preset migration (breaking change in v0.4) ─────────────
+if (raw.preset === 'qwen') {
+  if (!qwenWarningShown) {
+    process.stderr.write("[lumira] 'qwen' preset is removed — using 'minimal' instead\n");
+    qwenWarningShown = true;
+  }
+  raw = { ...raw, preset: 'minimal' };
+}
+```
+
+Add a module-level flag near the top of the file, below the imports:
+
+```ts
+let qwenWarningShown = false;
+```
+
+Also reassign `raw` type: `function mergeConfig(raw: Record<string, unknown>): HudConfig {` → needs `let` or `raw = { ...raw, preset: 'minimal' }` via local binding. Use a local binding to avoid mutating parameter:
+
+```ts
+function mergeConfig(rawIn: Record<string, unknown>): HudConfig {
+  let raw = rawIn;
+  if (raw.preset === 'qwen') {
+    if (!qwenWarningShown) {
+      process.stderr.write("[lumira] 'qwen' preset is removed — using 'minimal' instead\n");
+      qwenWarningShown = true;
+    }
+    raw = { ...raw, preset: 'minimal' };
+  }
+  // ... rest of function uses `raw`
+```
+
+Rename the single parameter reference — no external caller sees the change.
+
+- [ ] **Step 6: Run tests**
+
+Run: `npx vitest run tests/config.test.ts`
+Expected: all tests PASS, including the two new migration tests.
+
+- [ ] **Step 7: Update render-test and ensure full suite passes**
+
+Check `tests/render/index.test.ts` and `tests/integration.test.ts` for references to `qwen` preset. If any test explicitly sets `preset: 'qwen'`, change to `preset: 'minimal'`.
+
+Run: `npm test`
+Expected: all tests PASS. Type-check with `npm run lint`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/types.ts src/config.ts tests/config.test.ts tests/render/index.test.ts tests/integration.test.ts
+git commit -m "refactor(config)!: remove qwen preset, migrate to minimal
+
+BREAKING CHANGE: the 'qwen' preset was functionally identical to 'minimal'.
+With the render-layer auto-switch for qwen-code input, it's now redundant.
+Users with 'preset: qwen' in their config.json see a one-shot stderr
+warning and are silently coerced to 'minimal'. CLI flag '--qwen' is
+removed; use '--minimal' instead.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Atomic `saveConfig` helper
+
+**Files:**
+- Modify: `src/config.ts` (export new `saveConfig`)
+- Test: `tests/config.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/config.test.ts` (inside a new `describe('saveConfig', ...)` block):
+
+```ts
+import { saveConfig } from '../src/config.js';
+import { readFileSync, existsSync, statSync } from 'node:fs';
+
+describe('saveConfig', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'cc-save-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('creates config.json with only the three wizard keys', () => {
+    saveConfig({ preset: 'balanced', icons: 'nerd' }, join(dir, 'config.json'));
+    const content = JSON.parse(readFileSync(join(dir, 'config.json'), 'utf8'));
+    expect(content).toEqual({ preset: 'balanced', icons: 'nerd' });
+  });
+
+  it('writes with 0o600 permissions', () => {
+    const p = join(dir, 'config.json');
+    saveConfig({ preset: 'minimal' }, p);
+    const mode = statSync(p).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('preserves other keys in an existing config', () => {
+    const p = join(dir, 'config.json');
+    writeFileSync(p, JSON.stringify({
+      display: { tokens: false },
+      colors: { mode: 'truecolor' },
+      preset: 'full',
+    }));
+    saveConfig({ preset: 'balanced', theme: 'dracula', icons: 'nerd' }, p);
+    const content = JSON.parse(readFileSync(p, 'utf8'));
+    expect(content).toEqual({
+      display: { tokens: false },
+      colors: { mode: 'truecolor' },
+      preset: 'balanced',
+      theme: 'dracula',
+      icons: 'nerd',
+    });
+  });
+
+  it('overwrites corrupt JSON with wizard keys only', () => {
+    const p = join(dir, 'config.json');
+    writeFileSync(p, 'not { valid json');
+    saveConfig({ preset: 'minimal', icons: 'emoji' }, p);
+    const content = JSON.parse(readFileSync(p, 'utf8'));
+    expect(content).toEqual({ preset: 'minimal', icons: 'emoji' });
+  });
+
+  it('omits theme key when undefined in input', () => {
+    const p = join(dir, 'config.json');
+    saveConfig({ preset: 'balanced', icons: 'nerd' }, p);
+    const content = JSON.parse(readFileSync(p, 'utf8'));
+    expect('theme' in content).toBe(false);
+  });
+
+  it('creates the parent directory if missing', () => {
+    const p = join(dir, 'nested', 'deep', 'config.json');
+    saveConfig({ preset: 'full' }, p);
+    expect(existsSync(p)).toBe(true);
+  });
+
+  it('does not leave a stale .tmp file behind', () => {
+    const p = join(dir, 'config.json');
+    saveConfig({ preset: 'balanced' }, p);
+    expect(existsSync(p + '.tmp')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npx vitest run tests/config.test.ts -t 'saveConfig'`
+Expected: all 7 tests FAIL — `saveConfig` is not exported.
+
+- [ ] **Step 3: Implement saveConfig**
+
+At the bottom of `src/config.ts`, add:
+
+```ts
+import { writeFileSync as _writeFileSync, renameSync, readFileSync as _readFileSync, existsSync as _existsSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+export interface WizardResult {
+  preset: 'full' | 'balanced' | 'minimal';
+  theme?: string;
+  icons: 'nerd' | 'emoji' | 'none';
+}
+
+export function saveConfig(wizard: WizardResult, configPath: string): void {
+  mkdirSync(dirname(configPath), { recursive: true });
+
+  let existing: Record<string, unknown> = {};
+  if (_existsSync(configPath)) {
+    try {
+      existing = JSON.parse(_readFileSync(configPath, 'utf8'));
+      if (typeof existing !== 'object' || existing === null) existing = {};
+    } catch {
+      existing = {};
+    }
+  }
+
+  const merged: Record<string, unknown> = { ...existing, preset: wizard.preset, icons: wizard.icons };
+  if (wizard.theme !== undefined) merged.theme = wizard.theme;
+  else delete merged.theme;
+
+  const tmp = configPath + '.tmp';
+  _writeFileSync(tmp, JSON.stringify(merged, null, 2) + '\n', { mode: 0o600 });
+  renameSync(tmp, configPath);
+}
+```
+
+Note: if `readFileSync`/`existsSync`/`writeFileSync` are already imported in the file from `'node:fs'`, reuse those imports instead of aliasing. Check the top of `src/config.ts` and consolidate — the aliasing above is a fallback only if the symbols conflict.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npx vitest run tests/config.test.ts -t 'saveConfig'`
+Expected: all 7 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config.ts tests/config.test.ts
+git commit -m "feat(config): add atomic saveConfig helper
+
+Writes wizard keys (preset, theme, icons) to config.json via tmp file +
+rename. Preserves other user-set keys on merge. Creates parent dir if
+missing. Writes with 0o600 permissions.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: ASCII banner module
+
+**Files:**
+- Create: `src/tui/banner.ts`
+- Test: `tests/tui/banner.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/tui/banner.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { getBanner, getSubtitle } from '../../src/tui/banner.js';
+
+describe('getBanner', () => {
+  it('returns a banner string with cyan ANSI and the logo', () => {
+    const b = getBanner({ width: 80 });
+    expect(b).toContain('\x1b[36m');
+    expect(b).toContain('\x1b[0m');
+    expect(b).toContain('██╗     ██╗');
+  });
+
+  it('returns empty string when width < 50', () => {
+    expect(getBanner({ width: 40 })).toBe('');
+  });
+});
+
+describe('getSubtitle', () => {
+  it('reads version from package.json', () => {
+    const s = getSubtitle();
+    expect(s).toMatch(/real-time statusline for claude code & qwen code · v\d+\.\d+\.\d+/);
+  });
+
+  it('falls back to subtitle without version if read fails', () => {
+    // Inject a bad resolver
+    const s = getSubtitle({ readPackageJson: () => { throw new Error('boom'); } });
+    expect(s).toBe('real-time statusline for claude code & qwen code');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npx vitest run tests/tui/banner.test.ts`
+Expected: all tests FAIL — module doesn't exist.
+
+- [ ] **Step 3: Create src/tui/banner.ts**
+
+```ts
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const LOGO = [
+  '██╗     ██╗   ██╗███╗   ███╗██╗██████╗  █████╗ ',
+  '██║     ██║   ██║████╗ ████║██║██╔══██╗██╔══██╗',
+  '██║     ██║   ██║██╔████╔██║██║██████╔╝███████║',
+  '██║     ██║   ██║██║╚██╔╝██║██║██╔══██╗██╔══██║',
+  '███████╗╚██████╔╝██║ ╚═╝ ██║██║██║  ██║██║  ██║',
+  '╚══════╝ ╚═════╝ ╚═╝     ╚═╝╚═╝╚═╝  ╚═╝╚═╝  ╚═╝',
+].join('\n');
+
+const CYAN = '\x1b[36m';
+const RST = '\x1b[0m';
+
+export interface BannerOpts {
+  width?: number;
+}
+
+export function getBanner(opts: BannerOpts = {}): string {
+  const width = opts.width ?? (process.stdout.columns ?? 80);
+  if (width < 50) return '';
+  return `${CYAN}\n${LOGO}\n${RST}`;
+}
+
+export interface SubtitleOpts {
+  readPackageJson?: () => string;
+}
+
+function defaultReadPackageJson(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // dist/tui/banner.js lives at dist/tui/; package.json is at dist/..
+  const p = resolve(here, '..', '..', 'package.json');
+  return readFileSync(p, 'utf8');
+}
+
+export function getSubtitle(opts: SubtitleOpts = {}): string {
+  const read = opts.readPackageJson ?? defaultReadPackageJson;
+  const base = 'real-time statusline for claude code & qwen code';
+  try {
+    const pkg = JSON.parse(read());
+    if (typeof pkg.version === 'string') return `${base} · v${pkg.version}`;
+    return base;
+  } catch {
+    return base;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npx vitest run tests/tui/banner.test.ts`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/banner.ts tests/tui/banner.test.ts
+git commit -m "feat(tui): add ASCII banner module
+
+Exports getBanner() and getSubtitle() for the install wizard entry
+screen. Banner is hidden on terminals <50 cols. Subtitle reads
+version from package.json with a graceful fallback.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: TUI select helper — non-TTY path + public shape
+
+**Files:**
+- Create: `src/tui/select.ts`
+- Create: `tests/tui/select.test.ts`
+- Create: `tests/tui/_mock-stdin.ts` (shared helper)
+
+- [ ] **Step 1: Create the mock stdin helper**
+
+Create `tests/tui/_mock-stdin.ts`:
+
+```ts
+import { EventEmitter } from 'node:events';
+
+export interface MockStdin extends EventEmitter {
+  isTTY: boolean;
+  isRaw: boolean;
+  setRawMode(flag: boolean): MockStdin;
+  resume(): MockStdin;
+  pause(): MockStdin;
+  removeListener(event: string, fn: (...args: unknown[]) => void): MockStdin;
+  pressKey(name: string, opts?: { ctrl?: boolean; shift?: boolean; meta?: boolean }): void;
+  emitEnd(): void;
+}
+
+export function createMockStdin(isTTY = true): MockStdin {
+  const ee = new EventEmitter() as MockStdin;
+  ee.isTTY = isTTY;
+  ee.isRaw = false;
+  ee.setRawMode = function (flag: boolean) { this.isRaw = flag; return this; };
+  ee.resume = function () { return this; };
+  ee.pause = function () { return this; };
+  ee.pressKey = function (name: string, opts = {}) {
+    const seq = name === 'return' ? '\r' : '';
+    this.emit('keypress', seq, { name, ctrl: !!opts.ctrl, shift: !!opts.shift, meta: !!opts.meta });
+  };
+  ee.emitEnd = function () { this.emit('end'); };
+  return ee;
+}
+
+export interface MockStdout extends EventEmitter {
+  columns: number;
+  rows: number;
+  written: string[];
+  write(chunk: string): boolean;
+}
+
+export function createMockStdout(columns = 100): MockStdout {
+  const ee = new EventEmitter() as MockStdout;
+  ee.columns = columns;
+  ee.rows = 30;
+  ee.written = [];
+  ee.write = function (chunk: string) { this.written.push(chunk); return true; };
+  return ee;
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `tests/tui/select.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { interactiveSelect } from '../../src/tui/select.js';
+import { createMockStdin, createMockStdout } from './_mock-stdin.js';
+
+describe('interactiveSelect — non-TTY', () => {
+  it('returns null immediately when stdin is not a TTY', async () => {
+    const stdin = createMockStdin(false);
+    const stdout = createMockStdout();
+    const result = await interactiveSelect({
+      title: 'pick',
+      options: [{ label: 'a', value: 'a' }, { label: 'b', value: 'b' }],
+      initial: 'a',
+      preview: () => 'preview',
+      stdin, stdout,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('never enters raw mode when stdin is not a TTY', async () => {
+    const stdin = createMockStdin(false);
+    const stdout = createMockStdout();
+    await interactiveSelect({
+      title: 'pick',
+      options: [{ label: 'a', value: 'a' }],
+      initial: 'a',
+      preview: () => '',
+      stdin, stdout,
+    });
+    expect(stdin.isRaw).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests — they should fail (module missing)**
+
+Run: `npx vitest run tests/tui/select.test.ts`
+Expected: tests FAIL with import error.
+
+- [ ] **Step 4: Implement minimal select.ts with non-TTY path**
+
+Create `src/tui/select.ts`:
+
+```ts
+import type { Readable, Writable } from 'node:stream';
+
+export interface SelectOption<T> {
+  label: string;
+  value: T;
+  description?: string;
+  hint?: string;   // optional inline preview snippet (e.g. theme color sample)
+  disabled?: boolean;
+}
+
+export interface SelectOpts<T> {
+  title: string;
+  options: SelectOption<T>[];
+  initial?: T;
+  preview: (focused: T) => string;
+  /** Optional injection points for tests. Default: process.stdin / process.stdout. */
+  stdin?: NodeJS.ReadStream | (Readable & { isTTY?: boolean; isRaw?: boolean; setRawMode?: (flag: boolean) => unknown });
+  stdout?: NodeJS.WriteStream | (Writable & { columns?: number });
+}
+
+export async function interactiveSelect<T>(opts: SelectOpts<T>): Promise<T | null> {
+  const stdin = (opts.stdin ?? process.stdin) as NodeJS.ReadStream;
+  if (!stdin.isTTY) return null;
+
+  // Placeholder for later tasks — resolved in Task 6+
+  return null;
+}
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `npx vitest run tests/tui/select.test.ts`
+Expected: both tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tui/select.ts tests/tui/select.test.ts tests/tui/_mock-stdin.ts
+git commit -m "feat(tui): interactiveSelect scaffold with non-TTY fallback
+
+Adds the public shape for the TUI select helper and the mock-stdin
+test infrastructure. Non-TTY stdin short-circuits to null so callers
+can detect piped input and fall back to defaults.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: TUI select helper — navigation, Enter, cleanup
+
+**Files:**
+- Modify: `src/tui/select.ts`
+- Modify: `tests/tui/select.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/tui/select.test.ts`:
+
+```ts
+import { emitKeypressEvents } from 'node:readline';  // only needed if cross-module monkey-patch
+
+describe('interactiveSelect — navigation', () => {
+  const makeOpts = (overrides: Record<string, unknown> = {}) => {
+    const stdin = createMockStdin(true);
+    const stdout = createMockStdout();
+    return {
+      stdin, stdout,
+      title: 'pick',
+      options: [
+        { label: 'a', value: 'a' },
+        { label: 'b', value: 'b' },
+        { label: 'c', value: 'c' },
+      ],
+      initial: 'b',
+      preview: () => 'p',
+      ...overrides,
+    };
+  };
+
+  it('Enter on initial focus resolves with that value', async () => {
+    const opts = makeOpts();
+    const promise = interactiveSelect(opts);
+    // Let the first render flush
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.pressKey('return');
+    expect(await promise).toBe('b');
+  });
+
+  it('Down then Enter resolves with the next value', async () => {
+    const opts = makeOpts();
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.pressKey('down');
+    opts.stdin.pressKey('return');
+    expect(await promise).toBe('c');
+  });
+
+  it('Up from first wraps to last', async () => {
+    const opts = makeOpts({ initial: 'a' });
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.pressKey('up');
+    opts.stdin.pressKey('return');
+    expect(await promise).toBe('c');
+  });
+
+  it('Down from last wraps to first', async () => {
+    const opts = makeOpts({ initial: 'c' });
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.pressKey('down');
+    opts.stdin.pressKey('return');
+    expect(await promise).toBe('a');
+  });
+
+  it('j/k navigate identically to down/up', async () => {
+    const opts = makeOpts();
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.pressKey('j');
+    opts.stdin.pressKey('return');
+    expect(await promise).toBe('c');
+  });
+
+  it('invokes preview with the focused value on each move', async () => {
+    const calls: string[] = [];
+    const opts = makeOpts({ preview: (v: string) => { calls.push(v); return v; } });
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.pressKey('down');
+    opts.stdin.pressKey('down');
+    opts.stdin.pressKey('return');
+    await promise;
+    // initial render (b), after down (c), after down wrap (a)
+    expect(calls).toEqual(['b', 'c', 'a']);
+  });
+
+  it('restores stdin to non-raw and shows cursor after resolve', async () => {
+    const opts = makeOpts();
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    expect(opts.stdin.isRaw).toBe(true);
+    opts.stdin.pressKey('return');
+    await promise;
+    expect(opts.stdin.isRaw).toBe(false);
+    const out = opts.stdout.written.join('');
+    expect(out).toContain('\x1b[?25h'); // show-cursor
+    expect(out).toContain('\x1b[?25l'); // hide-cursor (was written earlier)
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — they should fail**
+
+Run: `npx vitest run tests/tui/select.test.ts -t 'navigation'`
+Expected: FAIL — select.ts currently returns null on TTY too.
+
+- [ ] **Step 3: Implement navigation and Enter resolution**
+
+Replace the body of `interactiveSelect` in `src/tui/select.ts`:
+
+```ts
+import readline from 'node:readline';
+import type { Readable, Writable } from 'node:stream';
+
+const SHOW_CURSOR = '\x1b[?25h';
+const HIDE_CURSOR = '\x1b[?25l';
+const CLEAR_SCREEN = '\x1b[2J\x1b[H';
+
+export async function interactiveSelect<T>(opts: SelectOpts<T>): Promise<T | null> {
+  const stdin = (opts.stdin ?? process.stdin) as NodeJS.ReadStream;
+  const stdout = (opts.stdout ?? process.stdout) as NodeJS.WriteStream;
+  if (!stdin.isTTY) return null;
+
+  const options = opts.options;
+  const initialIdx = Math.max(0, options.findIndex((o) => o.value === opts.initial));
+  let focus = initialIdx >= 0 ? initialIdx : 0;
+
+  let keypressListener: ((str: string, key: KeypressKey) => void) | null = null;
+
+  const cleanup = () => {
+    if (keypressListener) stdin.removeListener('keypress', keypressListener);
+    if (typeof stdin.setRawMode === 'function') stdin.setRawMode(false);
+    stdin.pause?.();
+    stdout.write(SHOW_CURSOR);
+  };
+
+  const render = () => {
+    stdout.write(CLEAR_SCREEN);
+    stdout.write(` ${opts.title}\n\n`);
+    for (let i = 0; i < options.length; i++) {
+      const o = options[i];
+      const marker = i === focus ? ' ❯ ' : '   ';
+      stdout.write(`${marker}${o.label}${o.description ? '  ' + o.description : ''}\n`);
+    }
+    stdout.write('\n');
+    stdout.write(opts.preview(options[focus].value));
+    stdout.write('\n');
+  };
+
+  try {
+    readline.emitKeypressEvents(stdin);
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdout.write(HIDE_CURSOR);
+    render();
+
+    return await new Promise<T | null>((resolve) => {
+      keypressListener = (_str, key) => {
+        if (!key) return;
+        if (key.name === 'down' || key.name === 'j') { focus = (focus + 1) % options.length; render(); return; }
+        if (key.name === 'up' || key.name === 'k') { focus = (focus - 1 + options.length) % options.length; render(); return; }
+        if (key.name === 'return') { resolve(options[focus].value); return; }
+      };
+      stdin.on('keypress', keypressListener);
+    });
+  } finally {
+    cleanup();
+  }
+}
+
+interface KeypressKey { name: string; ctrl?: boolean; shift?: boolean; meta?: boolean; }
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npx vitest run tests/tui/select.test.ts`
+Expected: all navigation tests PASS (plus the non-TTY tests from Task 5).
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `npm test`
+Expected: all PASS, no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tui/select.ts tests/tui/select.test.ts
+git commit -m "feat(tui): navigation, Enter resolution, and cleanup
+
+Implements wrap-around up/down with j/k aliases, live preview on
+every move, cursor hide/show, raw-mode restoration via try/finally.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: TUI select helper — abort (Esc, q, Ctrl+C) and resize
+
+**Files:**
+- Modify: `src/tui/select.ts`
+- Modify: `tests/tui/select.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/tui/select.test.ts`:
+
+```ts
+describe('interactiveSelect — abort and resize', () => {
+  const makeOpts = () => ({
+    stdin: createMockStdin(true),
+    stdout: createMockStdout(),
+    title: 'pick',
+    options: [{ label: 'a', value: 'a' }, { label: 'b', value: 'b' }],
+    initial: 'a',
+    preview: () => '',
+  });
+
+  it('Esc resolves with null', async () => {
+    const opts = makeOpts();
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.pressKey('escape');
+    expect(await promise).toBeNull();
+  });
+
+  it('q resolves with null', async () => {
+    const opts = makeOpts();
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.pressKey('q');
+    expect(await promise).toBeNull();
+  });
+
+  it('Ctrl+C resolves with null', async () => {
+    const opts = makeOpts();
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.pressKey('c', { ctrl: true });
+    expect(await promise).toBeNull();
+  });
+
+  it('stdin end event resolves with null', async () => {
+    const opts = makeOpts();
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.emitEnd();
+    expect(await promise).toBeNull();
+  });
+
+  it('resize event triggers a re-render', async () => {
+    const opts = makeOpts();
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    const beforeCount = opts.stdout.written.filter((c) => c.includes('\x1b[2J')).length;
+    opts.stdout.emit('resize');
+    await new Promise((r) => setImmediate(r));
+    const afterCount = opts.stdout.written.filter((c) => c.includes('\x1b[2J')).length;
+    expect(afterCount).toBeGreaterThan(beforeCount);
+    opts.stdin.pressKey('return');
+    await promise;
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — they should fail**
+
+Run: `npx vitest run tests/tui/select.test.ts -t 'abort and resize'`
+Expected: FAIL.
+
+- [ ] **Step 3: Add abort and resize handling**
+
+Edit `src/tui/select.ts`. Replace the body of the `new Promise<T | null>((resolve) => { ... })` section:
+
+```ts
+return await new Promise<T | null>((resolve) => {
+  let resizeListener: (() => void) | null = null;
+  let endListener: (() => void) | null = null;
+
+  const finish = (v: T | null) => {
+    if (resizeListener && typeof stdout.removeListener === 'function') stdout.removeListener('resize', resizeListener);
+    if (endListener) stdin.removeListener('end', endListener);
+    resolve(v);
+  };
+
+  keypressListener = (_str, key) => {
+    if (!key) return;
+    if (key.name === 'down' || key.name === 'j') { focus = (focus + 1) % options.length; render(); return; }
+    if (key.name === 'up' || key.name === 'k') { focus = (focus - 1 + options.length) % options.length; render(); return; }
+    if (key.name === 'return') { finish(options[focus].value); return; }
+    if (key.name === 'escape' || key.name === 'q') { finish(null); return; }
+    if (key.name === 'c' && key.ctrl) { finish(null); return; }
+  };
+  stdin.on('keypress', keypressListener);
+
+  endListener = () => finish(null);
+  stdin.on('end', endListener);
+
+  resizeListener = () => render();
+  if (typeof stdout.on === 'function') stdout.on('resize', resizeListener);
+});
+```
+
+Update `cleanup()` to also remove these listeners defensively if still present at exit (already handled in `finish`, but `cleanup` may run from `finally` without `finish` — e.g. exception path):
+
+```ts
+const cleanup = () => {
+  if (keypressListener) stdin.removeListener('keypress', keypressListener);
+  if (typeof stdin.setRawMode === 'function') stdin.setRawMode(false);
+  stdin.pause?.();
+  stdout.write(SHOW_CURSOR);
+};
+```
+
+(Note: resize and end listeners are scoped inside the Promise closure; if an exception fires before `finish` resolves, they leak briefly until GC. In practice acceptable; if tightening is needed, hoist them to the outer scope.)
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npx vitest run tests/tui/select.test.ts`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Add defensive process exit handler**
+
+At the top of `src/tui/select.ts`, add a one-shot process.exit handler registered only when used:
+
+```ts
+let exitHandlerInstalled = false;
+function installExitHandler(stdin: NodeJS.ReadStream, stdout: NodeJS.WriteStream): void {
+  if (exitHandlerInstalled) return;
+  exitHandlerInstalled = true;
+  process.once('exit', () => {
+    try {
+      if (typeof stdin.setRawMode === 'function' && stdin.isRaw) stdin.setRawMode(false);
+      stdout.write(SHOW_CURSOR);
+    } catch { /* best effort */ }
+  });
+}
+```
+
+Call `installExitHandler(stdin, stdout)` inside `interactiveSelect` right after the `isTTY` guard.
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `npm test`
+Expected: all tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/tui/select.ts tests/tui/select.test.ts
+git commit -m "feat(tui): abort keys, resize re-render, defensive exit cleanup
+
+Esc, q, and Ctrl+C resolve interactiveSelect with null. Stdin 'end'
+event (pipe closed) also aborts. Terminal resize triggers a re-render.
+A one-shot process.exit handler restores raw mode and cursor as a
+safety net against uncaughtException or external process.exit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Preview generator
+
+**Files:**
+- Create: `src/tui/preview.ts`
+- Create: `tests/tui/preview.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/tui/preview.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildPreview } from '../../src/tui/preview.js';
+
+describe('buildPreview', () => {
+  it('returns a non-empty string for preset "balanced"', () => {
+    const out = buildPreview({ preset: 'balanced', icons: 'nerd' });
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it('dracula theme in truecolor emits a dracula RGB code', () => {
+    const out = buildPreview({ preset: 'full', theme: 'dracula', icons: 'nerd', colorMode: 'truecolor' });
+    // Dracula cyan: rgb(139, 233, 253)
+    expect(out).toContain('\x1b[38;2;139;233;253m');
+  });
+
+  it('named color mode does not emit 24-bit RGB escapes', () => {
+    const out = buildPreview({ preset: 'full', theme: 'dracula', icons: 'nerd', colorMode: 'named' });
+    expect(out).not.toContain('\x1b[38;2;');
+  });
+
+  it('icons="none" produces no Nerd Font codepoints (e.g. no \\uE000+ range)', () => {
+    const out = buildPreview({ preset: 'full', icons: 'none' });
+    expect(/[\uE000-\uF8FF]/.test(out)).toBe(false);
+  });
+
+  it('returns "(preview unavailable)" when render throws', () => {
+    // Simulate by providing an impossible preset value via cast
+    const out = buildPreview({ preset: 'xx' as unknown as 'full', icons: 'nerd' });
+    // invalid preset still renders with defaults — this test pins the fallback
+    // by injecting a broken renderer; see buildPreview opts
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it('catches renderer exceptions and returns fallback', () => {
+    const out = buildPreview({ preset: 'balanced', icons: 'nerd' }, {
+      render: () => { throw new Error('boom'); },
+    });
+    expect(out).toBe('(preview unavailable)');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — they should fail**
+
+Run: `npx vitest run tests/tui/preview.test.ts`
+Expected: FAIL with import error.
+
+- [ ] **Step 3: Create src/tui/preview.ts**
+
+```ts
+import { render as defaultRender } from '../render/index.js';
+import { createIcons } from '../render/icons.js';
+import { DEFAULT_CONFIG, DEFAULT_DISPLAY, type HudConfig, type RenderContext } from '../types.js';
+import type { ColorMode } from '../render/colors.js';
+
+export interface PreviewOpts {
+  preset: HudConfig['preset'];
+  theme?: string;
+  icons: 'nerd' | 'emoji' | 'none';
+  colorMode?: ColorMode;
+}
+
+export interface BuildPreviewDeps {
+  render?: (ctx: RenderContext) => string;
+}
+
+function buildMockContext(opts: PreviewOpts): RenderContext {
+  const config: HudConfig = {
+    ...DEFAULT_CONFIG,
+    preset: opts.preset,
+    icons: opts.icons,
+    theme: opts.theme,
+    display: { ...DEFAULT_DISPLAY },
+    colors: { mode: opts.colorMode ?? 'truecolor' },
+  };
+
+  // Apply preset if valid (uses config.ts's applyPreset semantics inline)
+  // Minimal inline: we call loadConfig-like logic by constructing via raw object
+  // would be overkill — we just fill display from DEFAULT_DISPLAY and let render
+  // handle layout via config.layout (left as DEFAULT_CONFIG.layout).
+  //
+  // For faithful preview, mimic applyPreset's effect on layout:
+  if (opts.preset === 'minimal') config.layout = 'singleline';
+  else if (opts.preset === 'balanced') config.layout = 'auto';
+  else if (opts.preset === 'full') config.layout = 'multiline';
+
+  return {
+    input: {
+      raw: { model: { display_name: 'Claude Sonnet 4.6', id: 'claude-sonnet-4-6' } },
+      cwd: '/home/carlos/projects/lumira',
+      platform: 'claude-code',
+      tokens: { input: 12_000, output: 1_800, cached: 0, total: 13_800 },
+      costUsd: 0.42,
+      contextTokens: 80_000,
+      windowSize: 200_000,
+      gitBranch: 'main',
+    } as unknown as RenderContext['input'],
+    git: { branch: 'main', added: 3, modified: 2, deleted: 0 } as unknown as RenderContext['git'],
+    transcript: { todos: [], tools: [], messages: 0, duration: 0 } as unknown as RenderContext['transcript'],
+    config,
+    cols: 120,
+    icons: createIcons(opts.icons),
+  };
+}
+
+export function buildPreview(opts: PreviewOpts, deps: BuildPreviewDeps = {}): string {
+  const render = deps.render ?? defaultRender;
+  try {
+    const ctx = buildMockContext(opts);
+    return render(ctx);
+  } catch {
+    return '(preview unavailable)';
+  }
+}
+```
+
+Note: the mock shape above uses `as unknown as` casts to match `RenderContext` without pulling every nested field. If the real `RenderContext` types complain, inspect `src/types.ts` and `src/normalize.ts` for the exact `NormalizedInput`, `GitStatus`, and `TranscriptData` shapes and fill in just enough fields — only what `renderLine1/2/3/4` and `renderMinimal` actually read (search for `.` accesses inside those files). Do not leak `undefined` into fields that the renderer indexes without null checks.
+
+- [ ] **Step 4: Run tests; if type errors or render crashes, inspect the renderer and fill mock fields**
+
+Run: `npm run lint && npx vitest run tests/tui/preview.test.ts`
+
+If tests fail due to missing fields, grep the renderers for every `ctx.input.X`, `ctx.git.Y`, `ctx.transcript.Z` access and populate those fields in the mock. This iteration loop may take 2–3 rounds.
+
+Expected after iteration: all 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/preview.ts tests/tui/preview.test.ts
+git commit -m "feat(tui): preview generator for the install wizard
+
+Builds a RenderContext with realistic mock data and invokes render()
+to produce a live preview of the statusline. Wraps the renderer in
+try/catch; returns '(preview unavailable)' on failure so the wizard
+can't be taken down by a broken preview input.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Installer wizard orchestration
+
+**Files:**
+- Create: `src/installer-wizard.ts`
+- Create: `tests/installer-wizard.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/installer-wizard.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { runWizard } from '../src/installer-wizard.js';
+import { createMockStdin, createMockStdout } from './tui/_mock-stdin.js';
+
+async function flushMicrotasks() { await new Promise((r) => setImmediate(r)); }
+
+describe('runWizard', () => {
+  it('three Enters accept defaults: preset=balanced, no theme, icons=nerd', async () => {
+    const stdin = createMockStdin(true);
+    const stdout = createMockStdout();
+    const p = runWizard({ stdin, stdout, current: {} });
+
+    await flushMicrotasks();
+    stdin.pressKey('return'); // step 1: preset=balanced (default initial)
+    await flushMicrotasks();
+    stdin.pressKey('return'); // step 2: theme=(none)
+    await flushMicrotasks();
+    stdin.pressKey('return'); // step 3: icons=nerd
+
+    const result = await p;
+    expect(result).toEqual({ preset: 'balanced', icons: 'nerd' });
+    expect('theme' in (result ?? {})).toBe(false);
+  });
+
+  it('down+Enter on step 1 picks minimal', async () => {
+    const stdin = createMockStdin(true);
+    const stdout = createMockStdout();
+    const p = runWizard({ stdin, stdout, current: {} });
+
+    await flushMicrotasks();
+    stdin.pressKey('down'); stdin.pressKey('return'); // minimal
+    await flushMicrotasks();
+    stdin.pressKey('return'); // theme (none)
+    await flushMicrotasks();
+    stdin.pressKey('return'); // icons nerd
+
+    expect(await p).toEqual({ preset: 'minimal', icons: 'nerd' });
+  });
+
+  it('Esc at any step resolves with null', async () => {
+    const stdin = createMockStdin(true);
+    const stdout = createMockStdout();
+    const p = runWizard({ stdin, stdout, current: {} });
+
+    await flushMicrotasks();
+    stdin.pressKey('escape');
+
+    expect(await p).toBeNull();
+  });
+
+  it('pre-selects values from current config', async () => {
+    const stdin = createMockStdin(true);
+    const stdout = createMockStdout();
+    const p = runWizard({
+      stdin, stdout,
+      current: { preset: 'full', theme: 'dracula', icons: 'emoji' },
+    });
+
+    await flushMicrotasks();
+    stdin.pressKey('return'); // accept full
+    await flushMicrotasks();
+    stdin.pressKey('return'); // accept dracula
+    await flushMicrotasks();
+    stdin.pressKey('return'); // accept emoji
+
+    expect(await p).toEqual({ preset: 'full', theme: 'dracula', icons: 'emoji' });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — should fail**
+
+Run: `npx vitest run tests/installer-wizard.test.ts`
+Expected: FAIL (module missing).
+
+- [ ] **Step 3: Implement src/installer-wizard.ts**
+
+```ts
+import { interactiveSelect, type SelectOption } from './tui/select.js';
+import { buildPreview } from './tui/preview.js';
+import { THEMES } from './themes.js';
+
+export interface WizardCurrent {
+  preset?: 'full' | 'balanced' | 'minimal';
+  theme?: string;
+  icons?: 'nerd' | 'emoji' | 'none';
+}
+
+export interface RunWizardOpts {
+  current: WizardCurrent;
+  stdin?: NodeJS.ReadStream;
+  stdout?: NodeJS.WriteStream;
+}
+
+export interface WizardResult {
+  preset: 'full' | 'balanced' | 'minimal';
+  theme?: string;
+  icons: 'nerd' | 'emoji' | 'none';
+}
+
+const PRESET_OPTIONS: SelectOption<'full' | 'balanced' | 'minimal'>[] = [
+  { label: 'full',     value: 'full',     description: '▸ everything on, 4 lines' },
+  { label: 'balanced', value: 'balanced', description: '▸ essentials, auto-compact' },
+  { label: 'minimal',  value: 'minimal',  description: '▸ single line, just the basics' },
+];
+
+const ICON_OPTIONS: SelectOption<'nerd' | 'emoji' | 'none'>[] = [
+  { label: 'nerd',  value: 'nerd',  description: '▸ Nerd Font icons (default)' },
+  { label: 'emoji', value: 'emoji', description: '▸ Unicode emoji icons' },
+  { label: 'none',  value: 'none',  description: '▸ no icons, ASCII fallbacks' },
+];
+
+const NONE_THEME = '__none__';
+function themeOptions(): SelectOption<string>[] {
+  const names = Object.keys(THEMES);
+  return [
+    { label: '(none)', value: NONE_THEME },
+    ...names.map((n) => ({ label: n, value: n })),
+  ];
+}
+
+export async function runWizard(opts: RunWizardOpts): Promise<WizardResult | null> {
+  const { current, stdin, stdout } = opts;
+
+  const preset = await interactiveSelect({
+    title: 'lumira setup · step 1/3 — preset',
+    options: PRESET_OPTIONS,
+    initial: current.preset ?? 'balanced',
+    preview: (v) => buildPreview({ preset: v, theme: current.theme, icons: current.icons ?? 'nerd' }),
+    stdin, stdout,
+  });
+  if (preset === null) return null;
+
+  const themeValue = await interactiveSelect({
+    title: 'lumira setup · step 2/3 — theme',
+    options: themeOptions(),
+    initial: current.theme ?? NONE_THEME,
+    preview: (v) => buildPreview({ preset, theme: v === NONE_THEME ? undefined : v, icons: current.icons ?? 'nerd' }),
+    stdin, stdout,
+  });
+  if (themeValue === null) return null;
+  const theme = themeValue === NONE_THEME ? undefined : themeValue;
+
+  const icons = await interactiveSelect({
+    title: 'lumira setup · step 3/3 — icons',
+    options: ICON_OPTIONS,
+    initial: current.icons ?? 'nerd',
+    preview: (v) => buildPreview({ preset, theme, icons: v }),
+    stdin, stdout,
+  });
+  if (icons === null) return null;
+
+  const result: WizardResult = { preset, icons };
+  if (theme !== undefined) result.theme = theme;
+  return result;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run tests/installer-wizard.test.ts`
+Expected: all 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/installer-wizard.ts tests/installer-wizard.test.ts
+git commit -m "feat(installer): wizard orchestration (preset → theme → icons)
+
+Wires three interactiveSelect calls with a live buildPreview callback.
+Pre-selects values from the user's current config.json. Esc at any
+step bubbles up as null for a clean abort.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Note: `[Back]` navigation between steps is deferred from this task. It's a UX polish — add it as a follow-up task if needed. The spec listed it; if required, extend `interactiveSelect` to support an extra `goBack` signal via Left arrow or a `[ Back ]` pseudo-option and have `runWizard` loop back. Flag for review before implementing.
+
+---
+
+## Task 10: Installer integration — wizard hookup, defaults, banner
+
+**Files:**
+- Modify: `src/installer.ts`
+- Modify: `tests/installer.test.ts`
+
+- [ ] **Step 1: Read the current installer**
+
+Read `src/installer.ts` fully to see the existing `install()` flow and its signature.
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `tests/installer.test.ts`:
+
+```ts
+import { createMockStdin, createMockStdout } from './tui/_mock-stdin.js';
+
+describe('install — wizard integration', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'lumira-wizard-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('writes config.json with wizard result after wizard completes', async () => {
+    const settingsPath = join(dir, 'settings.json');
+    const configPath = join(dir, 'config.json');
+    const stdin = createMockStdin(true);
+    const stdout = createMockStdout();
+
+    const promise = install({
+      settingsPath,
+      configPath,
+      confirm: async () => true,
+      stdin, stdout,
+    });
+
+    // defaults: preset=balanced, theme=none, icons=nerd
+    await new Promise((r) => setImmediate(r));
+    stdin.pressKey('return');
+    await new Promise((r) => setImmediate(r));
+    stdin.pressKey('return');
+    await new Promise((r) => setImmediate(r));
+    stdin.pressKey('return');
+
+    await promise;
+    const cfg = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(cfg).toEqual({ preset: 'balanced', icons: 'nerd' });
+  });
+
+  it('skips wizard and writes defaults when stdin is not a TTY', async () => {
+    const settingsPath = join(dir, 'settings.json');
+    const configPath = join(dir, 'config.json');
+    const stdin = createMockStdin(false);
+
+    const output = await install({
+      settingsPath,
+      configPath,
+      confirm: async () => true,
+      stdin,
+    });
+
+    const cfg = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(cfg).toEqual({ preset: 'balanced', icons: 'nerd' });
+    expect(output).toContain('Non-interactive');
+  });
+
+  it('aborts cleanly when user Escs — no settings.json, no config.json', async () => {
+    const settingsPath = join(dir, 'settings.json');
+    const configPath = join(dir, 'config.json');
+    const stdin = createMockStdin(true);
+
+    const promise = install({ settingsPath, configPath, confirm: async () => true, stdin });
+    await new Promise((r) => setImmediate(r));
+    stdin.pressKey('escape');
+
+    const output = await promise;
+    expect(existsSync(settingsPath)).toBe(false);
+    expect(existsSync(configPath)).toBe(false);
+    expect(output).toContain('cancelled');
+  });
+
+  it('preserves unrelated keys when config.json already has user edits', async () => {
+    const configPath = join(dir, 'config.json');
+    writeFileSync(configPath, JSON.stringify({ display: { tokens: false } }));
+    const settingsPath = join(dir, 'settings.json');
+    const stdin = createMockStdin(false);
+
+    await install({ settingsPath, configPath, confirm: async () => true, stdin });
+    const cfg = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(cfg.display).toEqual({ tokens: false });
+    expect(cfg.preset).toBe('balanced');
+  });
+});
+```
+
+- [ ] **Step 3: Run tests — they should fail**
+
+Run: `npx vitest run tests/installer.test.ts`
+Expected: new tests FAIL (install doesn't accept new opts yet).
+
+- [ ] **Step 4: Refactor install() in src/installer.ts**
+
+Update `src/installer.ts`:
+
+1. Extend `InstallerOptions`:
+
+```ts
+export interface InstallerOptions {
+  settingsPath?: string;
+  configPath?: string;
+  confirm?: (prompt: string) => Promise<boolean>;
+  stdin?: NodeJS.ReadStream;
+  stdout?: NodeJS.WriteStream;
+}
+```
+
+2. Add helper for the default config path:
+
+```ts
+function defaultConfigPath(): string {
+  return join(homedir(), '.config', 'lumira', 'config.json');
+}
+```
+
+3. Import wizard + saveConfig + banner at the top:
+
+```ts
+import { runWizard, type WizardResult } from './installer-wizard.js';
+import { saveConfig } from './config.js';
+import { getBanner, getSubtitle } from './tui/banner.js';
+import { loadConfig } from './config.js';
+```
+
+4. Refactor `install()` to:
+   - Print banner (via `stdout.write(getBanner({ width: (opts.stdout ?? process.stdout).columns }))` + subtitle).
+   - Load current config (if any) via `loadConfig(dirname(configPath))` — reuse existing function.
+   - Detect TTY via `(opts.stdin ?? process.stdin).isTTY`.
+   - If TTY: call `runWizard({ current, stdin: opts.stdin, stdout: opts.stdout })`. If it returns `null`, print "Setup cancelled — no changes made." and return early (NO writes).
+   - If not TTY: use `{ preset: 'balanced', icons: 'nerd' }` as the wizard result and append "Non-interactive mode — defaults applied." to the output.
+   - Continue with existing settings.json write.
+   - After settings write, call `saveConfig(wizardResult, configPath ?? defaultConfigPath())`.
+   - Existing `installSkill()` call remains (Task 11 extends it to Qwen).
+
+The refactored `install()` sketch (keep existing logic for settings.json merge/backup intact — only insert wizard and saveConfig calls):
+
+```ts
+export async function install(opts: InstallerOptions = {}): Promise<string> {
+  const settingsPath = opts.settingsPath ?? defaultSettingsPath();
+  const configPath = opts.configPath ?? defaultConfigPath();
+  const stdin = opts.stdin ?? process.stdin;
+  const stdout = opts.stdout ?? process.stdout;
+  const backupPath = settingsPath + '.lumira.bak';
+  const confirm = opts.confirm ?? promptYN;
+  const lines: string[] = [];
+
+  // Banner
+  const banner = getBanner({ width: stdout.columns ?? 80 });
+  if (banner) lines.push(banner);
+  lines.push(' ' + getSubtitle() + '\n');
+
+  // Read current lumira config (for wizard pre-selection) — ignore file-not-found
+  const current = loadConfig(dirname(configPath));
+  const wizardCurrent = {
+    preset: current.preset,
+    theme: current.theme,
+    icons: current.icons,
+  };
+
+  // Run wizard or fall back to defaults
+  let wizard: WizardResult;
+  if (stdin.isTTY) {
+    const w = await runWizard({ current: wizardCurrent, stdin, stdout });
+    if (w === null) {
+      lines.push('\n  ⚠ Setup cancelled — no changes made.\n');
+      return lines.join('\n') + '\n';
+    }
+    wizard = w;
+  } else {
+    wizard = { preset: 'balanced', icons: 'nerd' };
+    lines.push('  ℹ Non-interactive mode — defaults applied.\n');
+  }
+
+  // ... existing settings.json logic (read, check statusLine, backup, write)
+  //     leave that code unchanged. At the end of the successful write path,
+  //     insert saveConfig(wizard, configPath).
+
+  // Save wizard config
+  saveConfig(wizard, configPath);
+  lines.push(ok(`Saved config → ${DIM}${configPath}${RST}`));
+
+  // Install /lumira skill (existing call — Task 11 extends it)
+  lines.push(...installSkill());
+
+  lines.push(`\n  Restart Claude Code to see your statusline.\n`);
+  return lines.join('\n') + '\n';
+}
+```
+
+Important: keep the existing statusLine read/write/backup logic verbatim. The wizard runs BEFORE statusLine write per the spec — but the current code uses `await confirm(...)` which is synchronous-waiting. Preserve that flow by running the wizard first and, if user confirms, proceeding to the backup+write. If wizard aborts, neither statusLine nor config.json are written.
+
+Precise ordering in the rewritten function:
+1. Banner.
+2. Read current config.json (for wizard pre-selection).
+3. Run wizard (or defaults if non-TTY). On null → return with "cancelled" message, write nothing.
+4. Read settings.json; if existing statusLine is non-lumira → `confirm()` before proceeding; if user says no → return without writing.
+5. Back up existing settings.json if replacing.
+6. Write settings.json with lumira statusLine.
+7. Write `saveConfig(wizard, configPath)`.
+8. Install skill (Task 11 adds Qwen path).
+9. Final summary.
+
+- [ ] **Step 5: Run tests**
+
+Run: `npx vitest run tests/installer.test.ts`
+Expected: all tests PASS, including existing ones and the 4 new ones.
+
+- [ ] **Step 6: Run full suite + lint**
+
+Run: `npm test && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/installer.ts tests/installer.test.ts
+git commit -m "feat(installer): integrate wizard, banner, and config save
+
+install() now prints the ASCII banner, runs the interactive wizard
+(or falls back to defaults on non-TTY), and writes the chosen
+preset/theme/icons to ~/.config/lumira/config.json via atomic
+saveConfig. Esc aborts cleanly with no file writes.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Skill dual-install for Qwen Code
+
+**Files:**
+- Modify: `src/installer.ts` (`installSkill`, `uninstall`)
+- Modify: `tests/installer.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/installer.test.ts`:
+
+```ts
+describe('install — skill dual install for Qwen', () => {
+  let dir: string;
+  let claudeHome: string;
+  let qwenHome: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'lumira-qwen-'));
+    claudeHome = join(dir, '.claude');
+    qwenHome = join(dir, '.qwen');
+    mkdirSync(claudeHome, { recursive: true });
+  });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('installs skill only under claude when ~/.qwen/ does not exist', async () => {
+    const settingsPath = join(claudeHome, 'settings.json');
+    const configPath = join(dir, 'config.json');
+    const stdin = createMockStdin(false);
+
+    await install({
+      settingsPath,
+      configPath,
+      confirm: async () => true,
+      stdin,
+      homeOverride: dir, // allows installSkill to resolve skill dest under our tmp dir
+    });
+
+    expect(existsSync(join(claudeHome, 'skills', 'lumira', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(qwenHome, 'skills', 'lumira', 'SKILL.md'))).toBe(false);
+  });
+
+  it('installs skill under both claude and qwen when ~/.qwen/ exists', async () => {
+    mkdirSync(qwenHome, { recursive: true });
+    const settingsPath = join(claudeHome, 'settings.json');
+    const configPath = join(dir, 'config.json');
+    const stdin = createMockStdin(false);
+
+    await install({
+      settingsPath,
+      configPath,
+      confirm: async () => true,
+      stdin,
+      homeOverride: dir,
+    });
+
+    expect(existsSync(join(claudeHome, 'skills', 'lumira', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(qwenHome, 'skills', 'lumira', 'SKILL.md'))).toBe(true);
+  });
+
+  it('uninstall removes skill from both destinations', async () => {
+    mkdirSync(join(claudeHome, 'skills', 'lumira'), { recursive: true });
+    writeFileSync(join(claudeHome, 'skills', 'lumira', 'SKILL.md'), 'dummy');
+    mkdirSync(join(qwenHome, 'skills', 'lumira'), { recursive: true });
+    writeFileSync(join(qwenHome, 'skills', 'lumira', 'SKILL.md'), 'dummy');
+
+    const settingsPath = join(claudeHome, 'settings.json');
+    writeFileSync(settingsPath, JSON.stringify({ statusLine: { command: 'npx lumira@latest' } }));
+
+    uninstall({ settingsPath, homeOverride: dir });
+
+    expect(existsSync(join(claudeHome, 'skills', 'lumira', 'SKILL.md'))).toBe(false);
+    expect(existsSync(join(qwenHome, 'skills', 'lumira', 'SKILL.md'))).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — should fail**
+
+Run: `npx vitest run tests/installer.test.ts -t 'dual install'`
+Expected: FAIL (no `homeOverride` support; skill goes to real `~/.claude`).
+
+- [ ] **Step 3: Extend installSkill and uninstall**
+
+In `src/installer.ts`:
+
+1. Add `homeOverride?: string` to `InstallerOptions`.
+2. Refactor `installSkill()` to take an options object:
+
+```ts
+function installSkill(opts: { homeOverride?: string } = {}): string[] {
+  const lines: string[] = [];
+  const home = opts.homeOverride ?? homedir();
+
+  const thisDir = dirname(fileURLToPath(import.meta.url));
+  const srcFile = resolve(thisDir, '..', 'skills', 'lumira', 'SKILL.md');
+
+  if (!existsSync(srcFile)) {
+    lines.push(warn('Skill file not found in package — skipping /lumira skill'));
+    return lines;
+  }
+
+  const destinations = [
+    { label: 'claude', dir: join(home, '.claude') },
+    { label: 'qwen',   dir: join(home, '.qwen')   },
+  ];
+
+  for (const { label, dir } of destinations) {
+    // Install claude always; qwen only if dir exists
+    if (label === 'qwen' && !existsSync(dir)) continue;
+    const destDir = join(dir, 'skills', 'lumira');
+    const destFile = join(destDir, 'SKILL.md');
+    try {
+      mkdirSync(destDir, { recursive: true });
+      copyFileSync(srcFile, destFile);
+      lines.push(ok(`Installed ${DIM}/lumira${RST} skill → ${DIM}${destDir}/${RST}`));
+    } catch {
+      lines.push(warn(`Could not install /lumira skill to ${destDir}`));
+    }
+  }
+
+  return lines;
+}
+```
+
+3. Update `uninstall()` to also remove Qwen skill:
+
+```ts
+export function uninstall(opts: InstallerOptions = {}): string {
+  const settingsPath = opts.settingsPath ?? defaultSettingsPath();
+  const home = opts.homeOverride ?? homedir();
+  // ... existing settings restoration logic
+
+  // Remove skills from both destinations
+  for (const root of [join(home, '.claude'), join(home, '.qwen')]) {
+    const skillFile = join(root, 'skills', 'lumira', 'SKILL.md');
+    if (existsSync(skillFile)) {
+      try {
+        unlinkSync(skillFile);
+        // try to rmdir the now-empty skills/lumira/ dir — best effort, ignore errors
+        try { rmdirSync(dirname(skillFile)); } catch { /* not empty; fine */ }
+      } catch { /* skip */ }
+    }
+  }
+  // ... return lines as before
+}
+```
+
+Add `rmdirSync` to the `node:fs` import block at the top of `installer.ts`.
+
+Also update call site in `install()` to pass `homeOverride`:
+
+```ts
+lines.push(...installSkill({ homeOverride: opts.homeOverride }));
+```
+
+And extend the Qwen detection note in the final summary (inside `install()`):
+
+```ts
+if (existsSync(join(opts.homeOverride ?? homedir(), '.qwen'))) {
+  lines.push('\n  ℹ Qwen Code detected — in Qwen sessions, lumira renders');
+  lines.push('    single-line automatically. Your preset above applies to Claude Code.\n');
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run tests/installer.test.ts`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Run full suite**
+
+Run: `npm test`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/installer.ts tests/installer.test.ts
+git commit -m "feat(installer): install /lumira skill for Qwen Code when detected
+
+If ~/.qwen/ exists, also copy SKILL.md to ~/.qwen/skills/lumira/.
+Uninstall removes the skill from both destinations. Final install
+summary includes a Qwen detection notice when applicable.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: SKILL.md Platform Support section + CHANGELOG
+
+**Files:**
+- Modify: `skills/lumira/SKILL.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Edit SKILL.md**
+
+Insert new section in `skills/lumira/SKILL.md` right after the `## Available Settings` block (before `## Example Configs`):
+
+```markdown
+## Platform Support
+
+Lumira auto-detects the caller's platform:
+
+- **Claude Code** — renders per your configured `layout` / `preset`.
+- **Qwen Code** — renders compact single-line output automatically, regardless of `layout`. Qwen Code only displays the first line of statusline commands, so lumira always uses the single-line renderer (which fits model, branch, context bar, cost, cached tokens, and thoughts into one line).
+
+No configuration needed. One `config.json` serves both CLIs.
+```
+
+Also verify the Presets section lists only `full` / `balanced` / `minimal` — it already does. If you see `qwen` listed, remove it.
+
+- [ ] **Step 2: Update CHANGELOG.md**
+
+Prepend to `CHANGELOG.md` a new entry (match the existing style of the file):
+
+```markdown
+## [Unreleased]
+
+### Added
+- Interactive install wizard (`lumira install`): choose preset, theme, and icons with arrow-key navigation and live preview.
+- ASCII banner with dynamic version from `package.json`.
+- `/lumira` skill is now installed for Qwen Code as well, when `~/.qwen/` is detected.
+- Render layer now auto-switches to single-line output when the caller is Qwen Code.
+
+### Changed
+- `saveConfig` writes `~/.config/lumira/config.json` atomically (tmp file + rename) with 0o600 permissions.
+
+### Removed
+- **BREAKING:** `qwen` preset removed. It was functionally identical to `minimal`; the render layer now auto-switches for Qwen Code so the alias no longer serves a purpose. Existing configs with `preset: "qwen"` are coerced to `minimal` with a one-shot stderr warning. CLI flag `--qwen` is removed; use `--minimal` instead.
+```
+
+Verify the top of `CHANGELOG.md` first to match the project's exact header style — adjust heading level / section names accordingly if different.
+
+- [ ] **Step 3: Run full suite one last time**
+
+Run: `npm test && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/lumira/SKILL.md CHANGELOG.md
+git commit -m "docs: document Qwen auto-detect and v0.4 breaking changes
+
+Adds a Platform Support section to the /lumira skill explaining the
+qwen auto-switch. Updates CHANGELOG with the wizard feature, Qwen
+skill dual-install, render auto-switch, and the removal of the
+qwen preset.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- ✅ Render-layer Qwen fix → Task 1
+- ✅ Remove `qwen` preset + migration → Task 2
+- ✅ Atomic `saveConfig` → Task 3
+- ✅ ASCII banner with dynamic version → Task 4
+- ✅ TUI select helper (raw mode, navigation, abort, resize, cleanup) → Tasks 5, 6, 7
+- ✅ Preview generator → Task 8
+- ✅ Wizard orchestration (preset → theme → icons, pre-selection) → Task 9
+- ✅ Installer integration (wizard hookup, non-TTY defaults, no-write-on-abort) → Task 10
+- ✅ Skill dual-install for Qwen + uninstall cleanup + Qwen detection notice → Task 11
+- ✅ SKILL.md Platform Support + CHANGELOG breaking-change entry → Task 12
+
+**Gaps or deferred items:**
+- `[ Back ]` navigation between wizard steps (spec called it out) is deferred as a UX polish — flagged in Task 9 Step 5 as a follow-up. The core wizard ships without it; Esc is the recovery path.
+- The stderr migration warning in Task 2 uses a module-level `qwenWarningShown` flag. Per-process single warning — acceptable; not per-invocation.
+
+**Placeholder scan:** no "TBD", "TODO", or "fill in" strings in the plan. Every code step contains the actual code.
+
+**Type consistency:** `WizardResult` defined in Task 3 (exported from config.ts) is re-exported/shadowed from `src/installer-wizard.ts` in Task 9. This is minor duplication; if a reviewer wants, collapse into a single definition in `src/types.ts` before landing. Flagged but not blocking.

--- a/docs/superpowers/specs/2026-04-20-install-wizard-design.md
+++ b/docs/superpowers/specs/2026-04-20-install-wizard-design.md
@@ -30,7 +30,7 @@ Today, `lumira install` silently writes a `statusLine` entry to `~/.claude/setti
 
 - `src/tui/select.ts` — generic `interactiveSelect<T>()` helper. Owns raw-mode setup, keypress handling, render loop, cleanup, and resize handling. ~200 LOC. Knows nothing about lumira.
 - `src/tui/preview.ts` — builds a mock `RenderContext` with realistic sample data and calls `render()` to produce a string preview. Used by the wizard to paint the preview pane.
-- `src/installer-wizard.ts` — orchestrates the three-step flow (preset → theme → icons). Calls `interactiveSelect` three times, passing a `preview(choice)` function per step. Returns `{ preset, theme, icons } | null`.
+- `src/installer-wizard.ts` — orchestrates the three-step flow (preset → theme → icons). Calls `interactiveSelect` three times, passing a `preview(choice)` function per step. Returns `WizardResult | null`, where `WizardResult = { preset: string; theme?: string; icons: string }` — `theme` is omitted entirely when user picks `(none)`.
 - `src/tui/banner.ts` — exports the ASCII banner string and a `printBanner()` helper that reads version from `package.json` and omits the banner on terminals under 50 columns.
 - `tests/tui/select.test.ts` — TUI helper tests with a mock stdin that supports synthetic `keypress` events.
 - `tests/tui/preview.test.ts` — preview generator tests.
@@ -296,7 +296,7 @@ A once-only handler that unconditionally calls `setRawMode(false)` and writes th
 
 ### `tests/installer-wizard.test.ts`
 
-- Happy path: three Enters accept defaults, returns `{ preset: 'balanced', theme: null, icons: 'nerd' }`.
+- Happy path: three Enters accept defaults, returns `{ preset: 'balanced', icons: 'nerd' }` (theme omitted since `(none)` is the initial focus).
 - Down+Enter on step 1 selects `minimal`.
 - `[ Back ]` from step 2 returns to step 1 with prior choice focused.
 - Esc at any step resolves with `null`; no disk writes observed.

--- a/docs/superpowers/specs/2026-04-20-install-wizard-design.md
+++ b/docs/superpowers/specs/2026-04-20-install-wizard-design.md
@@ -1,0 +1,358 @@
+# Install Wizard Design
+
+Date: 2026-04-20
+Status: Approved for implementation
+Scope: `npx lumira install` becomes interactive — preset, theme, and icons selection with live preview. Writes `~/.config/lumira/config.json`. Skill installs for both Claude Code and Qwen Code when detected. Removes the `qwen` preset and auto-switches to singleline rendering when Qwen is the caller.
+
+## Summary
+
+Today, `lumira install` silently writes a `statusLine` entry to `~/.claude/settings.json` and copies a skill file. Users must discover presets, themes, and icon modes from the README and hand-edit `~/.config/lumira/config.json`. This spec introduces a zero-dependency interactive TUI that runs during install, guiding the user through three selections with a live rendered preview. A latent dual-platform rendering gap (Qwen Code truncates multi-line output) is fixed at the render layer as part of the same feature.
+
+## Goals
+
+- First-run `lumira install` guides the user through preset / theme / icons selection.
+- Re-running `lumira install` re-opens the wizard with current values pre-selected.
+- Live preview shows a realistic rendered statusline that updates as the user navigates.
+- Qwen Code users get a correct compact statusline automatically, regardless of configured preset.
+- Install writes the `/lumira` skill to both `~/.claude/skills/lumira/` and `~/.qwen/skills/lumira/` when Qwen Code is detected.
+- Zero new runtime dependencies.
+
+## Non-goals
+
+- Per-CLI configuration sections inside `config.json` (both CLIs share one config).
+- Configuring Qwen Code's statusline entry (`~/.qwen/settings.json`) from this installer.
+- Internationalization — wizard strings are English-only.
+- Windows native terminal polish beyond best-effort.
+
+## Architecture
+
+### New files
+
+- `src/tui/select.ts` — generic `interactiveSelect<T>()` helper. Owns raw-mode setup, keypress handling, render loop, cleanup, and resize handling. ~200 LOC. Knows nothing about lumira.
+- `src/tui/preview.ts` — builds a mock `RenderContext` with realistic sample data and calls `render()` to produce a string preview. Used by the wizard to paint the preview pane.
+- `src/installer-wizard.ts` — orchestrates the three-step flow (preset → theme → icons). Calls `interactiveSelect` three times, passing a `preview(choice)` function per step. Returns `{ preset, theme, icons } | null`.
+- `src/tui/banner.ts` — exports the ASCII banner string and a `printBanner()` helper that reads version from `package.json` and omits the banner on terminals under 50 columns.
+- `tests/tui/select.test.ts` — TUI helper tests with a mock stdin that supports synthetic `keypress` events.
+- `tests/tui/preview.test.ts` — preview generator tests.
+- `tests/installer-wizard.test.ts` — end-to-end wizard orchestration tests.
+
+### Modified files
+
+- `src/installer.ts`
+  - `install()` runs the wizard BEFORE writing anything. On abort, exits cleanly with no file writes.
+  - `installSkill()` gains a second destination: if `~/.qwen/` exists, copy `SKILL.md` to `~/.qwen/skills/lumira/` as well.
+  - `uninstall()` removes skill from both `~/.claude/skills/lumira/` and `~/.qwen/skills/lumira/` when present.
+  - Prints the ASCII banner before the wizard and before uninstall output.
+- `src/config.ts`
+  - Remove `qwen` from `validPresets` and from `PRESET_DEFS`.
+  - Remove `--qwen` and `qwen` from CLI-flag matchers.
+  - Add a one-shot migration: if `raw.preset === "qwen"` is seen, log once to stderr (`[lumira] 'qwen' preset is removed — using 'minimal' instead`) and coerce to `minimal`.
+  - Export new `saveConfig(config, path)` that merges with existing file and writes atomically (temp file + rename).
+- `src/render/index.ts`
+  - Change the layout branch condition so that Qwen input ALSO triggers `renderMinimal`, regardless of `ctx.config.layout`:
+    ```ts
+    const isQwen = ctx.input.platform === 'qwen-code';
+    if (isQwen || ctx.config.layout === 'singleline' || (ctx.config.layout === 'auto' && ctx.cols < 70)) {
+      return renderMinimal(ctx, c);
+    }
+    ```
+- `src/types.ts`
+  - Remove `'qwen'` from the `HudConfig['preset']` union.
+- `skills/lumira/SKILL.md`
+  - Add a "Platform Support" section noting that lumira auto-detects Qwen Code and renders compact single-line output in those sessions.
+- `tests/render/index.test.ts`, `tests/config.test.ts`
+  - Update tests referencing `qwen` preset. Add new tests per Test Strategy below.
+
+### Module boundaries
+
+- `src/tui/*` has no lumira-specific knowledge — it's a reusable TUI primitive.
+- `installer-wizard.ts` orchestrates wizard logic only — does not touch disk.
+- `installer.ts` owns all file writes. Calls wizard, receives a pure value, writes atomically.
+
+## UX flow
+
+### Entry
+
+```
+ \x1b[36m
+ ██╗     ██╗   ██╗███╗   ███╗██╗██████╗  █████╗ 
+ ██║     ██║   ██║████╗ ████║██║██╔══██╗██╔══██╗
+ ██║     ██║   ██║██╔████╔██║██║██████╔╝███████║
+ ██║     ██║   ██║██║╚██╔╝██║██║██╔══██╗██╔══██║
+ ███████╗╚██████╔╝██║ ╚═╝ ██║██║██║  ██║██║  ██║
+ ╚══════╝ ╚═════╝ ╚═╝     ╚═╝╚═╝╚═╝  ╚═╝╚═╝  ╚═╝
+ \x1b[0m
+ real-time statusline for claude code & qwen code · v{version}
+```
+
+Version read dynamically from `package.json` using `fileURLToPath(import.meta.url)` path resolution. Fallback: omit ` · v{version}` if read fails.
+
+### Step 1 of 3 — preset
+
+```
+ lumira setup · step 1/3 — preset
+
+ Pick a preset. Arrow keys to move, Enter to select, Esc to abort.
+
+ ❯ full      ▸ everything on, 4 lines
+   balanced  ▸ essentials, auto-compact
+   minimal   ▸ single line, just the basics
+
+ Preview:
+ ╭────────────────────────────────────────────────────╮
+ │ <real rendered statusline with focused option>     │
+ ╰────────────────────────────────────────────────────╯
+```
+
+- `❯` marks focused option. Preview reflects the focused option live (updates on every keypress).
+- Initial focus: current `config.json` preset, or `balanced` if absent or invalid.
+
+### Step 2 of 3 — theme
+
+```
+ lumira setup · step 2/3 — theme
+
+   [ Back ]
+ ❯ (none)
+   dracula    <inline color preview>
+   nord       <inline color preview>
+   tokyo-night <inline color preview>
+   catppuccin <inline color preview>
+   monokai    <inline color preview>
+
+ ⚠ your terminal doesn't support truecolor — themes will have no effect
+   (shown only when detectColorMode() !== 'truecolor')
+
+ Preview:
+ ╭────────────────────────────────────────────────────╮
+ │ <preset from step 1 + focused theme applied>       │
+ ╰────────────────────────────────────────────────────╯
+```
+
+- `[ Back ]` at top returns to step 1 with prior selection pre-focused.
+- Initial focus: current `config.json` theme, or `(none)` if absent.
+
+### Step 3 of 3 — icons
+
+```
+ lumira setup · step 3/3 — icons
+
+   [ Back ]
+ ❯ nerd   ▸ Nerd Font icons (default)
+   emoji  ▸ Unicode emoji icons
+   none   ▸ no icons, ASCII fallbacks
+
+ Preview:
+ ╭────────────────────────────────────────────────────╮
+ │ <preset + theme + focused icon set>                │
+ ╰────────────────────────────────────────────────────╯
+```
+
+- Initial focus: current `config.json` icons, or `nerd`.
+
+### Final summary
+
+```
+ ✓ Configured lumira as statusline
+ ✓ Saved config → ~/.config/lumira/config.json
+ ✓ Installed /lumira skill → ~/.claude/skills/lumira/
+ ✓ Installed /lumira skill → ~/.qwen/skills/lumira/     (only if ~/.qwen/ exists)
+
+ ℹ Qwen Code detected — in Qwen sessions, lumira renders single-line
+   automatically. Your preset above applies to Claude Code.
+   (shown only when `which qwen` succeeds)
+
+ Restart Claude Code to see your statusline.
+```
+
+### Controls (all steps)
+
+- `↑` / `↓` or `k` / `j` — navigate options (wrap on ends).
+- `Enter` — confirm focused option and advance. On `[ Back ]`, return to previous step.
+- `Esc` or `q` — abort wizard. No writes occur. Prints `⚠ Setup cancelled — no changes made.`, exit 1.
+- `Ctrl+C` — same as Esc, exit 130.
+
+### Pre-selection rules
+
+- Preset: read from existing `config.json`. If missing or invalid, default to `balanced`.
+- Theme: read from existing `config.json`. If missing, focus `(none)`.
+- Icons: read from existing `config.json`. If missing, focus `nerd`.
+
+## Data model
+
+### File: `~/.config/lumira/config.json`
+
+Schema written by the wizard:
+
+```json
+{
+  "preset": "balanced",
+  "theme": "dracula",
+  "icons": "nerd"
+}
+```
+
+Only these three keys are written. `display`, `colors`, `gsd`, `layout`, and any other keys the user has added by hand are preserved verbatim on merge.
+
+### Merge strategy
+
+1. Read existing `config.json`. On parse failure, warn and proceed with empty object.
+2. Deep-merge is NOT used. Only the three top-level keys `preset`, `theme`, `icons` are overwritten. Other keys pass through untouched.
+3. Write to temp file `config.json.tmp` with mode `0o600`, then `rename` to `config.json`. POSIX atomic.
+
+### Write order
+
+1. Wizard returns `{preset, theme, icons}` (or aborts and returns nothing).
+2. Write `~/.claude/settings.json` with the `statusLine` entry (existing behavior).
+3. Write `~/.config/lumira/config.json` with atomic merge.
+4. Install skill to `~/.claude/skills/lumira/SKILL.md`.
+5. If `~/.qwen/` exists, install skill to `~/.qwen/skills/lumira/SKILL.md`.
+6. Print summary with optional Qwen info note.
+
+If step 2 fails, abort. Steps 3-5 do not run. If step 3 fails after step 2 succeeded, user has a working lumira with default config — acceptable.
+
+## Signal handling and cleanup
+
+### State restored on any exit path
+
+- `process.stdin.setRawMode(false)`
+- `process.stdin.pause()`
+- `process.stdin.removeListener('keypress', ...)`
+- `process.removeListener('SIGINT', ...)` / `SIGTERM`
+- `process.stdout.write('\x1b[?25h')` — show cursor
+- `process.stdout.removeListener('resize', ...)` (if installed)
+
+### Helper pattern
+
+```ts
+async function interactiveSelect<T>(opts: SelectOpts<T>): Promise<T | null> {
+  if (!process.stdin.isTTY) return null;
+
+  const cleanup = () => { /* restore all state */ };
+
+  try {
+    readline.emitKeypressEvents(process.stdin);
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdout.write('\x1b[?25l'); // hide cursor
+    // install listeners (keypress, SIGINT, SIGTERM, resize)
+    return await new Promise<T | null>((resolve) => {
+      // resolve on Enter (value), Esc / Ctrl+C / SIGINT / SIGTERM (null)
+    });
+  } finally {
+    cleanup();
+  }
+}
+```
+
+### Defensive `process.on('exit')` handler
+
+A once-only handler that unconditionally calls `setRawMode(false)` and writes the show-cursor ANSI. Guards against `uncaughtException` and `process.exit()` from elsewhere. Does NOT touch listeners (exit is terminal).
+
+### Abort semantics
+
+- Any `null` return from `interactiveSelect` bubbles up through the wizard as a user cancel.
+- On cancel, installer writes nothing, prints the cancellation message, and exits with code 1 (Esc/q) or 130 (Ctrl+C).
+
+## Breaking changes
+
+### `qwen` preset removed
+
+- `validPresets` no longer includes `qwen`.
+- `--qwen` CLI flag is removed from argv parsing.
+- Existing configs with `preset: "qwen"` trigger a one-shot stderr warning on the first render:
+  `[lumira] 'qwen' preset is removed — using 'minimal' instead`
+  and are coerced to `minimal` at runtime. The next `lumira install` writes `minimal` to the file.
+- CHANGELOG entry under "Breaking changes" documents this with migration note: `--qwen` → `--minimal`.
+
+### Render layer — Qwen forces singleline
+
+- `render()` now returns `renderMinimal()` whenever `ctx.input.platform === 'qwen-code'`, overriding `config.layout`.
+- This restores the intended behavior: Qwen users see the rich compact line, not a truncated multi-line line 1.
+- No user-facing breaking change — only affects rendered output, and the new output is strictly more informative.
+
+## Test strategy
+
+### `tests/tui/select.test.ts`
+
+- Navigate down from last option wraps to first; up from first wraps to last.
+- `j`/`k` navigate identically to `↓`/`↑`.
+- `Enter` resolves with the focused option.
+- `Esc` resolves with `null`.
+- `Ctrl+C` resolves with `null` and triggers SIGINT cleanup.
+- Non-TTY stdin → immediate `null` without raw-mode setup.
+- `initial` parameter pre-focuses the correct option.
+- `preview(choice)` is invoked with the focused option on each keypress.
+- Cleanup: after resolution, `setRawMode(false)` was called, cursor-show ANSI was written, all listeners removed.
+- Resize event on stdout triggers re-render.
+
+### `tests/tui/preview.test.ts`
+
+- `buildPreview({ preset: 'balanced' })` returns non-empty string with model/branch/directory fields.
+- Preview with theme `dracula` in truecolor mode contains Dracula RGB codes.
+- Preview with `colors.mode === 'named'` contains no RGB escapes.
+- Preview with `icons: 'none'` contains no Nerd Font codepoints.
+- `buildPreview` wraps `render()` in try/catch; on render failure returns `(preview unavailable)`.
+
+### `tests/installer-wizard.test.ts`
+
+- Happy path: three Enters accept defaults, returns `{ preset: 'balanced', theme: null, icons: 'nerd' }`.
+- Down+Enter on step 1 selects `minimal`.
+- `[ Back ]` from step 2 returns to step 1 with prior choice focused.
+- Esc at any step resolves with `null`; no disk writes observed.
+
+### `tests/installer.test.ts` (extend existing)
+
+- TTY mocked + wizard happy path → `settings.json`, `config.json`, and `~/.claude/skills/lumira/SKILL.md` all written.
+- `~/.qwen/` mocked as existing → skill also copied to `~/.qwen/skills/lumira/SKILL.md`.
+- No TTY → wizard skipped, defaults written (`preset: "balanced"`, no theme, `icons: "nerd"`), non-interactive notice printed.
+- Existing `config.json` with custom `display.tokens: false` → merge preserves `display.tokens: false` and adds the three new keys.
+- Corrupt `config.json` → warn, overwrite cleanly with three keys.
+- Wizard aborted → no file mutations (verified by mtime or snapshot).
+- Uninstall with Qwen skill present → removes from both destinations.
+
+### `tests/render/index.test.ts`
+
+- `render(ctx)` with `ctx.input.platform === 'qwen-code'` and `ctx.config.layout === 'multiline'` → routes to `renderMinimal`.
+
+### `tests/config.test.ts`
+
+- Existing tests referencing `qwen` preset: migrate to `minimal`.
+- New test: `mergeConfig({ preset: 'qwen' })` returns valid config with `preset: 'minimal'` (coerced) and no crash.
+
+### Coverage target
+
+- 100% line and branch coverage on new code (`src/tui/*`, `src/installer-wizard.ts`, render-Qwen branch in `src/render/index.ts`).
+- Existing coverage levels maintained elsewhere.
+
+## Edge cases
+
+| Scenario | Behavior |
+|---|---|
+| No TTY (stdin piped) | Skip wizard, write defaults, print notice. Exit 0. |
+| Terminal < 50 cols | Banner hidden, wizard still runs with compact layout. |
+| Corrupt `config.json` | Warn, overwrite. |
+| `~/.config/lumira/` missing | `mkdirSync` with recursive. |
+| `~/.qwen/` missing | Skip Qwen skill; summary omits that line. |
+| `~/.qwen/skills/` missing but `~/.qwen/` exists | Create `skills/lumira/` recursively. |
+| EACCES on write | Clear error message, exit 1, no partial state. |
+| Ctrl+C during raw mode | Cleanup, cancel message, exit 130. |
+| Ctrl+C during write | Atomic `rename` guarantees `config.json` never half-written. |
+| Theme picked without truecolor | Value stored; `resolveTheme()` no-ops at runtime. Warning shown in wizard. |
+| `stdin` pipe closed (parent dies) | `'end'` event treated as abort. |
+
+## Risks and mitigations
+
+1. **Terminal left in raw mode on hard crash.** Mitigated by `try/finally` and defensive `exit` handler. Residual: Node SIGKILL (very low probability). User recovers with `reset` or new terminal.
+2. **TUI tests fragile against Node internals.** Mock encapsulated in one helper (`createMockStdin()`) — single point of adaptation.
+3. **Preview crashes if renderer fails on mock data.** `buildPreview` wraps `render()` in try/catch, returns fallback string.
+4. **Breaking change surprises users of `--qwen`.** CHANGELOG + one-shot stderr migration message + runtime coercion to `minimal` mean zero functional regression.
+5. **Qwen auto-detect surprises a user wanting multi-line in Qwen.** Hypothetical — Qwen only displays one line anyway. No real loss.
+6. **`~/.qwen/skills/` may not be the Qwen convention.** Directory exists on this machine, suggesting yes, but unverified against Qwen Code docs. Before implementation, verify. If uncertain, ship Claude-only install and file a follow-up issue for Qwen skill install.
+
+## Out-of-scope limitations
+
+- Windows native terminal polish.
+- `TERM=dumb` or non-ANSI terminals — recommendation: detect and fall back to text prompt (future).
+- i18n.
+- Per-CLI configuration sections.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "lumira — real-time statusline for Claude Code",
   "type": "module",
   "main": "dist/index.js",

--- a/skills/lumira/SKILL.md
+++ b/skills/lumira/SKILL.md
@@ -49,6 +49,15 @@ Each is a boolean (`true`/`false`):
 - `true` — show GSD task info
 - `false` — hide GSD section
 
+## Platform Support
+
+Lumira auto-detects the caller's platform:
+
+- **Claude Code** — renders per your configured `layout` / `preset`.
+- **Qwen Code** — renders compact single-line output automatically, regardless of `layout`. Qwen Code only displays the first line of statusline commands, so lumira always uses the single-line renderer (which fits model, branch, context bar, cost, cached tokens, and thoughts into one line).
+
+No configuration needed. One `config.json` serves both CLIs.
+
 ## Example Configs
 
 Minimal with emoji icons:

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,9 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { DEFAULT_CONFIG, DEFAULT_DISPLAY, type HudConfig, type DisplayToggles, type ColorConfig } from './types.js';
 
+let qwenWarningShown = false;
+export function _resetMigrationFlags(): void { qwenWarningShown = false; }
+
 export function loadConfig(configDir: string = join(homedir(), '.config', 'lumira')): HudConfig {
   const p = join(configDir, 'config.json');
   if (!existsSync(p)) return { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } };
@@ -12,7 +15,15 @@ export function loadConfig(configDir: string = join(homedir(), '.config', 'lumir
   } catch { return { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } }; }
 }
 
-function mergeConfig(raw: Record<string, unknown>): HudConfig {
+function mergeConfig(rawIn: Record<string, unknown>): HudConfig {
+  let raw = rawIn;
+  if (raw.preset === 'qwen') {
+    if (!qwenWarningShown) {
+      process.stderr.write("[lumira] 'qwen' preset is removed — using 'minimal' instead\n");
+      qwenWarningShown = true;
+    }
+    raw = { ...raw, preset: 'minimal' };
+  }
   const layout = (['multiline', 'singleline', 'auto'] as const).includes(raw.layout as never) ? raw.layout as HudConfig['layout'] : DEFAULT_CONFIG.layout;
   const colors: ColorConfig = { ...DEFAULT_CONFIG.colors };
   if (raw.colors && typeof raw.colors === 'object') {
@@ -22,7 +33,7 @@ function mergeConfig(raw: Record<string, unknown>): HudConfig {
   const result: HudConfig = { layout, gsd: typeof raw.gsd === 'boolean' ? raw.gsd : DEFAULT_CONFIG.gsd, display: { ...DEFAULT_DISPLAY }, colors };
 
   // Apply preset FIRST (sets layout + display defaults)
-  const validPresets = ['full', 'balanced', 'minimal', 'qwen'] as const;
+  const validPresets = ['full', 'balanced', 'minimal'] as const;
   if (validPresets.includes(raw.preset as never)) applyPreset(result, raw.preset as NonNullable<HudConfig['preset']>);
 
   // Then overlay user's explicit display toggles (user wins over preset)
@@ -67,30 +78,6 @@ const PRESET_DEFS: Record<NonNullable<HudConfig['preset']>, PresetDef> = {
       cacheMetrics: false,
     },
   },
-  qwen: {
-    layout: 'singleline',
-    display: {
-      tokens: false,
-      burnRate: false,
-      duration: false,
-      tokenSpeed: false,
-      rateLimits: false,
-      tools: false,
-      todos: false,
-      vim: false,
-      effort: false,
-      worktree: false,
-      agent: false,
-      sessionName: false,
-      style: false,
-      version: false,
-      linesChanged: false,
-      memory: false,
-      contextTokens: false,
-      cacheMetrics: false,
-      mcp: false,
-    },
-  },
   minimal: {
     layout: 'singleline',
     display: {
@@ -132,10 +119,9 @@ export function mergeCliFlags(config: HudConfig, argv: string[]): HudConfig {
   // Shorthand flags
   if (argv.includes('--minimal')) applyPreset(r, 'minimal');
   if (argv.includes('--balanced')) applyPreset(r, 'balanced');
-  if (argv.includes('--qwen')) applyPreset(r, 'qwen');
   if (argv.includes('--full')) applyPreset(r, 'full');
   for (const arg of argv) {
-    const presetMatch = arg.match(/^--preset[= ]?(full|balanced|minimal|qwen)$/);
+    const presetMatch = arg.match(/^--preset[= ]?(full|balanced|minimal)$/);
     if (presetMatch) { applyPreset(r, presetMatch[1] as NonNullable<HudConfig['preset']>); continue; }
     const iconsMatch = arg.match(/^--icons[= ]?(nerd|emoji|none)$/);
     if (iconsMatch) { r.icons = iconsMatch[1] as HudConfig['icons']; continue; }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
-import { readFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { readFileSync, existsSync, writeFileSync, renameSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { DEFAULT_CONFIG, DEFAULT_DISPLAY, type HudConfig, type DisplayToggles, type ColorConfig } from './types.js';
 
@@ -127,4 +127,34 @@ export function mergeCliFlags(config: HudConfig, argv: string[]): HudConfig {
     if (iconsMatch) { r.icons = iconsMatch[1] as HudConfig['icons']; continue; }
   }
   return r;
+}
+
+export interface WizardResult {
+  preset: 'full' | 'balanced' | 'minimal';
+  theme?: string;
+  icons: 'nerd' | 'emoji' | 'none';
+}
+
+export function saveConfig(wizard: WizardResult, configPath: string): void {
+  mkdirSync(dirname(configPath), { recursive: true });
+
+  let existing: Record<string, unknown> = {};
+  if (existsSync(configPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(configPath, 'utf8'));
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        existing = parsed as Record<string, unknown>;
+      }
+    } catch {
+      existing = {};
+    }
+  }
+
+  const merged: Record<string, unknown> = { ...existing, preset: wizard.preset, icons: wizard.icons };
+  if (wizard.theme !== undefined) merged.theme = wizard.theme;
+  else delete merged.theme;
+
+  const tmp = configPath + '.tmp';
+  writeFileSync(tmp, JSON.stringify(merged, null, 2) + '\n', { mode: 0o600 });
+  renameSync(tmp, configPath);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import { fileURLToPath } from 'node:url';
 import { realpathSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { readStdin as defaultReadStdin } from './stdin.js';
 import { parseGitStatus } from './parsers/git.js';
 import { parseTranscript } from './parsers/transcript.js';
@@ -69,7 +71,8 @@ function isDirectRun(): boolean {
 if (isDirectRun()) {
   const cmd = process.argv[2];
   if (cmd === 'install') {
-    install().then(o => process.stdout.write(o)).catch(e => process.stderr.write(`Install error: ${e.message}\n`));
+    const configPath = join(homedir(), '.config', 'lumira', 'config.json');
+    install({ configPath }).then(o => process.stdout.write(o)).catch(e => process.stderr.write(`Install error: ${e.message}\n`));
   } else if (cmd === 'uninstall') {
     const o = uninstall();
     process.stdout.write(o);

--- a/src/installer-wizard.ts
+++ b/src/installer-wizard.ts
@@ -12,6 +12,8 @@ export interface WizardCurrent {
 
 export interface RunWizardOpts {
   current: WizardCurrent;
+  /** Optional string rendered above each step's title (e.g. an ASCII banner). */
+  prelude?: string;
   stdin?: NodeJS.ReadStream | (Readable & {
     isTTY?: boolean;
     isRaw?: boolean;
@@ -56,6 +58,7 @@ export async function runWizard(opts: RunWizardOpts): Promise<WizardResult | nul
     options: PRESET_OPTIONS,
     initial: current.preset ?? 'balanced',
     preview: (v) => buildPreview({ preset: v, theme: current.theme, icons: current.icons ?? 'nerd' }),
+    prelude: opts.prelude,
     ...streams,
   });
   if (preset === null) return null;
@@ -70,6 +73,7 @@ export async function runWizard(opts: RunWizardOpts): Promise<WizardResult | nul
       theme: v === NONE_THEME ? undefined : v,
       icons: current.icons ?? 'nerd',
     }),
+    prelude: opts.prelude,
     ...streams,
   });
   if (themeValue === null) return null;
@@ -81,6 +85,7 @@ export async function runWizard(opts: RunWizardOpts): Promise<WizardResult | nul
     options: ICON_OPTIONS,
     initial: current.icons ?? 'nerd',
     preview: (v) => buildPreview({ preset, theme, icons: v }),
+    prelude: opts.prelude,
     ...streams,
   });
   if (icons === null) return null;

--- a/src/installer-wizard.ts
+++ b/src/installer-wizard.ts
@@ -1,0 +1,92 @@
+import type { Readable, Writable } from 'node:stream';
+import { interactiveSelect, type SelectOption } from './tui/select.js';
+import { buildPreview } from './tui/preview.js';
+import { THEMES } from './themes.js';
+import type { WizardResult } from './config.js';
+
+export interface WizardCurrent {
+  preset?: 'full' | 'balanced' | 'minimal';
+  theme?: string;
+  icons?: 'nerd' | 'emoji' | 'none';
+}
+
+export interface RunWizardOpts {
+  current: WizardCurrent;
+  stdin?: NodeJS.ReadStream | (Readable & {
+    isTTY?: boolean;
+    isRaw?: boolean;
+    setRawMode?: (flag: boolean) => unknown;
+  });
+  stdout?: NodeJS.WriteStream | (Writable & { columns?: number });
+}
+
+const PRESET_OPTIONS: SelectOption<'full' | 'balanced' | 'minimal'>[] = [
+  { label: 'full',     value: 'full',     description: '▸ everything on, 4 lines' },
+  { label: 'balanced', value: 'balanced', description: '▸ essentials, auto-compact' },
+  { label: 'minimal',  value: 'minimal',  description: '▸ single line, just the basics' },
+];
+
+const ICON_OPTIONS: SelectOption<'nerd' | 'emoji' | 'none'>[] = [
+  { label: 'nerd',  value: 'nerd',  description: '▸ Nerd Font icons (default)' },
+  { label: 'emoji', value: 'emoji', description: '▸ Unicode emoji icons' },
+  { label: 'none',  value: 'none',  description: '▸ no icons, ASCII fallbacks' },
+];
+
+const NONE_THEME = '__none__';
+
+function themeOptions(): SelectOption<string>[] {
+  const names = Object.keys(THEMES);
+  return [
+    { label: '(none)', value: NONE_THEME },
+    ...names.map((n) => ({ label: n, value: n })),
+  ];
+}
+
+export async function runWizard(opts: RunWizardOpts): Promise<WizardResult | null> {
+  const { current } = opts;
+
+  // Build a partial opts spread so unused keys don't get passed as undefined
+  const streams: Pick<RunWizardOpts, 'stdin' | 'stdout'> = {};
+  if (opts.stdin)  streams.stdin  = opts.stdin;
+  if (opts.stdout) streams.stdout = opts.stdout;
+
+  // Step 1: preset
+  const preset = await interactiveSelect({
+    title: 'lumira setup · step 1/3 — preset',
+    options: PRESET_OPTIONS,
+    initial: current.preset ?? 'balanced',
+    preview: (v) => buildPreview({ preset: v, theme: current.theme, icons: current.icons ?? 'nerd' }),
+    ...streams,
+  });
+  if (preset === null) return null;
+
+  // Step 2: theme
+  const themeValue = await interactiveSelect({
+    title: 'lumira setup · step 2/3 — theme',
+    options: themeOptions(),
+    initial: current.theme ?? NONE_THEME,
+    preview: (v) => buildPreview({
+      preset,
+      theme: v === NONE_THEME ? undefined : v,
+      icons: current.icons ?? 'nerd',
+    }),
+    ...streams,
+  });
+  if (themeValue === null) return null;
+  const theme = themeValue === NONE_THEME ? undefined : themeValue;
+
+  // Step 3: icons
+  const icons = await interactiveSelect({
+    title: 'lumira setup · step 3/3 — icons',
+    options: ICON_OPTIONS,
+    initial: current.icons ?? 'nerd',
+    preview: (v) => buildPreview({ preset, theme, icons: v }),
+    ...streams,
+  });
+  if (icons === null) return null;
+
+  // Build result — omit theme key entirely when none was chosen
+  const result: WizardResult = { preset, icons };
+  if (theme !== undefined) result.theme = theme;
+  return result;
+}

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -115,12 +115,13 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
     const stdin = opts.stdin ?? process.stdin;
     const stdout = opts.stdout ?? process.stdout;
 
-    // Print banner on TTY
+    // Build banner prelude (shown on each wizard frame so it survives screen clears)
+    let prelude = '';
     if (stdin?.isTTY) {
       const banner = getBanner({ width: (stdout as { columns?: number } | undefined)?.columns });
       if (banner) {
         const subtitle = getSubtitle();
-        (stdout as { write?: (s: string) => void } | undefined)?.write?.(banner + '\n ' + subtitle + '\n');
+        prelude = banner + '\n ' + subtitle + '\n\n';
       }
     }
 
@@ -135,7 +136,7 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
     // Determine wizard result
     let wizard: WizardResult;
     if (stdin?.isTTY) {
-      const result = await runWizard({ current, stdin, stdout });
+      const result = await runWizard({ current, prelude, stdin, stdout });
       if (result === null) {
         lines.push(`\n  Installation cancelled.\n`);
         return lines.join('\n') + '\n';

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -112,8 +112,8 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
 
   if (runInteractive) {
     const configPath = opts.configPath as string;
-    const stdin = opts.stdin;
-    const stdout = opts.stdout;
+    const stdin = opts.stdin ?? process.stdin;
+    const stdout = opts.stdout ?? process.stdout;
 
     // Print banner on TTY
     if (stdin?.isTTY) {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync, copyFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, copyFileSync, unlinkSync, mkdirSync, rmdirSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -36,6 +36,7 @@ export interface InstallerOptions {
     setRawMode?: (flag: boolean) => unknown;
   });
   stdout?: NodeJS.WriteStream | (import('node:stream').Writable & { columns?: number });
+  homeOverride?: string;
 }
 
 function defaultSettingsPath(): string {
@@ -64,12 +65,10 @@ export function promptYN(question: string): Promise<boolean> {
 }
 
 // ── Skill installer ─────────────────────────────────────────────────
-function installSkill(): string[] {
+function installSkill(opts: { homeOverride?: string } = {}): string[] {
   const lines: string[] = [];
-  const destDir = join(homedir(), '.claude', 'skills', 'lumira');
-  const destFile = join(destDir, 'SKILL.md');
+  const home = opts.homeOverride ?? homedir();
 
-  // Resolve skill source: dist/../skills/lumira/SKILL.md
   const thisDir = dirname(fileURLToPath(import.meta.url));
   const srcFile = resolve(thisDir, '..', 'skills', 'lumira', 'SKILL.md');
 
@@ -78,12 +77,22 @@ function installSkill(): string[] {
     return lines;
   }
 
-  try {
-    mkdirSync(destDir, { recursive: true });
-    copyFileSync(srcFile, destFile);
-    lines.push(ok(`Installed ${DIM}/lumira${RST} skill → ${DIM}~/.claude/skills/lumira/${RST}`));
-  } catch {
-    lines.push(warn('Could not install /lumira skill — copy manually from skills/lumira/SKILL.md'));
+  const destinations = [
+    { label: 'claude', dir: join(home, '.claude') },
+    { label: 'qwen',   dir: join(home, '.qwen')   },
+  ];
+
+  for (const { label, dir } of destinations) {
+    if (label === 'qwen' && !existsSync(dir)) continue;
+    const destDir = join(dir, 'skills', 'lumira');
+    const destFile = join(destDir, 'SKILL.md');
+    try {
+      mkdirSync(destDir, { recursive: true });
+      copyFileSync(srcFile, destFile);
+      lines.push(ok(`Installed ${DIM}/lumira${RST} skill → ${DIM}${destDir}/${RST}`));
+    } catch {
+      lines.push(warn(`Could not install /lumira skill to ${destDir}`));
+    }
   }
 
   return lines;
@@ -155,7 +164,7 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
         lines.push(ok('lumira is already configured as your statusline'));
         saveConfig(wizard, configPath);
         lines.push(ok(`Saved config → ${DIM}${configPath}${RST}`));
-        lines.push(...installSkill());
+        lines.push(...installSkill({ homeOverride: opts.homeOverride }));
         return lines.join('\n') + '\n';
       }
 
@@ -179,7 +188,14 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
     saveConfig(wizard, configPath);
     lines.push(ok(`Saved config → ${DIM}${configPath}${RST}`));
 
-    lines.push(...installSkill());
+    lines.push(...installSkill({ homeOverride: opts.homeOverride }));
+
+    if (existsSync(join(opts.homeOverride ?? homedir(), '.qwen'))) {
+      lines.push('');
+      lines.push('  \u2139 Qwen Code detected — in Qwen sessions, lumira renders');
+      lines.push('    single-line automatically. Your preset above applies to Claude Code.');
+    }
+
     lines.push(`\n  Restart Claude Code to see your statusline.\n`);
     return lines.join('\n') + '\n';
   }
@@ -201,7 +217,7 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
   if (settings.statusLine) {
     if (isLumira(settings.statusLine)) {
       lines.push(ok('lumira is already configured as your statusline'));
-      lines.push(...installSkill());
+      lines.push(...installSkill({ homeOverride: opts.homeOverride }));
       return lines.join('\n') + '\n';
     }
 
@@ -222,7 +238,7 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
   writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', { mode: 0o600 });
   lines.push(ok('Configured lumira as statusline'));
 
-  lines.push(...installSkill());
+  lines.push(...installSkill({ homeOverride: opts.homeOverride }));
   lines.push(`\n  Restart Claude Code to see your statusline.\n`);
   return lines.join('\n') + '\n';
 }
@@ -231,6 +247,7 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
 export function uninstall(opts: InstallerOptions = {}): string {
   const settingsPath = opts.settingsPath ?? defaultSettingsPath();
   const backupPath = settingsPath + '.lumira.bak';
+  const home = opts.homeOverride ?? homedir();
   const lines: string[] = [header()];
 
   if (!existsSync(settingsPath)) {
@@ -244,6 +261,18 @@ export function uninstall(opts: InstallerOptions = {}): string {
       copyFileSync(backupPath, settingsPath);
       unlinkSync(backupPath);
       lines.push(ok('Restored previous settings from backup'));
+
+      // Remove skill from both destinations (best effort)
+      for (const root of [join(home, '.claude'), join(home, '.qwen')]) {
+        const skillFile = join(root, 'skills', 'lumira', 'SKILL.md');
+        if (existsSync(skillFile)) {
+          try {
+            unlinkSync(skillFile);
+            try { rmdirSync(dirname(skillFile)); } catch { /* dir not empty, ok */ }
+          } catch { /* best effort */ }
+        }
+      }
+
       lines.push(`\n  Restart Claude Code to apply changes.\n`);
       return lines.join('\n') + '\n';
     } catch {
@@ -259,6 +288,17 @@ export function uninstall(opts: InstallerOptions = {}): string {
     lines.push(ok('Removed lumira statusline from settings'));
   } catch {
     lines.push(warn('Could not parse settings.json'));
+  }
+
+  // Remove skill from both destinations (best effort)
+  for (const root of [join(home, '.claude'), join(home, '.qwen')]) {
+    const skillFile = join(root, 'skills', 'lumira', 'SKILL.md');
+    if (existsSync(skillFile)) {
+      try {
+        unlinkSync(skillFile);
+        try { rmdirSync(dirname(skillFile)); } catch { /* dir not empty, ok */ }
+      } catch { /* best effort */ }
+    }
   }
 
   lines.push(`\n  Restart Claude Code to apply changes.\n`);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -3,6 +3,9 @@ import { join, dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { createInterface } from 'node:readline';
+import { runWizard } from './installer-wizard.js';
+import { saveConfig, loadConfig, type WizardResult } from './config.js';
+import { getBanner, getSubtitle } from './tui/banner.js';
 
 // ── ANSI helpers ────────────────────────────────────────────────────
 const RST = '\x1b[0m';
@@ -25,11 +28,22 @@ const LUMIRA_STATUSLINE = {
 // ── Install options (DI for testing) ────────────────────────────────
 export interface InstallerOptions {
   settingsPath?: string;
+  configPath?: string;
   confirm?: (prompt: string) => Promise<boolean>;
+  stdin?: NodeJS.ReadStream | (import('node:stream').Readable & {
+    isTTY?: boolean;
+    isRaw?: boolean;
+    setRawMode?: (flag: boolean) => unknown;
+  });
+  stdout?: NodeJS.WriteStream | (import('node:stream').Writable & { columns?: number });
 }
 
 function defaultSettingsPath(): string {
   return join(homedir(), '.claude', 'settings.json');
+}
+
+function defaultConfigPath(): string {
+  return join(homedir(), '.config', 'lumira', 'config.json');
 }
 
 function isLumira(statusLine: unknown): boolean {
@@ -80,7 +94,98 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
   const settingsPath = opts.settingsPath ?? defaultSettingsPath();
   const backupPath = settingsPath + '.lumira.bak';
   const confirm = opts.confirm ?? promptYN;
-  const lines: string[] = [header()];
+  const lines: string[] = [];
+
+  // ── Wizard / config path ─────────────────────────────────────────
+  // When configPath is not provided, skip the wizard and config write
+  // entirely (legacy path — preserves existing test behaviour).
+  const runInteractive = opts.configPath !== undefined;
+
+  if (runInteractive) {
+    const configPath = opts.configPath as string;
+    const stdin = opts.stdin;
+    const stdout = opts.stdout;
+
+    // Print banner on TTY
+    if (stdin?.isTTY) {
+      const banner = getBanner({ width: (stdout as { columns?: number } | undefined)?.columns });
+      if (banner) {
+        const subtitle = getSubtitle();
+        (stdout as { write?: (s: string) => void } | undefined)?.write?.(banner + '\n ' + subtitle + '\n');
+      }
+    }
+
+    // Load existing config to pre-populate wizard selections
+    const existingConfig = loadConfig(dirname(configPath));
+    const current = {
+      preset: existingConfig.preset,
+      theme: existingConfig.theme,
+      icons: existingConfig.icons,
+    };
+
+    // Determine wizard result
+    let wizard: WizardResult;
+    if (stdin?.isTTY) {
+      const result = await runWizard({ current, stdin, stdout });
+      if (result === null) {
+        lines.push(`\n  Installation cancelled.\n`);
+        return lines.join('\n') + '\n';
+      }
+      wizard = result;
+    } else {
+      // Non-TTY: use defaults
+      wizard = { preset: 'balanced', icons: 'nerd' };
+      lines.push(ok('Non-interactive mode — using defaults (preset: balanced, icons: nerd)'));
+    }
+
+    // ── settings.json read/replace/backup ──────────────────────────
+    let settings: Record<string, unknown> = {};
+
+    if (existsSync(settingsPath)) {
+      try {
+        settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+      } catch {
+        lines.push(warn('Could not parse existing settings.json, creating fresh'));
+        settings = {};
+      }
+    }
+
+    if (settings.statusLine) {
+      if (isLumira(settings.statusLine)) {
+        lines.push(ok('lumira is already configured as your statusline'));
+        saveConfig(wizard, configPath);
+        lines.push(ok(`Saved config → ${DIM}${configPath}${RST}`));
+        lines.push(...installSkill());
+        return lines.join('\n') + '\n';
+      }
+
+      const currentCmd = (settings.statusLine as Record<string, unknown>).command ?? 'unknown';
+      lines.push(warn(`Current statusline: ${YELLOW}${currentCmd}${RST}`));
+      const accepted = await confirm('Replace with lumira?');
+      if (!accepted) {
+        lines.push(`\n  Aborted. No changes made.\n`);
+        return lines.join('\n') + '\n';
+      }
+
+      copyFileSync(settingsPath, backupPath);
+      lines.push(ok(`Backed up existing settings → ${DIM}settings.json.lumira.bak${RST}`));
+    }
+
+    settings.statusLine = { ...LUMIRA_STATUSLINE };
+    mkdirSync(dirname(settingsPath), { recursive: true });
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', { mode: 0o600 });
+    lines.push(ok('Configured lumira as statusline'));
+
+    saveConfig(wizard, configPath);
+    lines.push(ok(`Saved config → ${DIM}${configPath}${RST}`));
+
+    lines.push(...installSkill());
+    lines.push(`\n  Restart Claude Code to see your statusline.\n`);
+    return lines.join('\n') + '\n';
+  }
+
+  // ── Legacy path (no configPath) — original behaviour ─────────────
+  lines.push(header());
 
   let settings: Record<string, unknown> = {};
 
@@ -117,9 +222,7 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
   writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', { mode: 0o600 });
   lines.push(ok('Configured lumira as statusline'));
 
-  // Install /lumira skill
   lines.push(...installSkill());
-
   lines.push(`\n  Restart Claude Code to see your statusline.\n`);
   return lines.join('\n') + '\n';
 }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -166,6 +166,14 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
         saveConfig(wizard, configPath);
         lines.push(ok(`Saved config → ${DIM}${configPath}${RST}`));
         lines.push(...installSkill({ homeOverride: opts.homeOverride }));
+
+        if (existsSync(join(opts.homeOverride ?? homedir(), '.qwen'))) {
+          lines.push('');
+          lines.push('  \u2139 Qwen Code detected — in Qwen sessions, lumira renders');
+          lines.push('    single-line automatically. Your preset above applies to Claude Code.');
+        }
+
+        lines.push(`\n  Restart Claude Code to see your statusline.\n`);
         return lines.join('\n') + '\n';
       }
 

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -12,7 +12,8 @@ export function render(ctx: RenderContext): string {
   const theme = resolveTheme(ctx.config.theme, colorMode);
   const c = createColors(colorMode, theme);
 
-  if (ctx.config.layout === 'singleline' || (ctx.config.layout === 'auto' && ctx.cols < 70)) {
+  const isQwen = ctx.input.platform === 'qwen-code';
+  if (isQwen || ctx.config.layout === 'singleline' || (ctx.config.layout === 'auto' && ctx.cols < 70)) {
     return renderMinimal(ctx, c);
   }
 

--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -23,7 +23,7 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
   // Branch + git changes (prefer Qwen's native git.branch, fallback to external git)
   const branchName = input.gitBranch || git.branch;
   if (display.branch && branchName) {
-    const branchLen = cols < 60 ? 12 : cols < 80 ? 20 : cols < 100 ? 30 : cols < 120 ? 40 : 60;
+    const branchLen = cols < 60 ? 20 : cols < 80 ? 35 : cols < 100 ? 50 : cols < 120 ? 70 : 80;
     const bName = truncField(branchName, branchLen);
     let branchStr = c.magenta(`${icons.branch} ${bName}`);
 

--- a/src/render/text.ts
+++ b/src/render/text.ts
@@ -40,20 +40,31 @@ export function truncatePath(str: string, maxLen: number = 20): string {
 }
 
 export function fitSegments(left: string[], right: string[], sep: string, cols: number): string {
-  const safeCols = cols - 4;
-  const leftStr = left.join(sep);
-  const leftW = displayWidth(leftStr);
-  for (let r = right.length; r >= 0; r--) {
-    const rSlice = right.slice(0, r);
-    if (rSlice.length === 0) return leftStr;
-    const rightStr = rSlice.join(sep);
-    const rightW = displayWidth(rightStr);
-    if (leftW + 1 + rightW <= safeCols) {
-      const gap = Math.max(1, safeCols - leftW - rightW);
-      return leftStr + ' '.repeat(gap) + rightStr;
+  const safeCols = Math.max(1, cols - 4);
+
+  for (let l = left.length; l >= 1; l--) {
+    const lSlice = left.slice(0, l);
+    const leftStr = lSlice.join(sep);
+    const leftW = displayWidth(leftStr);
+
+    if (leftW > safeCols) continue;
+
+    for (let r = right.length; r >= 0; r--) {
+      const rSlice = right.slice(0, r);
+      if (rSlice.length === 0) return leftStr;
+      const rightStr = rSlice.join(sep);
+      const rightW = displayWidth(rightStr);
+      if (leftW + 1 + rightW <= safeCols) {
+        const gap = Math.max(1, safeCols - leftW - rightW);
+        return leftStr + ' '.repeat(gap) + rightStr;
+      }
     }
+    return leftStr;
   }
-  return leftStr;
+
+  // Last resort: even the first left segment alone exceeds safeCols.
+  // Strip ANSI before hard-truncating to avoid cutting mid-escape-sequence.
+  return truncField(stripAnsi(left[0] ?? ''), safeCols);
 }
 
 export function padLine(left: string, right: string, cols: number): string {

--- a/src/tui/banner.ts
+++ b/src/tui/banner.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const LOGO = [
+  '██╗     ██╗   ██╗███╗   ███╗██╗██████╗  █████╗ ',
+  '██║     ██║   ██║████╗ ████║██║██╔══██╗██╔══██╗',
+  '██║     ██║   ██║██╔████╔██║██║██████╔╝███████║',
+  '██║     ██║   ██║██║╚██╔╝██║██║██╔══██╗██╔══██║',
+  '███████╗╚██████╔╝██║ ╚═╝ ██║██║██║  ██║██║  ██║',
+  '╚══════╝ ╚═════╝ ╚═╝     ╚═╝╚═╝╚═╝  ╚═╝╚═╝  ╚═╝',
+].join('\n');
+
+const CYAN = '\x1b[36m';
+const RST = '\x1b[0m';
+
+export interface BannerOpts {
+  /** Terminal width in columns. Banner hides when width < 50. Defaults to process.stdout.columns. */
+  width?: number;
+}
+
+export function getBanner(opts: BannerOpts = {}): string {
+  const width = opts.width ?? (process.stdout.columns ?? 80);
+  if (width < 50) return '';
+  return `${CYAN}\n${LOGO}\n${RST}`;
+}
+
+export interface SubtitleOpts {
+  /** Injection point for tests. Returns the raw package.json contents as a string. */
+  readPackageJson?: () => string;
+}
+
+function defaultReadPackageJson(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // Built file lives at dist/tui/banner.js; package.json is at dist/../package.json.
+  // Source file lives at src/tui/banner.ts; package.json is at src/../package.json.
+  // Either way: two levels up.
+  const p = resolve(here, '..', '..', 'package.json');
+  return readFileSync(p, 'utf8');
+}
+
+const BASE_SUBTITLE = 'real-time statusline for claude code & qwen code';
+
+export function getSubtitle(opts: SubtitleOpts = {}): string {
+  const read = opts.readPackageJson ?? defaultReadPackageJson;
+  try {
+    const pkg = JSON.parse(read());
+    if (typeof pkg.version === 'string' && pkg.version.length > 0) {
+      return `${BASE_SUBTITLE} · v${pkg.version}`;
+    }
+    return BASE_SUBTITLE;
+  } catch {
+    return BASE_SUBTITLE;
+  }
+}

--- a/src/tui/preview.ts
+++ b/src/tui/preview.ts
@@ -1,0 +1,137 @@
+import { render as defaultRender } from '../render/index.js';
+import { resolveIcons } from '../render/icons.js';
+import { normalize } from '../normalize.js';
+import {
+  DEFAULT_CONFIG,
+  DEFAULT_DISPLAY,
+  EMPTY_GIT,
+  EMPTY_TRANSCRIPT,
+  type HudConfig,
+  type RenderContext,
+} from '../types.js';
+import type { ColorMode } from '../render/colors.js';
+
+export interface PreviewOpts {
+  preset: NonNullable<HudConfig['preset']>;
+  theme?: string;
+  icons: 'nerd' | 'emoji' | 'none';
+  colorMode?: ColorMode;
+}
+
+export interface BuildPreviewDeps {
+  render?: (ctx: RenderContext) => string;
+}
+
+function buildMockContext(opts: PreviewOpts): RenderContext {
+  // Determine layout from preset (mirrors applyPreset logic without importing it)
+  let layout: HudConfig['layout'] = 'auto';
+  if (opts.preset === 'minimal') layout = 'singleline';
+  else if (opts.preset === 'full') layout = 'multiline';
+  else if (opts.preset === 'balanced') layout = 'auto';
+
+  const config: HudConfig = {
+    ...DEFAULT_CONFIG,
+    layout,
+    preset: opts.preset,
+    icons: opts.icons,
+    theme: opts.theme,
+    display: { ...DEFAULT_DISPLAY },
+    colors: { mode: opts.colorMode ?? 'truecolor' },
+  };
+
+  // Build a realistic raw Claude Code input that normalize() can consume.
+  // Fill every field that renderers access via ctx.input.* or ctx.input.raw.*
+  const rawInput = {
+    model: 'Claude Sonnet 4.6',
+    session_id: 'preview-session',
+    session_name: 'install-wizard preview',
+    cwd: '/home/carlos/projects/lumira',
+    context_window: {
+      context_window_size: 200000,
+      used_percentage: 42,
+      remaining_percentage: 58,
+      current_usage: 84000,
+      total_input_tokens: 12000,
+      total_output_tokens: 1800,
+      cache_read_input_tokens: 3500,
+      cache_creation_input_tokens: 0,
+    },
+    cost: {
+      total_cost_usd: 0.42,
+      total_duration_ms: 185000,
+      total_lines_added: 47,
+      total_lines_removed: 12,
+    },
+    version: '1.2.3',
+    output_style: { name: 'auto' },
+    vim: undefined,
+    agent: undefined,
+    worktree: undefined,
+    rate_limits: {
+      five_hour: { used_percentage: 65, resets_at: Math.floor(Date.now() / 1000) + 3600 },
+      seven_day: { used_percentage: 30 },
+    },
+    exceeds_200k_tokens: false,
+  };
+
+  const input = normalize(rawInput);
+
+  const git = {
+    ...EMPTY_GIT,
+    branch: 'main',
+    staged: 2,
+    modified: 3,
+    untracked: 1,
+  };
+
+  const transcript = {
+    ...EMPTY_TRANSCRIPT,
+    tools: [
+      {
+        id: '1',
+        name: 'Read',
+        target: 'src/types.ts',
+        status: 'completed' as const,
+        startTime: new Date(),
+        endTime: new Date(),
+      },
+      {
+        id: '2',
+        name: 'Edit',
+        target: 'src/tui/preview.ts',
+        status: 'completed' as const,
+        startTime: new Date(),
+        endTime: new Date(),
+      },
+    ],
+    todos: [
+      { id: '1', content: 'Implement preview generator', status: 'completed' as const },
+      { id: '2', content: 'Write tests', status: 'in_progress' as const },
+    ],
+    thinkingEffort: '' as const,
+    sessionStart: new Date(Date.now() - 185000),
+  };
+
+  return {
+    input,
+    git,
+    transcript,
+    tokenSpeed: 45,
+    memory: { usedBytes: 512 * 1024 * 1024, totalBytes: 16 * 1024 * 1024 * 1024, percentage: 3 },
+    gsd: null,
+    mcp: null,
+    cols: 120,
+    config,
+    icons: resolveIcons(opts.icons),
+  };
+}
+
+export function buildPreview(opts: PreviewOpts, deps: BuildPreviewDeps = {}): string {
+  const render = deps.render ?? defaultRender;
+  try {
+    const ctx = buildMockContext(opts);
+    return render(ctx);
+  } catch {
+    return '(preview unavailable)';
+  }
+}

--- a/src/tui/select.ts
+++ b/src/tui/select.ts
@@ -25,6 +25,8 @@ export interface SelectOpts<T> {
   options: SelectOption<T>[];
   initial?: T;
   preview: (focused: T) => string;
+  /** Optional string rendered above the title on each frame (e.g. an ASCII banner). */
+  prelude?: string;
   stdin?: SelectStdin;
   stdout?: SelectStdout;
 }
@@ -80,6 +82,7 @@ export async function interactiveSelect<T>(opts: SelectOpts<T>): Promise<T | nul
 
   const render = () => {
     stdout.write?.(CLEAR_SCREEN);
+    if (opts.prelude) stdout.write?.(opts.prelude);
     stdout.write?.(` ${opts.title}\n\n`);
     for (let i = 0; i < options.length; i++) {
       const o = options[i];

--- a/src/tui/select.ts
+++ b/src/tui/select.ts
@@ -40,19 +40,39 @@ const SHOW_CURSOR = '\x1b[?25h';
 const HIDE_CURSOR = '\x1b[?25l';
 const CLEAR_SCREEN = '\x1b[2J\x1b[H';
 
+let exitHandlerInstalled = false;
+function installExitHandler(stdin: SelectStdin, stdout: SelectStdout): void {
+  if (exitHandlerInstalled) return;
+  exitHandlerInstalled = true;
+  process.once('exit', () => {
+    try {
+      if (typeof stdin.setRawMode === 'function' && stdin.isRaw) stdin.setRawMode(false);
+      stdout.write?.(SHOW_CURSOR);
+    } catch { /* best effort */ }
+  });
+}
+
 export async function interactiveSelect<T>(opts: SelectOpts<T>): Promise<T | null> {
   const stdin = (opts.stdin ?? process.stdin) as SelectStdin;
   const stdout = (opts.stdout ?? process.stdout) as SelectStdout;
   if (!stdin.isTTY) return null;
+
+  installExitHandler(stdin, stdout);
 
   const options = opts.options;
   const initialIdx = options.findIndex((o) => o.value === opts.initial);
   let focus = initialIdx >= 0 ? initialIdx : 0;
 
   let keypressListener: ((str: string, key: KeypressKey) => void) | null = null;
+  let resizeListener: (() => void) | null = null;
+  let endListener: (() => void) | null = null;
 
   const cleanup = () => {
     if (keypressListener) stdin.removeListener?.('keypress', keypressListener);
+    if (resizeListener && typeof (stdout as { removeListener?: unknown }).removeListener === 'function') {
+      (stdout as Writable).removeListener('resize', resizeListener);
+    }
+    if (endListener) stdin.removeListener?.('end', endListener);
     if (typeof stdin.setRawMode === 'function') stdin.setRawMode(false);
     stdin.pause?.();
     stdout.write?.(SHOW_CURSOR);
@@ -80,24 +100,25 @@ export async function interactiveSelect<T>(opts: SelectOpts<T>): Promise<T | nul
     render();
 
     return await new Promise<T | null>((resolve) => {
+      const finish = (v: T | null) => resolve(v);
+
       keypressListener = (_str, key) => {
         if (!key || !key.name) return;
-        if (key.name === 'down' || key.name === 'j') {
-          focus = (focus + 1) % options.length;
-          render();
-          return;
-        }
-        if (key.name === 'up' || key.name === 'k') {
-          focus = (focus - 1 + options.length) % options.length;
-          render();
-          return;
-        }
-        if (key.name === 'return') {
-          resolve(options[focus].value);
-          return;
-        }
+        if (key.name === 'down' || key.name === 'j') { focus = (focus + 1) % options.length; render(); return; }
+        if (key.name === 'up'   || key.name === 'k') { focus = (focus - 1 + options.length) % options.length; render(); return; }
+        if (key.name === 'return') { finish(options[focus].value); return; }
+        if (key.name === 'escape' || key.name === 'q') { finish(null); return; }
+        if (key.name === 'c' && key.ctrl) { finish(null); return; }
       };
       stdin.on('keypress', keypressListener);
+
+      endListener = () => finish(null);
+      stdin.on('end', endListener);
+
+      resizeListener = () => render();
+      if (typeof (stdout as { on?: unknown }).on === 'function') {
+        (stdout as Writable).on('resize', resizeListener);
+      }
     });
   } finally {
     cleanup();

--- a/src/tui/select.ts
+++ b/src/tui/select.ts
@@ -1,0 +1,47 @@
+import type { Readable, Writable } from 'node:stream';
+
+export interface SelectOption<T> {
+  label: string;
+  value: T;
+  description?: string;
+  hint?: string;
+  disabled?: boolean;
+}
+
+/**
+ * Streams used by `interactiveSelect`. In production these default to
+ * `process.stdin` / `process.stdout`; tests inject fakes.
+ */
+type SelectStdin = NodeJS.ReadStream | (Readable & {
+  isTTY?: boolean;
+  isRaw?: boolean;
+  setRawMode?: (flag: boolean) => unknown;
+});
+type SelectStdout = NodeJS.WriteStream | (Writable & { columns?: number });
+
+export interface SelectOpts<T> {
+  title: string;
+  options: SelectOption<T>[];
+  initial?: T;
+  preview: (focused: T) => string;
+  stdin?: SelectStdin;
+  stdout?: SelectStdout;
+}
+
+/**
+ * Interactive single-select prompt. Resolves with the chosen value, or null
+ * when stdin is not a TTY (piped input), when the user aborts (Esc / q /
+ * Ctrl+C — added in Task 7), or when stdin closes.
+ *
+ * This is the Task 5 scaffold: only the non-TTY short-circuit is wired up.
+ * Navigation, abort keys, preview rendering, and resize handling arrive in
+ * Tasks 6 and 7.
+ */
+export async function interactiveSelect<T>(opts: SelectOpts<T>): Promise<T | null> {
+  const stdin = (opts.stdin ?? process.stdin) as SelectStdin;
+  if (!stdin.isTTY) return null;
+
+  // TODO(Task 6): render loop + navigation + Enter.
+  // TODO(Task 7): abort keys + stdin end + resize + cleanup.
+  return null;
+}

--- a/src/tui/select.ts
+++ b/src/tui/select.ts
@@ -1,3 +1,4 @@
+import readline from 'node:readline';
 import type { Readable, Writable } from 'node:stream';
 
 export interface SelectOption<T> {
@@ -28,20 +29,77 @@ export interface SelectOpts<T> {
   stdout?: SelectStdout;
 }
 
-/**
- * Interactive single-select prompt. Resolves with the chosen value, or null
- * when stdin is not a TTY (piped input), when the user aborts (Esc / q /
- * Ctrl+C — added in Task 7), or when stdin closes.
- *
- * This is the Task 5 scaffold: only the non-TTY short-circuit is wired up.
- * Navigation, abort keys, preview rendering, and resize handling arrive in
- * Tasks 6 and 7.
- */
+interface KeypressKey {
+  name?: string;
+  ctrl?: boolean;
+  shift?: boolean;
+  meta?: boolean;
+}
+
+const SHOW_CURSOR = '\x1b[?25h';
+const HIDE_CURSOR = '\x1b[?25l';
+const CLEAR_SCREEN = '\x1b[2J\x1b[H';
+
 export async function interactiveSelect<T>(opts: SelectOpts<T>): Promise<T | null> {
   const stdin = (opts.stdin ?? process.stdin) as SelectStdin;
+  const stdout = (opts.stdout ?? process.stdout) as SelectStdout;
   if (!stdin.isTTY) return null;
 
-  // TODO(Task 6): render loop + navigation + Enter.
-  // TODO(Task 7): abort keys + stdin end + resize + cleanup.
-  return null;
+  const options = opts.options;
+  const initialIdx = options.findIndex((o) => o.value === opts.initial);
+  let focus = initialIdx >= 0 ? initialIdx : 0;
+
+  let keypressListener: ((str: string, key: KeypressKey) => void) | null = null;
+
+  const cleanup = () => {
+    if (keypressListener) stdin.removeListener?.('keypress', keypressListener);
+    if (typeof stdin.setRawMode === 'function') stdin.setRawMode(false);
+    stdin.pause?.();
+    stdout.write?.(SHOW_CURSOR);
+  };
+
+  const render = () => {
+    stdout.write?.(CLEAR_SCREEN);
+    stdout.write?.(` ${opts.title}\n\n`);
+    for (let i = 0; i < options.length; i++) {
+      const o = options[i];
+      const marker = i === focus ? ' ❯ ' : '   ';
+      const desc = o.description ? '  ' + o.description : '';
+      stdout.write?.(`${marker}${o.label}${desc}\n`);
+    }
+    stdout.write?.('\n');
+    stdout.write?.(opts.preview(options[focus].value));
+    stdout.write?.('\n');
+  };
+
+  try {
+    readline.emitKeypressEvents(stdin as NodeJS.ReadStream);
+    if (typeof stdin.setRawMode === 'function') stdin.setRawMode(true);
+    stdin.resume?.();
+    stdout.write?.(HIDE_CURSOR);
+    render();
+
+    return await new Promise<T | null>((resolve) => {
+      keypressListener = (_str, key) => {
+        if (!key || !key.name) return;
+        if (key.name === 'down' || key.name === 'j') {
+          focus = (focus + 1) % options.length;
+          render();
+          return;
+        }
+        if (key.name === 'up' || key.name === 'k') {
+          focus = (focus - 1 + options.length) % options.length;
+          render();
+          return;
+        }
+        if (key.name === 'return') {
+          resolve(options[focus].value);
+          return;
+        }
+      };
+      stdin.on('keypress', keypressListener);
+    });
+  } finally {
+    cleanup();
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,7 +158,7 @@ export interface HudConfig {
    * User-facing preset — drives layout + display toggles (Phase 3).
    * CLI: --full | --balanced | --minimal | --preset=<value>
    */
-  preset?: 'full' | 'balanced' | 'minimal' | 'qwen';
+  preset?: 'full' | 'balanced' | 'minimal';
   theme?: string;
   icons?: 'nerd' | 'emoji' | 'none';
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { loadConfig, mergeCliFlags, _resetMigrationFlags } from '../src/config.js';
+import { loadConfig, mergeCliFlags, _resetMigrationFlags, saveConfig } from '../src/config.js';
 import { DEFAULT_CONFIG } from '../src/types.js';
 
 describe('loadConfig', () => {
@@ -122,6 +122,78 @@ describe('mergeCliFlags', () => {
     expect(r.layout).toBe('singleline');
   });
   it('parses --icons=none', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--icons=none']).icons).toBe('none'); });
+});
+
+describe('saveConfig', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'cc-save-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('creates config.json with only the three wizard keys', () => {
+    saveConfig({ preset: 'balanced', icons: 'nerd' }, join(dir, 'config.json'));
+    const content = JSON.parse(readFileSync(join(dir, 'config.json'), 'utf8'));
+    expect(content).toEqual({ preset: 'balanced', icons: 'nerd' });
+  });
+
+  it('writes with 0o600 permissions', () => {
+    const p = join(dir, 'config.json');
+    saveConfig({ preset: 'minimal', icons: 'nerd' }, p);
+    const mode = statSync(p).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('preserves other keys in an existing config', () => {
+    const p = join(dir, 'config.json');
+    writeFileSync(p, JSON.stringify({
+      display: { tokens: false },
+      colors: { mode: 'truecolor' },
+      preset: 'full',
+    }));
+    saveConfig({ preset: 'balanced', theme: 'dracula', icons: 'nerd' }, p);
+    const content = JSON.parse(readFileSync(p, 'utf8'));
+    expect(content).toEqual({
+      display: { tokens: false },
+      colors: { mode: 'truecolor' },
+      preset: 'balanced',
+      theme: 'dracula',
+      icons: 'nerd',
+    });
+  });
+
+  it('overwrites corrupt JSON with wizard keys only', () => {
+    const p = join(dir, 'config.json');
+    writeFileSync(p, 'not { valid json');
+    saveConfig({ preset: 'minimal', icons: 'emoji' }, p);
+    const content = JSON.parse(readFileSync(p, 'utf8'));
+    expect(content).toEqual({ preset: 'minimal', icons: 'emoji' });
+  });
+
+  it('omits theme key when undefined in input', () => {
+    const p = join(dir, 'config.json');
+    saveConfig({ preset: 'balanced', icons: 'nerd' }, p);
+    const content = JSON.parse(readFileSync(p, 'utf8'));
+    expect('theme' in content).toBe(false);
+  });
+
+  it('creates the parent directory if missing', () => {
+    const p = join(dir, 'nested', 'deep', 'config.json');
+    saveConfig({ preset: 'full', icons: 'nerd' }, p);
+    expect(existsSync(p)).toBe(true);
+  });
+
+  it('does not leave a stale .tmp file behind', () => {
+    const p = join(dir, 'config.json');
+    saveConfig({ preset: 'balanced', icons: 'nerd' }, p);
+    expect(existsSync(p + '.tmp')).toBe(false);
+  });
+
+  it('removes theme from existing config when new save has no theme', () => {
+    const p = join(dir, 'config.json');
+    writeFileSync(p, JSON.stringify({ theme: 'dracula', preset: 'full', icons: 'nerd' }));
+    saveConfig({ preset: 'full', icons: 'nerd' }, p);  // no theme
+    const content = JSON.parse(readFileSync(p, 'utf8'));
+    expect('theme' in content).toBe(false);
+  });
 });
 
 describe('qwen preset migration', () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { loadConfig, mergeCliFlags } from '../src/config.js';
+import { loadConfig, mergeCliFlags, _resetMigrationFlags } from '../src/config.js';
 import { DEFAULT_CONFIG } from '../src/types.js';
 
 describe('loadConfig', () => {
@@ -122,4 +122,35 @@ describe('mergeCliFlags', () => {
     expect(r.layout).toBe('singleline');
   });
   it('parses --icons=none', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--icons=none']).icons).toBe('none'); });
+});
+
+describe('qwen preset migration', () => {
+  let dir: string;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'cc-cfg-qwen-'));
+    _resetMigrationFlags();
+    errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    errSpy.mockRestore();
+  });
+
+  it('coerces legacy preset "qwen" to "minimal"', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"preset":"qwen"}');
+    const c = loadConfig(dir);
+    expect(c.preset).toBe('minimal');
+    expect(c.layout).toBe('singleline');
+  });
+
+  it('writes a deprecation warning to stderr when "qwen" preset is seen', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"preset":"qwen"}');
+    loadConfig(dir);
+    const calls = errSpy.mock.calls.flat().join('');
+    expect(calls).toContain("'qwen' preset is removed");
+  });
 });

--- a/tests/installer-wizard.test.ts
+++ b/tests/installer-wizard.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { runWizard } from '../src/installer-wizard.js';
+import { createMockStdin, createMockStdout } from './tui/_mock-stdin.js';
+
+async function flush() { await new Promise((r) => setImmediate(r)); }
+
+describe('runWizard', () => {
+  it('three Enters accept defaults: preset=balanced, no theme, icons=nerd', async () => {
+    const stdin = createMockStdin(true);
+    const stdout = createMockStdout();
+    const p = runWizard({ stdin, stdout, current: {} });
+
+    await flush();
+    stdin.pressKey('return'); // step 1: balanced (default initial)
+    await flush();
+    stdin.pressKey('return'); // step 2: (none)
+    await flush();
+    stdin.pressKey('return'); // step 3: nerd
+
+    const result = await p;
+    expect(result).toEqual({ preset: 'balanced', icons: 'nerd' });
+    expect('theme' in (result ?? {})).toBe(false);
+  });
+
+  it('down+Enter on step 1 picks minimal', async () => {
+    const stdin = createMockStdin(true);
+    const stdout = createMockStdout();
+    const p = runWizard({ stdin, stdout, current: {} });
+
+    await flush();
+    stdin.pressKey('down'); stdin.pressKey('return'); // minimal
+    await flush();
+    stdin.pressKey('return'); // (none)
+    await flush();
+    stdin.pressKey('return'); // nerd
+
+    expect(await p).toEqual({ preset: 'minimal', icons: 'nerd' });
+  });
+
+  it('Esc at step 1 resolves with null', async () => {
+    const stdin = createMockStdin(true);
+    const stdout = createMockStdout();
+    const p = runWizard({ stdin, stdout, current: {} });
+
+    await flush();
+    stdin.pressKey('escape');
+
+    expect(await p).toBeNull();
+  });
+
+  it('Esc at step 2 resolves with null (step 1 selection not persisted)', async () => {
+    const stdin = createMockStdin(true);
+    const stdout = createMockStdout();
+    const p = runWizard({ stdin, stdout, current: {} });
+
+    await flush();
+    stdin.pressKey('return'); // confirm step 1
+    await flush();
+    stdin.pressKey('escape'); // abort step 2
+
+    expect(await p).toBeNull();
+  });
+
+  it('pre-selects values from current config', async () => {
+    const stdin = createMockStdin(true);
+    const stdout = createMockStdout();
+    const p = runWizard({
+      stdin, stdout,
+      current: { preset: 'full', theme: 'dracula', icons: 'emoji' },
+    });
+
+    await flush();
+    stdin.pressKey('return'); // accept full
+    await flush();
+    stdin.pressKey('return'); // accept dracula
+    await flush();
+    stdin.pressKey('return'); // accept emoji
+
+    expect(await p).toEqual({ preset: 'full', theme: 'dracula', icons: 'emoji' });
+  });
+
+  it('selects dracula after down on step 2', async () => {
+    const stdin = createMockStdin(true);
+    const stdout = createMockStdout();
+    const p = runWizard({ stdin, stdout, current: {} });
+
+    await flush();
+    stdin.pressKey('return'); // step 1: balanced
+    await flush();
+    stdin.pressKey('down'); stdin.pressKey('return'); // theme step: from (none) → first real theme (dracula)
+    await flush();
+    stdin.pressKey('return'); // icons: nerd
+
+    const result = await p;
+    expect(result).toEqual({ preset: 'balanced', theme: 'dracula', icons: 'nerd' });
+  });
+});

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { install, uninstall } from '../src/installer.js';
@@ -204,5 +204,69 @@ describe('install — wizard integration', () => {
     const cfg = JSON.parse(readFileSync(configPath, 'utf8'));
     expect(cfg.display).toEqual({ tokens: false });
     expect(cfg.preset).toBe('balanced');
+  });
+});
+
+describe('install — skill dual install for Qwen', () => {
+  let tmpHome: string;
+  let claudeHome: string;
+  let qwenHome: string;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'lumira-home-'));
+    claudeHome = join(tmpHome, '.claude');
+    qwenHome = join(tmpHome, '.qwen');
+    mkdirSync(claudeHome, { recursive: true });
+  });
+  afterEach(() => { rmSync(tmpHome, { recursive: true, force: true }); });
+
+  it('installs skill only under .claude when ~/.qwen/ does not exist', async () => {
+    const settingsPath = join(claudeHome, 'settings.json');
+    const configPath = join(tmpHome, 'config.json');
+    const stdin = createMockStdin(false);
+
+    await install({
+      settingsPath, configPath,
+      confirm: async () => true,
+      stdin,
+      homeOverride: tmpHome,
+    });
+
+    expect(existsSync(join(claudeHome, 'skills', 'lumira', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(qwenHome, 'skills', 'lumira', 'SKILL.md'))).toBe(false);
+  });
+
+  it('installs skill under both .claude and .qwen when ~/.qwen/ exists', async () => {
+    mkdirSync(qwenHome, { recursive: true });
+    const settingsPath = join(claudeHome, 'settings.json');
+    const configPath = join(tmpHome, 'config.json');
+    const stdin = createMockStdin(false);
+
+    const output = await install({
+      settingsPath, configPath,
+      confirm: async () => true,
+      stdin,
+      homeOverride: tmpHome,
+    });
+
+    expect(existsSync(join(claudeHome, 'skills', 'lumira', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(qwenHome, 'skills', 'lumira', 'SKILL.md'))).toBe(true);
+    // Qwen-detection notice appears in summary
+    expect(output.toLowerCase()).toContain('qwen');
+  });
+
+  it('uninstall removes skill from both destinations', () => {
+    mkdirSync(join(claudeHome, 'skills', 'lumira'), { recursive: true });
+    writeFileSync(join(claudeHome, 'skills', 'lumira', 'SKILL.md'), 'dummy');
+    mkdirSync(join(qwenHome, 'skills', 'lumira'), { recursive: true });
+    writeFileSync(join(qwenHome, 'skills', 'lumira', 'SKILL.md'), 'dummy');
+
+    const settingsPath = join(claudeHome, 'settings.json');
+    writeFileSync(settingsPath, JSON.stringify({ statusLine: { type: 'command', command: 'npx lumira@latest' } }));
+
+    uninstall({ settingsPath, homeOverride: tmpHome });
+
+    expect(existsSync(join(claudeHome, 'skills', 'lumira', 'SKILL.md'))).toBe(false);
+    expect(existsSync(join(qwenHome, 'skills', 'lumira', 'SKILL.md'))).toBe(false);
   });
 });

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'no
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { install, uninstall } from '../src/installer.js';
+import { createMockStdin, createMockStdout } from './tui/_mock-stdin.js';
 
 describe('install', () => {
   let dir: string;
@@ -130,5 +131,78 @@ describe('uninstall', () => {
     // Should fall through to removing statusLine key
     const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
     expect(data.statusLine).toBeUndefined();
+  });
+});
+
+describe('install — wizard integration', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'lumira-wizard-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  async function flush() { await new Promise((r) => setImmediate(r)); }
+
+  it('writes config.json with wizard result after wizard completes', async () => {
+    const settingsPath = join(dir, 'settings.json');
+    const configPath = join(dir, 'config.json');
+    const stdin = createMockStdin(true);
+    const stdout = createMockStdout();
+
+    const promise = install({
+      settingsPath, configPath,
+      confirm: async () => true,
+      stdin, stdout,
+    });
+
+    // defaults: preset=balanced, theme=(none), icons=nerd
+    await flush(); stdin.pressKey('return');
+    await flush(); stdin.pressKey('return');
+    await flush(); stdin.pressKey('return');
+
+    await promise;
+    const cfg = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(cfg).toEqual({ preset: 'balanced', icons: 'nerd' });
+  });
+
+  it('skips wizard and writes defaults when stdin is not a TTY', async () => {
+    const settingsPath = join(dir, 'settings.json');
+    const configPath = join(dir, 'config.json');
+    const stdin = createMockStdin(false);
+
+    const output = await install({
+      settingsPath, configPath,
+      confirm: async () => true,
+      stdin,
+    });
+
+    const cfg = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(cfg).toEqual({ preset: 'balanced', icons: 'nerd' });
+    expect(output).toContain('Non-interactive');
+  });
+
+  it('aborts cleanly when user Escs — no settings.json, no config.json', async () => {
+    const settingsPath = join(dir, 'settings.json');
+    const configPath = join(dir, 'config.json');
+    const stdin = createMockStdin(true);
+
+    const promise = install({ settingsPath, configPath, confirm: async () => true, stdin });
+    await flush();
+    stdin.pressKey('escape');
+
+    const output = await promise;
+    expect(existsSync(settingsPath)).toBe(false);
+    expect(existsSync(configPath)).toBe(false);
+    expect(output.toLowerCase()).toContain('cancel');
+  });
+
+  it('preserves unrelated keys when config.json already has user edits', async () => {
+    const configPath = join(dir, 'config.json');
+    writeFileSync(configPath, JSON.stringify({ display: { tokens: false } }));
+    const settingsPath = join(dir, 'settings.json');
+    const stdin = createMockStdin(false);
+
+    await install({ settingsPath, configPath, confirm: async () => true, stdin });
+    const cfg = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(cfg.display).toEqual({ tokens: false });
+    expect(cfg.preset).toBe('balanced');
   });
 });

--- a/tests/render/index.test.ts
+++ b/tests/render/index.test.ts
@@ -2,11 +2,16 @@ import { describe, it, expect } from 'vitest';
 import { render } from '../../src/render/index.js';
 import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, type RenderContext } from '../../src/types.js';
 import { NERD_ICONS, EMOJI_ICONS } from '../../src/render/icons.js';
-import { normalize } from '../../src/normalize.js';
+import { normalize, type Platform } from '../../src/normalize.js';
 
 function makeCtx(ov: Partial<RenderContext> = {}): RenderContext {
   const rawInput = { model: 'Opus', session_id: 't', context_window: { used_percentage: 50, remaining_percentage: 50 }, cost: { total_cost_usd: 1, total_duration_ms: 60000 }, workspace: { current_dir: '/p' } } as any;
   return { input: normalize(rawInput), git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT, tokenSpeed: null, memory: null, gsd: null, mcp: null, cols: 120, config: { ...DEFAULT_CONFIG }, icons: NERD_ICONS, ...ov };
+}
+
+function makeCtxWithPlatform(platform: Platform, layout: typeof DEFAULT_CONFIG['layout'] = 'multiline'): RenderContext {
+  const base = makeCtx({ config: { ...DEFAULT_CONFIG, layout } });
+  return { ...base, input: { ...base.input, platform } };
 }
 
 describe('render', () => {
@@ -20,5 +25,9 @@ describe('render', () => {
   it('renders with emoji icons without crashing', () => {
     const out = render(makeCtx({ icons: EMOJI_ICONS }));
     expect(out.length).toBeGreaterThan(0);
+  });
+  it('forces singleline when input platform is qwen-code, even with multiline layout', () => {
+    const out = render(makeCtxWithPlatform('qwen-code', 'multiline'));
+    expect(out.split('\n').length).toBeLessThanOrEqual(1);
   });
 });

--- a/tests/render/line1.test.ts
+++ b/tests/render/line1.test.ts
@@ -84,4 +84,26 @@ describe('renderLine1', () => {
     const out = stripAnsi(renderLine1(makeCtx({}, inputOverride), c));
     expect(out).toContain('Sonnet 3.7');
   });
+
+  it('truncates long branch at narrow terminal (cols=59)', () => {
+    const longBranch = 'feat/ca-71-some-very-long-branch-description-that-exceeds-limit';
+    const out = stripAnsi(renderLine1(makeCtx({ git: { ...git, branch: longBranch }, cols: 59 }), c));
+    expect(out).not.toContain(longBranch);
+    expect(out).toContain('…');
+  });
+
+  it('shows more branch text at wide terminal than at narrow', () => {
+    const longBranch = 'feat/ca-71-some-long-description-that-was-truncated-before';
+    const narrow = stripAnsi(renderLine1(makeCtx({ git: { ...git, branch: longBranch }, cols: 79 }), c));
+    const wide = stripAnsi(renderLine1(makeCtx({ git: { ...git, branch: longBranch }, cols: 120 }), c));
+    const branchInNarrow = narrow.match(/feat\/[^\s]*/)?.[0] ?? '';
+    const branchInWide = wide.match(/feat\/[^\s]*/)?.[0] ?? '';
+    expect(branchInWide.length).toBeGreaterThan(branchInNarrow.length);
+  });
+
+  it('does not overflow layout at cols=120 with long model and branch', () => {
+    const longBranch = 'feat/ca-71-some-long-description-that-was-truncated-before';
+    const out = stripAnsi(renderLine1(makeCtx({ git: { ...git, branch: longBranch }, cols: 120 }), c));
+    expect(out.length).toBeLessThanOrEqual(120);
+  });
 });

--- a/tests/render/text.test.ts
+++ b/tests/render/text.test.ts
@@ -36,6 +36,33 @@ describe('fitSegments', () => {
     const result = fitSegments(['LEFT'], ['RIGHT'], ' | ', 10);
     expect(result).toContain('LEFT');
   });
+
+  it('drops tail left segment when left alone overflows', () => {
+    const model = 'A'.repeat(20);
+    const branch = 'B'.repeat(85);
+    const dir = 'C'.repeat(25);
+    const result = fitSegments([model, branch, dir], [], ' | ', 120);
+    expect(displayWidth(result)).toBeLessThanOrEqual(116);
+    expect(result).not.toContain('C'.repeat(25));
+  });
+
+  it('last-resort: truncates single oversized segment without ANSI bleed', () => {
+    const result = fitSegments(['X'.repeat(200)], [], ' | ', 50);
+    expect(displayWidth(result)).toBeLessThanOrEqual(46);
+    expect(result.endsWith('…')).toBe(true);
+  });
+
+  it('ANSI-colored left that overflows stays within displayWidth bounds', () => {
+    const colored = `\x1b[36m${'B'.repeat(90)}\x1b[0m`;
+    const result = fitSegments([colored], [], ' | ', 80);
+    expect(displayWidth(result)).toBeLessThanOrEqual(76);
+  });
+
+  it('leftW === safeCols exactly returns left unchanged', () => {
+    const left = 'A'.repeat(16); // safeCols = 20-4 = 16
+    const result = fitSegments([left], [], ' | ', 20);
+    expect(result).toBe(left);
+  });
 });
 
 describe('padLine', () => {

--- a/tests/tui/_mock-stdin.ts
+++ b/tests/tui/_mock-stdin.ts
@@ -1,0 +1,42 @@
+import { EventEmitter } from 'node:events';
+
+export interface MockStdin extends EventEmitter {
+  isTTY: boolean;
+  isRaw: boolean;
+  setRawMode(flag: boolean): MockStdin;
+  resume(): MockStdin;
+  pause(): MockStdin;
+  pressKey(name: string, opts?: { ctrl?: boolean; shift?: boolean; meta?: boolean }): void;
+  emitEnd(): void;
+}
+
+export function createMockStdin(isTTY = true): MockStdin {
+  const ee = new EventEmitter() as MockStdin;
+  ee.isTTY = isTTY;
+  ee.isRaw = false;
+  ee.setRawMode = function (flag: boolean) { this.isRaw = flag; return this; };
+  ee.resume = function () { return this; };
+  ee.pause = function () { return this; };
+  ee.pressKey = function (name: string, opts = {}) {
+    const seq = name === 'return' ? '\r' : '';
+    this.emit('keypress', seq, { name, ctrl: !!opts.ctrl, shift: !!opts.shift, meta: !!opts.meta });
+  };
+  ee.emitEnd = function () { this.emit('end'); };
+  return ee;
+}
+
+export interface MockStdout extends EventEmitter {
+  columns: number;
+  rows: number;
+  written: string[];
+  write(chunk: string): boolean;
+}
+
+export function createMockStdout(columns = 100): MockStdout {
+  const ee = new EventEmitter() as MockStdout;
+  ee.columns = columns;
+  ee.rows = 30;
+  ee.written = [];
+  ee.write = function (chunk: string) { this.written.push(chunk); return true; };
+  return ee;
+}

--- a/tests/tui/banner.test.ts
+++ b/tests/tui/banner.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { getBanner, getSubtitle } from '../../src/tui/banner.js';
+
+describe('getBanner', () => {
+  it('returns a banner string with cyan ANSI and the logo', () => {
+    const b = getBanner({ width: 80 });
+    expect(b).toContain('\x1b[36m');
+    expect(b).toContain('\x1b[0m');
+    expect(b).toContain('██╗     ██╗');
+  });
+
+  it('returns empty string when width < 50', () => {
+    expect(getBanner({ width: 40 })).toBe('');
+  });
+
+  it('uses process.stdout.columns when no width opt is passed', () => {
+    // Only assert type/truthiness — real columns var is environment-dependent
+    const b = getBanner();
+    expect(typeof b).toBe('string');
+  });
+});
+
+describe('getSubtitle', () => {
+  it('reads version from package.json', () => {
+    const s = getSubtitle();
+    expect(s).toMatch(/real-time statusline for claude code & qwen code · v\d+\.\d+\.\d+/);
+  });
+
+  it('falls back to subtitle without version if read fails', () => {
+    const s = getSubtitle({ readPackageJson: () => { throw new Error('boom'); } });
+    expect(s).toBe('real-time statusline for claude code & qwen code');
+  });
+
+  it('falls back to base subtitle when package.json has no version field', () => {
+    const s = getSubtitle({ readPackageJson: () => JSON.stringify({ name: 'x' }) });
+    expect(s).toBe('real-time statusline for claude code & qwen code');
+  });
+});

--- a/tests/tui/preview.test.ts
+++ b/tests/tui/preview.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { buildPreview } from '../../src/tui/preview.js';
+
+describe('buildPreview', () => {
+  it('returns a non-empty string for preset "balanced"', () => {
+    const out = buildPreview({ preset: 'balanced', icons: 'nerd' });
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it('dracula theme in truecolor emits a dracula RGB code', () => {
+    const out = buildPreview({ preset: 'full', theme: 'dracula', icons: 'nerd', colorMode: 'truecolor' });
+    // Dracula cyan: rgb(139, 233, 253)
+    expect(out).toContain('\x1b[38;2;139;233;253m');
+  });
+
+  it('named color mode does not emit 24-bit RGB escapes', () => {
+    const out = buildPreview({ preset: 'full', theme: 'dracula', icons: 'nerd', colorMode: 'named' });
+    expect(out).not.toContain('\x1b[38;2;');
+  });
+
+  it('icons="none" produces no Nerd Font codepoints (Private Use Area)', () => {
+    const out = buildPreview({ preset: 'full', icons: 'none' });
+    expect(/[\uE000-\uF8FF]/.test(out)).toBe(false);
+  });
+
+  it('catches renderer exceptions and returns fallback', () => {
+    const out = buildPreview({ preset: 'balanced', icons: 'nerd' }, {
+      render: () => { throw new Error('boom'); },
+    });
+    expect(out).toBe('(preview unavailable)');
+  });
+});

--- a/tests/tui/select.test.ts
+++ b/tests/tui/select.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { interactiveSelect } from '../../src/tui/select.js';
+import { createMockStdin, createMockStdout } from './_mock-stdin.js';
+
+describe('interactiveSelect — non-TTY', () => {
+  it('returns null immediately when stdin is not a TTY', async () => {
+    const stdin = createMockStdin(false);
+    const stdout = createMockStdout();
+    const result = await interactiveSelect({
+      title: 'pick',
+      options: [{ label: 'a', value: 'a' }, { label: 'b', value: 'b' }],
+      initial: 'a',
+      preview: () => 'preview',
+      stdin, stdout,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('never enters raw mode when stdin is not a TTY', async () => {
+    const stdin = createMockStdin(false);
+    const stdout = createMockStdout();
+    await interactiveSelect({
+      title: 'pick',
+      options: [{ label: 'a', value: 'a' }],
+      initial: 'a',
+      preview: () => '',
+      stdin, stdout,
+    });
+    expect(stdin.isRaw).toBe(false);
+  });
+
+  it('does not write to stdout when non-TTY', async () => {
+    const stdin = createMockStdin(false);
+    const stdout = createMockStdout();
+    await interactiveSelect({
+      title: 'pick',
+      options: [{ label: 'a', value: 'a' }],
+      initial: 'a',
+      preview: () => '',
+      stdin, stdout,
+    });
+    expect(stdout.written).toEqual([]);
+  });
+});

--- a/tests/tui/select.test.ts
+++ b/tests/tui/select.test.ts
@@ -131,3 +131,70 @@ describe('interactiveSelect — navigation', () => {
     expect(out).toContain('\x1b[?25l'); // hide-cursor (written earlier)
   });
 });
+
+describe('interactiveSelect — abort and resize', () => {
+  const makeOpts = () => ({
+    stdin: createMockStdin(true),
+    stdout: createMockStdout(),
+    title: 'pick',
+    options: [{ label: 'a', value: 'a' }, { label: 'b', value: 'b' }],
+    initial: 'a',
+    preview: () => '',
+  });
+
+  it('Esc resolves with null', async () => {
+    const opts = makeOpts();
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.pressKey('escape');
+    expect(await promise).toBeNull();
+  });
+
+  it('q resolves with null', async () => {
+    const opts = makeOpts();
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.pressKey('q');
+    expect(await promise).toBeNull();
+  });
+
+  it('Ctrl+C resolves with null', async () => {
+    const opts = makeOpts();
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.pressKey('c', { ctrl: true });
+    expect(await promise).toBeNull();
+  });
+
+  it('stdin end event resolves with null', async () => {
+    const opts = makeOpts();
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.emitEnd();
+    expect(await promise).toBeNull();
+  });
+
+  it('resize event triggers a re-render', async () => {
+    const opts = makeOpts();
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    const beforeCount = opts.stdout.written.filter((c) => c.includes('\x1b[2J')).length;
+    opts.stdout.emit('resize');
+    await new Promise((r) => setImmediate(r));
+    const afterCount = opts.stdout.written.filter((c) => c.includes('\x1b[2J')).length;
+    expect(afterCount).toBeGreaterThan(beforeCount);
+    opts.stdin.pressKey('return');
+    await promise;
+  });
+
+  it('cleans up resize and end listeners after abort', async () => {
+    const opts = makeOpts();
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.pressKey('escape');
+    await promise;
+    // After cleanup, there should be no more listeners on 'resize' / 'end'
+    expect(opts.stdout.listenerCount('resize')).toBe(0);
+    expect(opts.stdin.listenerCount('end')).toBe(0);
+  });
+});

--- a/tests/tui/select.test.ts
+++ b/tests/tui/select.test.ts
@@ -42,3 +42,92 @@ describe('interactiveSelect — non-TTY', () => {
     expect(stdout.written).toEqual([]);
   });
 });
+
+describe('interactiveSelect — navigation', () => {
+  const makeOpts = (overrides: Record<string, unknown> = {}) => {
+    const stdin = createMockStdin(true);
+    const stdout = createMockStdout();
+    return {
+      stdin, stdout,
+      title: 'pick',
+      options: [
+        { label: 'a', value: 'a' },
+        { label: 'b', value: 'b' },
+        { label: 'c', value: 'c' },
+      ],
+      initial: 'b',
+      preview: () => 'p',
+      ...overrides,
+    };
+  };
+
+  it('Enter on initial focus resolves with that value', async () => {
+    const opts = makeOpts();
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.pressKey('return');
+    expect(await promise).toBe('b');
+  });
+
+  it('Down then Enter resolves with the next value', async () => {
+    const opts = makeOpts();
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.pressKey('down');
+    opts.stdin.pressKey('return');
+    expect(await promise).toBe('c');
+  });
+
+  it('Up from first wraps to last', async () => {
+    const opts = makeOpts({ initial: 'a' });
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.pressKey('up');
+    opts.stdin.pressKey('return');
+    expect(await promise).toBe('c');
+  });
+
+  it('Down from last wraps to first', async () => {
+    const opts = makeOpts({ initial: 'c' });
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.pressKey('down');
+    opts.stdin.pressKey('return');
+    expect(await promise).toBe('a');
+  });
+
+  it('j/k navigate identically to down/up', async () => {
+    const opts = makeOpts();
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.pressKey('j');
+    opts.stdin.pressKey('return');
+    expect(await promise).toBe('c');
+  });
+
+  it('invokes preview with the focused value on each move', async () => {
+    const calls: string[] = [];
+    const opts = makeOpts({ preview: (v: string) => { calls.push(v); return v; } });
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    opts.stdin.pressKey('down');
+    opts.stdin.pressKey('down');
+    opts.stdin.pressKey('return');
+    await promise;
+    // initial render (b), after down (c), after down wrap (a)
+    expect(calls).toEqual(['b', 'c', 'a']);
+  });
+
+  it('restores stdin to non-raw and shows cursor after resolve', async () => {
+    const opts = makeOpts();
+    const promise = interactiveSelect(opts);
+    await new Promise((r) => setImmediate(r));
+    expect(opts.stdin.isRaw).toBe(true);
+    opts.stdin.pressKey('return');
+    await promise;
+    expect(opts.stdin.isRaw).toBe(false);
+    const out = opts.stdout.written.join('');
+    expect(out).toContain('\x1b[?25h'); // show-cursor
+    expect(out).toContain('\x1b[?25l'); // hide-cursor (written earlier)
+  });
+});


### PR DESCRIPTION
## Release v0.3.1

### Added
- Interactive install wizard (`npx lumira install`) with arrow-key navigation and live preview
- ASCII banner on install with dynamic version
- `/lumira` skill installed for Qwen Code when `~/.qwen/` is detected
- Render layer auto-switches to single-line for Qwen Code callers

### Changed
- `saveConfig` writes atomically with `0o600` permissions
- Branch name display caps raised across all terminal widths
- `fitSegments` drops tail left segments on overflow, preventing terminal line wrap

### Removed
- **BREAKING:** `qwen` preset removed — existing configs coerced to `minimal` with a one-shot warning

---
Merging this PR will trigger the GitHub Actions release workflow, create tag `v0.3.1`, and publish to npm.