### PR TITLE
refactor(installer): collapse dual-path install flow

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -131,6 +131,32 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
     }
   }
 
+  // ── settings.json read + early replacement confirmation ───────
+  // Read settings and confirm before running the wizard, so the user
+  // doesn't waste time configuring preset/theme/icons only to decline
+  // the replacement at the end.
+  let settings: Record<string, unknown> = {};
+
+  if (existsSync(settingsPath)) {
+    try {
+      settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    } catch {
+      lines.push(warn('Could not parse existing settings.json, creating fresh'));
+      settings = {};
+    }
+  }
+
+  const hasForeignStatusLine = settings.statusLine && !isLumira(settings.statusLine);
+  if (hasForeignStatusLine) {
+    const currentCmd = (settings.statusLine as Record<string, unknown>).command ?? 'unknown';
+    lines.push(warn(`Current statusline: ${YELLOW}${currentCmd}${RST}`));
+    const accepted = await confirm('Replace with lumira?');
+    if (!accepted) {
+      lines.push(`\n  Aborted. No changes made.\n`);
+      return lines.join('\n') + '\n';
+    }
+  }
+
   // Load existing config to pre-populate wizard selections
   const existingConfig = loadConfig(dirname(configPath));
   const current = {
@@ -154,18 +180,7 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
     lines.push(ok('Non-interactive mode — using defaults (preset: balanced, icons: nerd)'));
   }
 
-  // ── settings.json read/replace/backup ──────────────────────────
-  let settings: Record<string, unknown> = {};
-
-  if (existsSync(settingsPath)) {
-    try {
-      settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
-    } catch {
-      lines.push(warn('Could not parse existing settings.json, creating fresh'));
-      settings = {};
-    }
-  }
-
+  // ── settings.json replace/backup ───────────────────────────────
   if (settings.statusLine) {
     if (isLumira(settings.statusLine)) {
       lines.push(ok('lumira is already configured as your statusline'));
@@ -175,14 +190,7 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
       return lines.join('\n') + '\n';
     }
 
-    const currentCmd = (settings.statusLine as Record<string, unknown>).command ?? 'unknown';
-    lines.push(warn(`Current statusline: ${YELLOW}${currentCmd}${RST}`));
-    const accepted = await confirm('Replace with lumira?');
-    if (!accepted) {
-      lines.push(`\n  Aborted. No changes made.\n`);
-      return lines.join('\n') + '\n';
-    }
-
+    // Foreign statusLine already confirmed above — back it up and replace.
     copyFileSync(settingsPath, backupPath);
     lines.push(ok(`Backed up existing settings → ${DIM}settings.json.lumira.bak${RST}`));
   }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -98,120 +98,63 @@ function installSkill(opts: { homeOverride?: string } = {}): string[] {
   return lines;
 }
 
