### PR TITLE
docs(release): clarify release flow and emphasize post-release back-merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 coverage/
 *.tgz
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,21 +78,25 @@ npm run lint
 
 ## Deployment
 
-```bash
-# Publish to npm (requires maintainer access)
-npm publish --access public
-
-# Update version before publishing
-npm version patch   # or minor / major
-```
+Releases are fully automated by `.github/workflows/release.yml`. The workflow
+triggers when a `release/vX.Y.Z` branch is merged into `main`, then:
+parses the version from the branch name → creates the git tag → publishes
+the GitHub Release with notes from CHANGELOG.md → runs `npm publish`.
 
 **Release process:**
-1. Branch from `develop` → `release/X.Y.Z`
-2. Bump version, update CHANGELOG.md
-3. PR to `main`, squash merge
-4. `npm publish --access public`
-5. Merge `main` back to `develop`
-6. Tag release: `git tag vX.Y.Z && git push origin --tags`
+1. Branch from `develop` → `release/vX.Y.Z`
+2. Bump `package.json` version and move the `[Unreleased]` changelog entries
+   into a new `[X.Y.Z] - YYYY-MM-DD` section. Update the compare links.
+3. Open PR against `main` and use `--merge` (not squash — preserves branch
+   name for workflow detection).
+4. CI takes over: tag + GitHub Release + npm publish happen automatically.
+5. **Post-release: merge `main` back into `develop`.** This is mandatory —
+   without it, `develop` keeps the old version and stale changelog, and the
+   *next* release branch will conflict on every file touched since.
+   ```bash
+   git checkout develop && git pull
+   git merge origin/main --no-edit && git push
+   ```
 
 ## Guardrails
 


### PR DESCRIPTION
## Summary

Rewrites the Deployment section of \`AGENTS.md\` to match the actual automated release flow and make the post-release back-merge step non-optional.

### Why now

Releasing v0.3.2 today hit conflicts in 8 files because v0.3.1's back-merge was skipped — develop had stale \`package.json\` (0.3.0) and a \`[Unreleased]\` section that still contained content already released in v0.3.1. The step was technically documented (buried as step 5 with no rationale) but easy to miss.

### Changes

- Describe the GitHub Actions release workflow (it does tag + Release + npm publish automatically)
- Specify \`--merge\` instead of squash for release PRs (preserves branch name for workflow detection)
- Make back-merge to develop mandatory with a concrete command block and explain the failure mode
- Remove the misleading manual \`npm publish\` / \`npm version\` / \`git tag\` instructions