### PR TITLE
fix(gsd): sync integration with current get-shit-done state layout

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ const defaultDeps: Dependencies = {
   parseTranscript: (path) => parseTranscript(path),
   getTokenSpeed: (ctx) => getTokenSpeed(ctx),
   getMemoryInfo: () => getMemoryInfo(),
-  getGsdInfo: (session) => getGsdInfo(session),
+  getGsdInfo: (cwd) => getGsdInfo(cwd),
   getMcpInfo: (cwd) => getMcpInfo(cwd),
   getTermCols: () => getTermCols(),
 };
@@ -44,7 +44,7 @@ export async function main(overrides: Partial<Dependencies> = {}): Promise<strin
 
   const tokenSpeed = deps.getTokenSpeed(input.context_window);
   const memory = deps.getMemoryInfo();
-  const gsd = config.gsd ? deps.getGsdInfo(input.session_id) : null;
+  const gsd = config.gsd ? deps.getGsdInfo(cwd) : null;
   const mcp = deps.getMcpInfo(cwd);
 
   const rawCols = deps.getTermCols();

--- a/src/parsers/gsd.ts
+++ b/src/parsers/gsd.ts
@@ -1,30 +1,129 @@
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import type { GsdInfo } from '../types.js';
 import { sanitizeTermString } from '../normalize.js';
 
