### PR TITLE
chore: document module-level state and pin vitest to forks pool

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,9 @@ import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { DEFAULT_CONFIG, DEFAULT_DISPLAY, type HudConfig, type DisplayToggles, type ColorConfig } from './types.js';
 
+// Module-level flag: fires the qwen→minimal deprecation warning once per
+// Node process. Process-scoped by design — tests must run in forked workers
+// (see vitest.config.ts `pool: 'forks'`). Issue #20.
 let qwenWarningShown = false;
 /** Test-only — resets the process-scoped qwenWarningShown flag. Do not call in production. */
 export function _resetMigrationFlags(): void { qwenWarningShown = false; }

--- a/src/tui/select.ts
+++ b/src/tui/select.ts
@@ -42,6 +42,9 @@ const SHOW_CURSOR = '\x1b[?25h';
 const HIDE_CURSOR = '\x1b[?25l';
 const CLEAR_SCREEN = '\x1b[2J\x1b[H';
 
+// Module-level flag: guarantees the raw-mode cleanup exit handler is
+// registered once per Node process. Process-scoped by design — tests must
+// run in forked workers (see vitest.config.ts `pool: 'forks'`). Issue #20.
 let exitHandlerInstalled = false;
 function installExitHandler(stdin: SelectStdin, stdout: SelectStdout): void {
   if (exitHandlerInstalled) return;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,11 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['tests/**/*.test.ts'],
+    // Forked workers required: src/config.ts (qwenWarningShown) and
+    // src/tui/select.ts (exitHandlerInstalled) carry module-level flags
+    // that rely on per-process isolation. Switching to `pool: 'threads'`
+    // would cause parallel tests to share these flags and race. See #20.
+    pool: 'forks',
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
## Summary

Applies the cheapest of the three options proposed in #20: document the process-isolation constraint rather than restructure the state.

- Pins vitest to \`pool: 'forks'\` explicitly (already the default) with a comment explaining why.
- Adds pointer comments on \`qwenWarningShown\` (src/config.ts) and \`exitHandlerInstalled\` (src/tui/select.ts) so future contributors understand they rely on per-process isolation.

No behavior change — tests still pass, no runtime deps added. If we ever need parallelism with threads, issue #20 documents the refactor path (symbol-keyed global or injected state owner).

Closes #20

## Test plan
- 357 tests passing (\`npm test\`)