### PR TITLE
fix: sanitize transcript + gsd strings before terminal output

### DIFF
--- a/src/parsers/gsd.ts
+++ b/src/parsers/gsd.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import type { GsdInfo } from '../types.js';
+import { sanitizeTermString } from '../normalize.js';
 
 export function getGsdInfo(session: string, claudeDir: string = join(process.env['CLAUDE_CONFIG_DIR'] || join(homedir(), '.claude'))): GsdInfo | null {
   let updateAvailable = false;
@@ -21,7 +22,7 @@ export function getGsdInfo(session: string, claudeDir: string = join(process.env
         if (!resolve(todoPath).startsWith(resolve(todosDir))) return null;
         const todos = JSON.parse(readFileSync(resolve(todoPath), 'utf8'));
         const ip = todos.find((t: { status: string; activeForm?: string }) => t.status === 'in_progress');
-        if (ip?.activeForm) currentTask = ip.activeForm;
+        if (ip?.activeForm) currentTask = sanitizeTermString(String(ip.activeForm));
       }
     } catch {}
   }

--- a/src/parsers/transcript.ts
+++ b/src/parsers/transcript.ts
@@ -5,6 +5,7 @@ import { homedir, tmpdir } from 'node:os';
 import type { TranscriptData, ToolEntry, AgentEntry, TodoEntry, TodoStatus, ThinkingEffort } from '../types.js';
 import { EMPTY_TRANSCRIPT } from '../types.js';
 import { isMtimeFresh, getMtimeState, type MtimeState } from '../utils/cache.js';
+import { sanitizeTermString } from '../normalize.js';
 
 const transcriptCache = new Map<string, { result: TranscriptData; mtime: MtimeState }>();
 
@@ -20,17 +21,20 @@ export function normalizeTodoStatus(status: string | undefined): TodoStatus {
 
 export function extractToolTarget(toolName: string, input: Record<string, unknown> | undefined): string | undefined {
   if (!input) return undefined;
-  switch (toolName) {
-    case 'Read': case 'Write': case 'Edit':
-      return (input.file_path ?? input.path) as string | undefined;
-    case 'Glob': case 'Grep':
-      return input.pattern as string | undefined;
-    case 'Bash': {
-      const cmd = (input.command as string) || '';
-      return cmd.length > 30 ? cmd.slice(0, 30) + '...' : cmd;
+  const raw = (() => {
+    switch (toolName) {
+      case 'Read': case 'Write': case 'Edit':
+        return (input.file_path ?? input.path) as string | undefined;
+      case 'Glob': case 'Grep':
+        return input.pattern as string | undefined;
+      case 'Bash': {
+        const cmd = (input.command as string) || '';
+        return cmd.length > 30 ? cmd.slice(0, 30) + '...' : cmd;
+      }
+      default: return undefined;
     }
-    default: return undefined;
-  }
+  })();
+  return typeof raw === 'string' ? sanitizeTermString(raw) : raw;
 }
 
 export async function parseTranscript(transcriptPath: string): Promise<TranscriptData> {
@@ -75,11 +79,18 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
 
         for (const block of content) {
           if (block.type === 'tool_use' && block.id && block.name) {
-            toolMap.set(block.id, { id: block.id, name: block.name, target: extractToolTarget(block.name, block.input), status: 'running', startTime: timestamp });
+            toolMap.set(block.id, { id: block.id, name: sanitizeTermString(block.name), target: extractToolTarget(block.name, block.input), status: 'running', startTime: timestamp });
 
             if (block.name === 'Task') {
               const inp = block.input || {};
-              agentMap.set(block.id, { id: block.id, type: inp.subagent_type || 'unknown', model: inp.model, description: inp.description, status: 'running', startTime: timestamp });
+              agentMap.set(block.id, {
+                id: block.id,
+                type: sanitizeTermString(inp.subagent_type || 'unknown'),
+                model: typeof inp.model === 'string' ? sanitizeTermString(inp.model) : inp.model,
+                description: typeof inp.description === 'string' ? sanitizeTermString(inp.description) : inp.description,
+                status: 'running',
+                startTime: timestamp,
+              });
             }
 
             if (block.name === 'TodoWrite' && block.input?.todos && Array.isArray(block.input.todos)) {
@@ -88,14 +99,14 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
                 const id = t.id || t.content || '';
                 const existing = existingById.get(id);
                 if (existing && (!t.status || t.status === existing.status)) return existing;
-                return { id: t.id || '', content: t.content || '', status: normalizeTodoStatus(t.status) };
+                return { id: t.id || '', content: sanitizeTermString(t.content || ''), status: normalizeTodoStatus(t.status) };
               });
             }
 
             if (block.name === 'TaskCreate') {
               const inp = block.input || {};
               const todoContent = (typeof inp.subject === 'string' ? inp.subject : '') || (typeof inp.description === 'string' ? inp.description : '') || 'Untitled task';
-              todos.push({ id: inp.taskId || block.id, content: todoContent, status: normalizeTodoStatus(inp.status) });
+              todos.push({ id: inp.taskId || block.id, content: sanitizeTermString(todoContent), status: normalizeTodoStatus(inp.status) });
               if (inp.taskId || block.id) taskIdToIndex.set(String(inp.taskId || block.id), todos.length - 1);
             }
 
@@ -110,7 +121,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
                 if (inp.status) todos[index].status = normalizeTodoStatus(inp.status);
                 const subj = typeof inp.subject === 'string' ? inp.subject : '';
                 const desc = typeof inp.description === 'string' ? inp.description : '';
-                if (subj || desc) todos[index].content = subj || desc;
+                if (subj || desc) todos[index].content = sanitizeTermString(subj || desc);
               }
             }
           }