-export function getGsdInfo(session: string, claudeDir: string = join(process.env['CLAUDE_CONFIG_DIR'] || join(homedir(), '.claude'))): GsdInfo | null {
-  let updateAvailable = false;
-  let currentTask: string | undefined;
+// Max directory levels to walk upward looking for .planning/STATE.md
+const STATE_WALK_MAX = 10;
 
-  const cacheFile = join(claudeDir, 'cache', 'gsd-update-check.json');
-  if (existsSync(cacheFile)) { try { if (JSON.parse(readFileSync(cacheFile, 'utf8')).update_available) updateAvailable = true; } catch {} }
+interface GsdState {
+  status?: string;
+  milestone?: string;
+  milestoneName?: string;
+  phaseNum?: string;
+  phaseTotal?: string;
+  phaseName?: string;
+}
 
-  const todosDir = join(claudeDir, 'todos');
-  if (session && existsSync(todosDir)) {
+/**
+ * Parse .planning/STATE.md: YAML frontmatter + `Phase: N of M (name)` line.
+ * Mirrors the format produced by the GSD CLI (get-shit-done >= 1.x).
+ */
+export function parseStateMd(content: string): GsdState {
+  const state: GsdState = {};
+
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (fmMatch) {
+    for (const line of fmMatch[1].split('\n')) {
+      const m = line.match(/^(\w+):\s*(.+)/);
+      if (!m) continue;
+      const [, key, val] = m;
+      const v = val.trim().replace(/^["']|["']$/g, '');
+      if (v === 'null') continue;
+      if (key === 'status') state.status = v;
+      else if (key === 'milestone') state.milestone = v;
+      else if (key === 'milestone_name') state.milestoneName = v;
+    }
+  }
+
+  const phaseMatch = content.match(/^Phase:\s*(\d+)\s+of\s+(\d+)(?:\s+\(([^)]+)\))?/m);
+  if (phaseMatch) {
+    state.phaseNum = phaseMatch[1];
+    state.phaseTotal = phaseMatch[2];
+    state.phaseName = phaseMatch[3];
+  } else if (!state.status) {
+    // Fallback: parse body Status line when frontmatter is absent
+    const bodyStatus = content.match(/^Status:\s*(.+)/m);
+    if (bodyStatus) {
+      const raw = bodyStatus[1].trim().toLowerCase();
+      if (raw.includes('ready to plan') || raw.includes('planning')) state.status = 'planning';
+      else if (raw.includes('execut')) state.status = 'executing';
+      else if (raw.includes('complet') || raw.includes('archived')) state.status = 'complete';
+    }
+  }
+
+  return state;
+}
+
+/** Walk up from `cwd` looking for `.planning/STATE.md`; stop at home or filesystem root. */
+function findStateMd(cwd: string): string | null {
+  const home = homedir();
+  let current = resolve(cwd);
+  for (let i = 0; i < STATE_WALK_MAX; i++) {
+    const candidate = join(current, '.planning', 'STATE.md');
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(current);
+    if (parent === current || current === home) break;
+    current = parent;
+  }
+  return null;
+}
+
+/** Format a GSD state into a compact status string: `milestone · status · phase`. */
+function formatState(s: GsdState): string {
+  const parts: string[] = [];
+  if (s.milestone || s.milestoneName) {
+    const ver = s.milestone ?? '';
+    const name = s.milestoneName && s.milestoneName !== 'milestone' ? s.milestoneName : '';
+    const ms = [ver, name].filter(Boolean).join(' ');
+    if (ms) parts.push(ms);
+  }
+  if (s.status) parts.push(s.status);
+  if (s.phaseNum && s.phaseTotal) {
+    const phase = s.phaseName ? `${s.phaseName} (${s.phaseNum}/${s.phaseTotal})` : `ph ${s.phaseNum}/${s.phaseTotal}`;
+    parts.push(phase);
+  }
+  return parts.join(' · ');
+}
+
+/**
+ * Read GSD update-check cache. Checks the shared tool-agnostic cache first
+ * (`~/.cache/gsd/`, introduced by GSD #1421), then falls back to the legacy
+ * per-runtime location (`~/.claude/cache/`) for older GSD installs.
+ */
+function readUpdateCache(sharedCacheFile: string, legacyCacheFile: string): boolean {
+  for (const file of [sharedCacheFile, legacyCacheFile]) {
+    if (!existsSync(file)) continue;
     try {
-      const sanitized = (session || '').replace(/[^\w-]/g, '');
-      const files = readdirSync(todosDir).filter(f => f.startsWith(sanitized) && f.includes('-agent-') && f.endsWith('.json'))
-        .map(f => ({ name: f, mtime: statSync(join(todosDir, f)).mtime })).sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
-      if (files.length > 0) {
-        const todoPath = join(todosDir, files[0].name);
-        if (!resolve(todoPath).startsWith(resolve(todosDir))) return null;
-        const todos = JSON.parse(readFileSync(resolve(todoPath), 'utf8'));
-        const ip = todos.find((t: { status: string; activeForm?: string }) => t.status === 'in_progress');
-        if (ip?.activeForm) currentTask = sanitizeTermString(String(ip.activeForm));
-      }
-    } catch {}
+      const parsed = JSON.parse(readFileSync(file, 'utf8')) as { update_available?: boolean };
+      if (parsed.update_available) return true;
+    } catch { /* ignore malformed */ }
+  }
+  return false;
+}
+
+export interface GsdInfoOptions {
+  /** Per-runtime claude config dir (holds `cache/gsd-update-check.json` in old GSD). */
+  claudeDir?: string;
+  /** Tool-agnostic shared cache file path. Overridable for tests. */
+  sharedCacheFile?: string;
+}
+
+export function getGsdInfo(cwd: string, opts: GsdInfoOptions = {}): GsdInfo | null {
+  const claudeDir = opts.claudeDir ?? process.env['CLAUDE_CONFIG_DIR'] ?? join(homedir(), '.claude');
+  const sharedCacheFile = opts.sharedCacheFile ?? join(homedir(), '.cache', 'gsd', 'gsd-update-check.json');
+  const legacyCacheFile = join(claudeDir, 'cache', 'gsd-update-check.json');
+  const updateAvailable = readUpdateCache(sharedCacheFile, legacyCacheFile);
+
+  let currentTask: string | undefined;
+  const stateFile = findStateMd(cwd || process.cwd());
+  if (stateFile) {
+    try {
+      const state = parseStateMd(readFileSync(stateFile, 'utf8'));
+      const formatted = formatState(state);
+      if (formatted) currentTask = sanitizeTermString(formatted);
+    } catch { /* ignore */ }
   }
 
   if (!updateAvailable && !currentTask) return null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -238,7 +238,7 @@ export interface Dependencies {
   parseTranscript: (path: string) => Promise<TranscriptData>;
   getTokenSpeed: (contextWindow: ClaudeCodeInput['context_window']) => number | null;
   getMemoryInfo: () => MemoryInfo | null;
-  getGsdInfo: (session: string) => GsdInfo | null;
+  getGsdInfo: (cwd: string) => GsdInfo | null;
   getMcpInfo: (cwd: string) => McpInfo | null;
   getTermCols: () => number;
   loadConfig?: () => HudConfig;

--- a/tests/parsers/gsd.test.ts
+++ b/tests/parsers/gsd.test.ts
@@ -2,47 +2,108 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { getGsdInfo } from '../../src/parsers/gsd.js';
+import { getGsdInfo, parseStateMd } from '../../src/parsers/gsd.js';
+
+describe('parseStateMd', () => {
+  it('parses YAML frontmatter (milestone, status, name)', () => {
+    const content = `---
+milestone: v2.0
+milestone_name: "Automation Phase"
+status: executing
+---
+
+# body`;
+    const s = parseStateMd(content);
+    expect(s.milestone).toBe('v2.0');
+    expect(s.milestoneName).toBe('Automation Phase');
+    expect(s.status).toBe('executing');
+  });
+
+  it('parses Phase: N of M (name) line', () => {
+    const content = `---\nstatus: planning\n---\n\nPhase: 9 of 12 (multi-role-permissions)`;
+    const s = parseStateMd(content);
+    expect(s.phaseNum).toBe('9');
+    expect(s.phaseTotal).toBe('12');
+    expect(s.phaseName).toBe('multi-role-permissions');
+  });
+
+  it('falls back to body Status when frontmatter is absent', () => {
+    const content = `# State\n\nStatus: Ready to plan phase 3`;
+    expect(parseStateMd(content).status).toBe('planning');
+  });
+
+  it('treats `null` frontmatter values as absent', () => {
+    const content = `---\nstatus: null\nmilestone: v1.0\n---`;
+    const s = parseStateMd(content);
+    expect(s.status).toBeUndefined();
+    expect(s.milestone).toBe('v1.0');
+  });
+});
 
 describe('getGsdInfo', () => {
   let dir: string;
-  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'gsd-')); mkdirSync(join(dir, 'cache'), { recursive: true }); mkdirSync(join(dir, 'todos'), { recursive: true }); });
-  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
-
-  it('returns null when no data', () => { expect(getGsdInfo('s', dir)).toBeNull(); });
-  it('detects update available', () => {
-    writeFileSync(join(dir, 'cache', 'gsd-update-check.json'), '{"update_available":true}');
-    expect(getGsdInfo('s', dir)?.updateAvailable).toBe(true);
+  let claudeDir: string;
+  let opts: { claudeDir: string; sharedCacheFile: string };
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'gsd-cwd-'));
+    claudeDir = mkdtempSync(join(tmpdir(), 'gsd-claude-'));
+    mkdirSync(join(claudeDir, 'cache'), { recursive: true });
+    // Point shared cache at a path inside claudeDir so tests don't read the
+    // real ~/.cache/gsd on the dev machine.
+    opts = { claudeDir, sharedCacheFile: join(claudeDir, 'shared-cache.json') };
   });