+// Shared footer emitted at the end of every successful install path:
+// skill install + Qwen-detected notice + restart message. Keeps the two
+// success branches (already-configured vs fresh-install) from drifting.
+function emitFooter(lines: string[], homeOverride?: string): void {
+  lines.push(...installSkill({ homeOverride }));
+  if (existsSync(join(homeOverride ?? homedir(), '.qwen'))) {
+    lines.push('');
+    lines.push('  ℹ Qwen Code detected — in Qwen sessions, lumira renders');
+    lines.push('    single-line automatically. Your preset above applies to Claude Code.');
+  }
+  lines.push(`\n  Restart Claude Code to see your statusline.\n`);
+}
+
 // ── Install ─────────────────────────────────────────────────────────
 export async function install(opts: InstallerOptions = {}): Promise<string> {
   const settingsPath = opts.settingsPath ?? defaultSettingsPath();
+  const configPath = opts.configPath ?? defaultConfigPath();
   const backupPath = settingsPath + '.lumira.bak';
   const confirm = opts.confirm ?? promptYN;
+  const stdin = opts.stdin ?? process.stdin;
+  const stdout = opts.stdout ?? process.stdout;
   const lines: string[] = [];
 
-  // ── Wizard / config path ─────────────────────────────────────────
-  // When configPath is not provided, skip the wizard and config write
-  // entirely (legacy path — preserves existing test behaviour).
-  const runInteractive = opts.configPath !== undefined;
-
-  if (runInteractive) {
-    const configPath = opts.configPath as string;
-    const stdin = opts.stdin ?? process.stdin;
-    const stdout = opts.stdout ?? process.stdout;
-
-    // Build banner prelude (shown on each wizard frame so it survives screen clears)
-    let prelude = '';
-    if (stdin?.isTTY) {
-      const banner = getBanner({ width: (stdout as { columns?: number } | undefined)?.columns });
-      if (banner) {
-        const subtitle = getSubtitle();
-        prelude = banner + '\n ' + subtitle + '\n\n';
-      }
+  // Build banner prelude (shown on each wizard frame so it survives screen clears)
+  let prelude = '';
+  if (stdin?.isTTY) {
+    const banner = getBanner({ width: (stdout as { columns?: number } | undefined)?.columns });
+    if (banner) {
+      const subtitle = getSubtitle();
+      prelude = banner + '\n ' + subtitle + '\n\n';
     }
-
-    // Load existing config to pre-populate wizard selections
-    const existingConfig = loadConfig(dirname(configPath));
-    const current = {
-      preset: existingConfig.preset,
-      theme: existingConfig.theme,
-      icons: existingConfig.icons,
-    };
-
-    // Determine wizard result
-    let wizard: WizardResult;
-    if (stdin?.isTTY) {
-      const result = await runWizard({ current, prelude, stdin, stdout });
-      if (result === null) {
-        lines.push(`\n  Installation cancelled.\n`);
-        return lines.join('\n') + '\n';
-      }
-      wizard = result;
-    } else {
-      // Non-TTY: use defaults
-      wizard = { preset: 'balanced', icons: 'nerd' };
-      lines.push(ok('Non-interactive mode — using defaults (preset: balanced, icons: nerd)'));
-    }
-
-    // ── settings.json read/replace/backup ──────────────────────────
-    let settings: Record<string, unknown> = {};
-
-    if (existsSync(settingsPath)) {
-      try {
-        settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
-      } catch {
-        lines.push(warn('Could not parse existing settings.json, creating fresh'));
-        settings = {};
-      }
-    }
-
-    if (settings.statusLine) {
-      if (isLumira(settings.statusLine)) {
-        lines.push(ok('lumira is already configured as your statusline'));
-        saveConfig(wizard, configPath);
-        lines.push(ok(`Saved config → ${DIM}${configPath}${RST}`));
-        lines.push(...installSkill({ homeOverride: opts.homeOverride }));
-
-        if (existsSync(join(opts.homeOverride ?? homedir(), '.qwen'))) {
-          lines.push('');
-          lines.push('  \u2139 Qwen Code detected — in Qwen sessions, lumira renders');
-          lines.push('    single-line automatically. Your preset above applies to Claude Code.');
-        }
-
-        lines.push(`\n  Restart Claude Code to see your statusline.\n`);
-        return lines.join('\n') + '\n';
-      }
-
-      const currentCmd = (settings.statusLine as Record<string, unknown>).command ?? 'unknown';
-      lines.push(warn(`Current statusline: ${YELLOW}${currentCmd}${RST}`));
-      const accepted = await confirm('Replace with lumira?');
-      if (!accepted) {
-        lines.push(`\n  Aborted. No changes made.\n`);
-        return lines.join('\n') + '\n';
-      }
-
-      copyFileSync(settingsPath, backupPath);
-      lines.push(ok(`Backed up existing settings → ${DIM}settings.json.lumira.bak${RST}`));
-    }
-
-    settings.statusLine = { ...LUMIRA_STATUSLINE };
-    mkdirSync(dirname(settingsPath), { recursive: true });
-    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', { mode: 0o600 });
-    lines.push(ok('Configured lumira as statusline'));
-
-    saveConfig(wizard, configPath);
-    lines.push(ok(`Saved config → ${DIM}${configPath}${RST}`));
-
-    lines.push(...installSkill({ homeOverride: opts.homeOverride }));
-
-    if (existsSync(join(opts.homeOverride ?? homedir(), '.qwen'))) {
-      lines.push('');
-      lines.push('  \u2139 Qwen Code detected — in Qwen sessions, lumira renders');
-      lines.push('    single-line automatically. Your preset above applies to Claude Code.');
-    }
-
-    lines.push(`\n  Restart Claude Code to see your statusline.\n`);
-    return lines.join('\n') + '\n';
   }
 
-  // ── Legacy path (no configPath) — original behaviour ─────────────
-  lines.push(header());
+  // Load existing config to pre-populate wizard selections
+  const existingConfig = loadConfig(dirname(configPath));
+  const current = {
+    preset: existingConfig.preset,
+    theme: existingConfig.theme,
+    icons: existingConfig.icons,
+  };
 
+  // Determine wizard result
+  let wizard: WizardResult;
+  if (stdin?.isTTY) {
+    const result = await runWizard({ current, prelude, stdin, stdout });
+    if (result === null) {
+      lines.push(`\n  Installation cancelled.\n`);
+      return lines.join('\n') + '\n';
+    }
+    wizard = result;
+  } else {
+    // Non-TTY: use defaults
+    wizard = { preset: 'balanced', icons: 'nerd' };
+    lines.push(ok('Non-interactive mode — using defaults (preset: balanced, icons: nerd)'));
+  }
+
+  // ── settings.json read/replace/backup ──────────────────────────
   let settings: Record<string, unknown> = {};
 
   if (existsSync(settingsPath)) {
@@ -226,12 +169,14 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
   if (settings.statusLine) {
     if (isLumira(settings.statusLine)) {
       lines.push(ok('lumira is already configured as your statusline'));
-      lines.push(...installSkill({ homeOverride: opts.homeOverride }));
+      saveConfig(wizard, configPath);
+      lines.push(ok(`Saved config → ${DIM}${configPath}${RST}`));
+      emitFooter(lines, opts.homeOverride);
       return lines.join('\n') + '\n';
     }
 
-    const current = (settings.statusLine as Record<string, unknown>).command ?? 'unknown';
-    lines.push(warn(`Current statusline: ${YELLOW}${current}${RST}`));
+    const currentCmd = (settings.statusLine as Record<string, unknown>).command ?? 'unknown';
+    lines.push(warn(`Current statusline: ${YELLOW}${currentCmd}${RST}`));
     const accepted = await confirm('Replace with lumira?');
     if (!accepted) {
       lines.push(`\n  Aborted. No changes made.\n`);
@@ -247,8 +192,10 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
   writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', { mode: 0o600 });
   lines.push(ok('Configured lumira as statusline'));
 
-  lines.push(...installSkill({ homeOverride: opts.homeOverride }));
-  lines.push(`\n  Restart Claude Code to see your statusline.\n`);
+  saveConfig(wizard, configPath);
+  lines.push(ok(`Saved config → ${DIM}${configPath}${RST}`));
+
+  emitFooter(lines, opts.homeOverride);
   return lines.join('\n') + '\n';
 }
 

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -9,16 +9,28 @@ describe('install', () => {
   let dir: string;
   let settingsPath: string;
   let backupPath: string;
+  let configPath: string;
+
+  // Helper: non-TTY stdin + isolated home + temp config path. Installs run
+  // through the single interactive path with wizard defaults.
+  const baseOpts = () => ({
+    settingsPath,
+    configPath,
+    homeOverride: dir,
+    stdin: createMockStdin(false),
+    confirm: async () => true,
+  });
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'lumira-test-'));
     settingsPath = join(dir, 'settings.json');
     backupPath = join(dir, 'settings.json.lumira.bak');
+    configPath = join(dir, 'config.json');
   });
   afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
 
   it('creates settings file when none exists', async () => {
-    const output = await install({ settingsPath, confirm: async () => true });
+    const output = await install(baseOpts());
     expect(existsSync(settingsPath)).toBe(true);
     const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
     expect(data.statusLine.command).toBe('npx lumira@latest');
@@ -27,7 +39,7 @@ describe('install', () => {
 
   it('adds statusLine when settings exists without one', async () => {
     writeFileSync(settingsPath, JSON.stringify({ hooks: {} }, null, 2));
-    const output = await install({ settingsPath, confirm: async () => true });
+    await install(baseOpts());
     const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
     expect(data.statusLine.command).toBe('npx lumira@latest');
     expect(data.hooks).toEqual({});
@@ -37,7 +49,7 @@ describe('install', () => {
   it('backs up and replaces existing statusLine after confirmation', async () => {
     const original = { statusLine: { type: 'command', command: 'other-tool', padding: 0 } };
     writeFileSync(settingsPath, JSON.stringify(original, null, 2));
-    const output = await install({ settingsPath, confirm: async () => true });
+    const output = await install(baseOpts());
     expect(existsSync(backupPath)).toBe(true);
     const backup = JSON.parse(readFileSync(backupPath, 'utf8'));
     expect(backup.statusLine.command).toBe('other-tool');
@@ -49,7 +61,7 @@ describe('install', () => {
   it('skips when already configured with lumira', async () => {
     const existing = { statusLine: { type: 'command', command: 'npx lumira@latest', padding: 0 } };
     writeFileSync(settingsPath, JSON.stringify(existing, null, 2));
-    const output = await install({ settingsPath, confirm: async () => true });
+    const output = await install(baseOpts());
     expect(output).toContain('already configured');
     expect(existsSync(backupPath)).toBe(false);
   });
@@ -57,7 +69,7 @@ describe('install', () => {
   it('aborts when user declines replacement', async () => {
     const original = { statusLine: { type: 'command', command: 'other-tool', padding: 0 } };
     writeFileSync(settingsPath, JSON.stringify(original, null, 2));
-    const output = await install({ settingsPath, confirm: async () => false });
+    const output = await install({ ...baseOpts(), confirm: async () => false });
     const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
     expect(data.statusLine.command).toBe('other-tool');
     expect(output).toContain('Aborted');
@@ -65,7 +77,7 @@ describe('install', () => {
 
   it('recovers from malformed settings.json and creates fresh settings', async () => {
     writeFileSync(settingsPath, 'this is { not valid JSON!!');
-    const output = await install({ settingsPath, confirm: async () => true });
+    const output = await install(baseOpts());
     expect(output).toContain('Could not parse');
     const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
     expect(data.statusLine.command).toBe('npx lumira@latest');
@@ -74,7 +86,7 @@ describe('install', () => {
 
   it('creates parent directory when it does not exist', async () => {
     const nestedSettingsPath = join(dir, 'nested', 'deep', 'settings.json');
-    const output = await install({ settingsPath: nestedSettingsPath, confirm: async () => true });
+    const output = await install({ ...baseOpts(), settingsPath: nestedSettingsPath });
     expect(existsSync(nestedSettingsPath)).toBe(true);
     const data = JSON.parse(readFileSync(nestedSettingsPath, 'utf8'));
     expect(data.statusLine.command).toBe('npx lumira@latest');


### PR DESCRIPTION
## Summary

Collapses \`install()\` into a single linear pipeline and extracts a shared footer helper, eliminating the dual-path structure introduced during PR #18 and its drift-prone duplicated footer.

### What changed

- **Shared footer helper (\`emitFooter\`):** skill install + Qwen notice + restart message now live in one helper called by both success branches (already-configured vs fresh-install). Fixes the drift risk that was caught manually during PR #18 review. Closes #22.
- **Single \`install()\` flow:** the \`runInteractive\` branch on \`opts.configPath\` is gone. \`configPath\` defaults to \`~/.config/lumira/config.json\`; TTY vs non-TTY is decided from \`opts.stdin\`. The wizard runs on TTY and uses defaults on non-TTY. Closes #19.
- **Test migration:** the 7 pre-wizard tests now pass \`configPath\` + non-TTY mock stdin + \`homeOverride\`, so they exercise the single path. Side benefit: they no longer leak skill files into the developer's real \`~/.claude/skills/\` during test runs.

### Test plan
- 354 tests passing (\`npm test\`)
- \`npm run lint\` clean
- Manual smoke pending: \`npx lumira install\` from a TTY still works identically (interactive wizard flow unchanged)

Closes #19
Closes #22