--- a/tests/parsers/gsd.test.ts
+++ b/tests/parsers/gsd.test.ts
@@ -38,4 +38,13 @@ describe('getGsdInfo', () => {
     writeFileSync(join(dir, 'todos', 's-agent-1.json'), 'broken json');
     expect(getGsdInfo('s', dir)).toBeNull();
   });
+
+  it('sanitizes control characters from currentTask', () => {
+    const malicious = 'Safe\x1b[31mPart\x00\x07\x7fend';
+    writeFileSync(join(dir, 'todos', 's-agent-1.json'), JSON.stringify([{ status: 'in_progress', activeForm: malicious }]));
+    const task = getGsdInfo('s', dir)?.currentTask ?? '';
+    expect(task).not.toMatch(/[\x00-\x1f\x7f-\x9f]/);
+    expect(task).toContain('Safe');
+    expect(task).toContain('end');
+  });
 });

--- a/tests/parsers/transcript.test.ts
+++ b/tests/parsers/transcript.test.ts
@@ -62,6 +62,15 @@ describe('extractToolTarget', () => {
   it('extracts pattern for Glob/Grep', () => { expect(extractToolTarget('Glob', { pattern: '**/*.ts' })).toBe('**/*.ts'); });
   it('truncates Bash command at 30 chars', () => { expect(extractToolTarget('Bash', { command: 'a'.repeat(50) })).toBe('a'.repeat(30) + '...'); });
   it('returns undefined for unknown tools', () => { expect(extractToolTarget('Unknown', {})).toBeUndefined(); });
+  it('strips control characters from file_path targets', () => {
+    const result = extractToolTarget('Read', { file_path: '/safe\x1b[31m/evil\x00.ts' });
+    expect(result).not.toMatch(/[\x00-\x1f\x7f-\x9f]/);
+    expect(result).toContain('/safe');
+  });
+  it('strips control characters from Bash commands', () => {
+    const result = extractToolTarget('Bash', { command: 'ls\x1b[31m -la\x07' });
+    expect(result).not.toMatch(/[\x00-\x1f\x7f-\x9f]/);
+  });
 });
 
 describe('normalizeTodoStatus', () => {


### PR DESCRIPTION
## Summary

Applies \`sanitizeTermString()\` at two parser boundaries that were bypassing the sanitization the normalize layer already applies to stdin JSON.

- **Transcript parser** (\`parsers/transcript.ts\`) — tool names, targets (file paths / patterns / Bash commands), todo content, and agent type/model/description sanitized before being cached in \`ToolEntry\` / \`AgentEntry\` / \`TodoEntry\`.
- **GSD parser** (\`parsers/gsd.ts\`) — \`currentTask\` from local JSON files sanitized before returning.

Both parsers read user-controlled files (transcript JSONL in \`~/.claude\`, GSD todo JSON). A malformed or adversarial file could previously inject C0/C1/DEL control sequences reaching the terminal via \`line1\`, \`line3\`, \`line4\`, and \`minimal\`.

Closes #14
Closes #15

## Test plan

- 357 tests passing (\`npm test\`)
- New tests: \`extractToolTarget\` strips control chars from file paths and Bash commands
- New test: \`getGsdInfo\` strips control chars from \`currentTask\`