-  it('reads current task', () => {
-    writeFileSync(join(dir, 'todos', 's-agent-1.json'), JSON.stringify([{ status: 'in_progress', activeForm: 'Building X' }]));
-    expect(getGsdInfo('s', dir)?.currentTask).toBe('Building X');
-  });
-
-  it('sanitizes session ID with special characters', () => {
-    writeFileSync(join(dir, 'todos', 'abc-agent-1.json'), JSON.stringify([{ status: 'in_progress', activeForm: 'Task' }]));
-    // ../evil gets sanitized to empty or safe string — should not match
-    expect(getGsdInfo('../evil', dir)).toBeNull();
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(claudeDir, { recursive: true, force: true });
   });
 
-  it('sanitizes session ID with slashes', () => {
-    expect(getGsdInfo('../../etc/passwd', dir)).toBeNull();
+  it('returns null when no STATE.md and no update cache', () => {
+    expect(getGsdInfo(dir, opts)).toBeNull();
   });
 
-  it('handles malformed JSON in cache file', () => {
-    writeFileSync(join(dir, 'cache', 'gsd-update-check.json'), 'not json');
-    expect(getGsdInfo('s', dir)).toBeNull();
+  it('reads update_available from legacy per-runtime cache', () => {
+    writeFileSync(join(claudeDir, 'cache', 'gsd-update-check.json'), '{"update_available":true}');
+    expect(getGsdInfo(dir, opts)?.updateAvailable).toBe(true);
   });
 
-  it('handles malformed JSON in todos file', () => {
-    writeFileSync(join(dir, 'todos', 's-agent-1.json'), 'broken json');
-    expect(getGsdInfo('s', dir)).toBeNull();
+  it('reads GSD state from nearest .planning/STATE.md walking up from cwd', () => {
+    const projectRoot = join(dir, 'project');
+    const nested = join(projectRoot, 'src', 'deeply', 'nested');
+    mkdirSync(join(projectRoot, '.planning'), { recursive: true });
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(
+      join(projectRoot, '.planning', 'STATE.md'),
+      `---\nmilestone: v1.2\nstatus: executing\n---\n\nPhase: 3 of 5 (auth)`,
+    );
+    const info = getGsdInfo(nested, opts);
+    expect(info?.currentTask).toContain('v1.2');
+    expect(info?.currentTask).toContain('executing');
+    expect(info?.currentTask).toContain('auth (3/5)');
   });
 
-  it('sanitizes control characters from currentTask', () => {
-    const malicious = 'Safe\x1b[31mPart\x00\x07\x7fend';
-    writeFileSync(join(dir, 'todos', 's-agent-1.json'), JSON.stringify([{ status: 'in_progress', activeForm: malicious }]));
-    const task = getGsdInfo('s', dir)?.currentTask ?? '';
+  it('stops walking at home directory', () => {
+    // cwd is a tmpdir outside any .planning ancestor
+    expect(getGsdInfo(dir, opts)).toBeNull();
+  });
+
+  it('handles malformed JSON in cache gracefully', () => {
+    writeFileSync(join(claudeDir, 'cache', 'gsd-update-check.json'), 'not json');
+    expect(getGsdInfo(dir, opts)).toBeNull();
+  });
+
+  it('handles malformed STATE.md gracefully', () => {
+    mkdirSync(join(dir, '.planning'), { recursive: true });
+    writeFileSync(join(dir, '.planning', 'STATE.md'), '');
+    expect(getGsdInfo(dir, opts)).toBeNull();
+  });
+
+  it('sanitizes control characters from formatted state', () => {
+    mkdirSync(join(dir, '.planning'), { recursive: true });
+    writeFileSync(
+      join(dir, '.planning', 'STATE.md'),
+      `---\nmilestone: v1.0\nmilestone_name: "Safe\x1b[31mPart\x00end"\nstatus: executing\n---`,
+    );
+    const task = getGsdInfo(dir, opts)?.currentTask ?? '';
     expect(task).not.toMatch(/[\x00-\x1f\x7f-\x9f]/);
     expect(task).toContain('Safe');
     expect(task).toContain('end');


### PR DESCRIPTION
## Summary

Lumira's GSD integration was reading paths that GSD deprecated. Result: line4 showed nothing (no currentTask, no update notification) even with \`config.gsd: true\`.

Verified live on this machine — kovia project's STATE.md now renders correctly.

### Changes
- **Update cache path**: checks \`~/.cache/gsd/gsd-update-check.json\` first (GSD #1421's tool-agnostic shared location), falls back to legacy \`~/.claude/cache/gsd-update-check.json\` for back-compat.
- **Current task**: walks up from \`cwd\` looking for \`.planning/STATE.md\`, parses YAML frontmatter (milestone/status) + \`Phase: N of M (name)\` body line, formats as \`milestone · status · phase (N/M)\`.
- **New export \`parseStateMd\`**: unit-testable state parser with frontmatter + Phase: line support, \`null\` frontmatter handling, and body-Status fallback.
- **Signature change**: \`getGsdInfo(session, claudeDir)\` → \`getGsdInfo(cwd, opts?)\`. Options bag accepts \`claudeDir\` and \`sharedCacheFile\` overrides. Callers in \`src/index.ts\` updated to pass \`cwd\` instead of \`session_id\`.

## Test plan
- 360 tests passing (\`npm test\`)
- \`npm run lint\` clean
- Manual smoke test on live machine — line4 renders milestone + status + update flag from kovia project

Closes the "not working" issue raised during v1.0 roadmap discussion.