### PR TITLE
feat(theming): 256-color theme fallback, /compact hints, gruvbox + solarized

### DIFF
--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -31,8 +31,12 @@ export function createColors(mode: ColorMode, theme?: import('../themes.js').The
     brightBlue: wrap('\x1b[94m'), dim: wrap('\x1b[2m'), bold: wrap('\x1b[1m'),
   };
 
-  // Theme overrides (truecolor only — resolveTheme returns null otherwise)
-  if (theme && mode === 'truecolor') {
+  // Theme overrides: applied for both truecolor and 256-color modes.
+  // `resolveTheme` projects the palette's RGB values to 256-color indices when
+  // mode is '256', and returns null for 'named' mode (named ANSI has only 8
+  // base hues — not enough fidelity to honour a theme accurately, so we fall
+  // back to built-in defaults instead of approximating with wrong colors).
+  if (theme && (mode === 'truecolor' || mode === '256')) {
     return {
       ...named,
       cyan: wrap(theme.cyan), magenta: wrap(theme.magenta),

--- a/src/render/minimal.ts
+++ b/src/render/minimal.ts
@@ -38,7 +38,10 @@ export function renderMinimal(ctx: RenderContext, c: Colors): string {
 
   // Context bar
   if (display.contextBar) {
-    parts.push(buildContextBar(input.context.usedPercentage, c, { segments: 10, iconSet: icons }));
+    // `showHint: false` — the minimal preset targets tight single-line terminals,
+    // where the /compact hint's ~10 trailing chars pushes truncation earlier. Users
+    // on minimal can still read the blinking skull icon as an at-risk signal.
+    parts.push(buildContextBar(input.context.usedPercentage, c, { segments: 10, iconSet: icons, showHint: false }));
   }
 
   // Only add these if cols >= 60

--- a/src/render/shared.ts
+++ b/src/render/shared.ts
@@ -17,11 +17,14 @@ export interface ContextBarOpts {
   segments?: number;
   showIcons?: boolean;
   iconSet?: IconSet;
+  /** When true (default), append an actionable hint like `/compact?` at high fill. */
+  showHint?: boolean;
 }
 
 export function buildContextBar(pct: number, c: Colors, opts?: ContextBarOpts): string {
   const segments = opts?.segments ?? 20;
   const showIcons = opts?.showIcons ?? true;
+  const showHint = opts?.showHint ?? true;
   const ic = opts?.iconSet ?? NERD_ICONS;
 
   const filled = Math.round((pct / 100) * segments);
@@ -34,9 +37,17 @@ export function buildContextBar(pct: number, c: Colors, opts?: ContextBarOpts): 
     else if (pct >= 65) icon = c.orange(ic.fire);
   }
 
+  // Actionable hint at high fill — nudges the user to reclaim context before
+  // the session stalls. Thresholds align with the color/icon tiers above.
+  let hint = '';
+  if (showHint) {
+    if (pct >= 90) hint = ' ' + c.red('/compact!');
+    else if (pct >= 80) hint = ' ' + c.dim('/compact?');
+  }
+
   const pctStr = colorFn(`${pct < 10 ? pct.toFixed(1) : pct.toFixed(0)}%`);
 
-  return `${bar} ${pctStr}${icon ? ' ' + icon : ''}`;
+  return `${bar} ${pctStr}${icon ? ' ' + icon : ''}${hint}`;
 }
 
 export function formatGitChanges(git: GitStatus, c: Colors): string[] {

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -1,9 +1,11 @@
 import type { ColorMode } from './render/colors.js';
 
 /**
- * A theme defines truecolor overrides for each named color.
- * At runtime, if the user selects a theme AND their terminal supports
- * truecolor/256, these values replace the defaults in createColors.
+ * A theme defines truecolor RGB values for each named color.
+ * At runtime:
+ * - truecolor terminals get the exact RGB via `\x1b[38;2;r;g;bm`
+ * - 256-color terminals get the nearest xterm 256-color index via `\x1b[38;5;Nm`
+ * - named-ANSI terminals fall back to defaults (themes are not applied)
  */
 export interface ThemePalette {
   cyan: string;
@@ -16,8 +18,53 @@ export interface ThemePalette {
   gray: string;
 }
 
+interface RGB { r: number; g: number; b: number; }
+
 function rgb(r: number, g: number, b: number): string {
   return `\x1b[38;2;${r};${g};${b}m`;
+}
+
+/** Parse a truecolor escape `\x1b[38;2;R;G;Bm` back into RGB components. */
+function parseRgb(escape: string): RGB | null {
+  const m = escape.match(/^\x1b\[38;2;(\d+);(\d+);(\d+)m$/);
+  if (!m) return null;
+  return { r: parseInt(m[1], 10), g: parseInt(m[2], 10), b: parseInt(m[3], 10) };
+}
+
+/**
+ * Convert an RGB triple to the nearest xterm 256-color index (0..255).
+ * Uses the standard 6×6×6 color cube (indices 16..231) plus grayscale ramp
+ * (232..255). Algorithm follows Chalk/ansi-styles conventions.
+ */
+function rgbTo256(r: number, g: number, b: number): number {
+  // Grayscale shortcut when r≈g≈b
+  if (r === g && g === b) {
+    if (r < 8) return 16;
+    if (r > 248) return 231;
+    return Math.round((r - 8) / 247 * 24) + 232;
+  }
+  const cube = (v: number) => Math.round(v / 255 * 5);
+  return 16 + 36 * cube(r) + 6 * cube(g) + cube(b);
+}
+
+function rgbEscapeTo256(escape: string): string {
+  const c = parseRgb(escape);
+  if (!c) return escape;
+  return `\x1b[38;5;${rgbTo256(c.r, c.g, c.b)}m`;
+}
+
+/** Project a truecolor-only palette to 256-color escapes. */
+export function downgradePaletteTo256(p: ThemePalette): ThemePalette {
+  return {
+    cyan: rgbEscapeTo256(p.cyan),
+    magenta: rgbEscapeTo256(p.magenta),
+    yellow: rgbEscapeTo256(p.yellow),
+    green: rgbEscapeTo256(p.green),
+    orange: rgbEscapeTo256(p.orange),
+    red: rgbEscapeTo256(p.red),
+    brightBlue: rgbEscapeTo256(p.brightBlue),
+    gray: rgbEscapeTo256(p.gray),
+  };
 }
 
 export const THEMES: Record<string, ThemePalette> = {
@@ -71,6 +118,26 @@ export const THEMES: Record<string, ThemePalette> = {
     brightBlue: rgb(102, 217, 239),
     gray: rgb(117, 113, 94),
   },
+  gruvbox: {
+    cyan: rgb(131, 165, 152),
+    magenta: rgb(211, 134, 155),
+    yellow: rgb(215, 153, 33),
+    green: rgb(152, 151, 26),
+    orange: rgb(214, 93, 14),
+    red: rgb(204, 36, 29),
+    brightBlue: rgb(69, 133, 136),
+    gray: rgb(146, 131, 116),
+  },
+  solarized: {
+    cyan: rgb(42, 161, 152),
+    magenta: rgb(211, 54, 130),
+    yellow: rgb(181, 137, 0),
+    green: rgb(133, 153, 0),
+    orange: rgb(203, 75, 22),
+    red: rgb(220, 50, 47),
+    brightBlue: rgb(38, 139, 210),
+    gray: rgb(101, 123, 131),
+  },
 };
 
 export function getThemeNames(): string[] {
@@ -79,7 +146,13 @@ export function getThemeNames(): string[] {
 
 export function resolveTheme(name: string | undefined, mode: ColorMode): ThemePalette | null {
   if (!name) return null;
-  // Themes only apply in truecolor mode — they use RGB values
-  if (mode !== 'truecolor') return null;
-  return THEMES[name.toLowerCase()] ?? null;
+  const base = THEMES[name.toLowerCase()];
+  if (!base) return null;
+  // Truecolor terminals get the exact palette; 256-color terminals get a
+  // nearest-index projection. Named-ANSI terminals cannot represent arbitrary
+  // palettes — fall back to built-in defaults rather than lying with mismatched
+  // named colors (only 8 base hues available).
+  if (mode === 'truecolor') return base;
+  if (mode === '256') return downgradePaletteTo256(base);
+  return null;
 }

--- a/tests/render/shared.test.ts
+++ b/tests/render/shared.test.ts
@@ -111,6 +111,17 @@ describe('buildContextBar — compact hint', () => {
     expect(bar).not.toContain('/compact');
   });
 
+  it('shows /compact? at exactly 80% (boundary inclusive)', () => {
+    const bar = stripAnsi(buildContextBar(80, c));
+    expect(bar).toContain('/compact?');
+    expect(bar).not.toContain('/compact!');
+  });
+
+  it('shows /compact! at exactly 90% (boundary inclusive)', () => {
+    const bar = stripAnsi(buildContextBar(90, c));
+    expect(bar).toContain('/compact!');
+  });
+
   it('hides compact hint when showHint=false', () => {
     const bar = stripAnsi(buildContextBar(95, c, { showHint: false }));
     expect(bar).not.toContain('/compact');

--- a/tests/render/shared.test.ts
+++ b/tests/render/shared.test.ts
@@ -94,6 +94,29 @@ describe('formatGitChanges', () => {
   });
 });
 
+describe('buildContextBar — compact hint', () => {
+  it('shows /compact? hint at 80-89%', () => {
+    const bar = stripAnsi(buildContextBar(85, c));
+    expect(bar).toContain('/compact?');
+    expect(bar).not.toContain('/compact!');
+  });
+
+  it('shows /compact! hint at 90%+', () => {
+    const bar = stripAnsi(buildContextBar(95, c));
+    expect(bar).toContain('/compact!');
+  });
+
+  it('does not show compact hint below 80%', () => {
+    const bar = stripAnsi(buildContextBar(70, c));
+    expect(bar).not.toContain('/compact');
+  });
+
+  it('hides compact hint when showHint=false', () => {
+    const bar = stripAnsi(buildContextBar(95, c, { showHint: false }));
+    expect(bar).not.toContain('/compact');
+  });
+});
+
 describe('SEP constants', () => {
   it('SEP uses Unicode pipe', () => {
     expect(SEP).toContain('\u2502');

--- a/tests/themes.test.ts
+++ b/tests/themes.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { THEMES, getThemeNames, resolveTheme } from '../src/themes.js';
+import { THEMES, getThemeNames, resolveTheme, downgradePaletteTo256, type ThemePalette } from '../src/themes.js';
+
+// Build a synthetic palette where every color slot is the same RGB triple.
+// Used to exercise rgbTo256 indirectly through downgradePaletteTo256.
+function synthetic(escape: string): ThemePalette {
+  return {
+    cyan: escape, magenta: escape, yellow: escape, green: escape,
+    orange: escape, red: escape, brightBlue: escape, gray: escape,
+  };
+}
+const rgbEsc = (r: number, g: number, b: number) => `\x1b[38;2;${r};${g};${b}m`;
 
 describe('THEMES', () => {
   it('has at least 7 themes', () => {
@@ -55,5 +65,49 @@ describe('resolveTheme', () => {
 
   it('returns null for unknown theme', () => {
     expect(resolveTheme('nonexistent', 'truecolor')).toBeNull();
+  });
+});
+
+describe('downgradePaletteTo256 (rgbTo256 projection)', () => {
+  it('maps pure black (0,0,0) to xterm index 16', () => {
+    expect(downgradePaletteTo256(synthetic(rgbEsc(0, 0, 0))).cyan).toBe('\x1b[38;5;16m');
+  });
+
+  it('maps pure white (255,255,255) to xterm index 231', () => {
+    expect(downgradePaletteTo256(synthetic(rgbEsc(255, 255, 255))).cyan).toBe('\x1b[38;5;231m');
+  });
+
+  it('maps mid-gray (128,128,128) into the grayscale ramp (232-255)', () => {
+    const m = downgradePaletteTo256(synthetic(rgbEsc(128, 128, 128))).cyan.match(/38;5;(\d+)m/);
+    const idx = parseInt(m![1], 10);
+    expect(idx).toBeGreaterThanOrEqual(232);
+    expect(idx).toBeLessThanOrEqual(255);
+  });
+
+  it('maps pure red (255,0,0) to cube index 196', () => {
+    expect(downgradePaletteTo256(synthetic(rgbEsc(255, 0, 0))).cyan).toBe('\x1b[38;5;196m');
+  });
+
+  it('maps pure green (0,255,0) to cube index 46', () => {
+    expect(downgradePaletteTo256(synthetic(rgbEsc(0, 255, 0))).cyan).toBe('\x1b[38;5;46m');
+  });
+
+  it('maps pure blue (0,0,255) to cube index 21', () => {
+    expect(downgradePaletteTo256(synthetic(rgbEsc(0, 0, 255))).cyan).toBe('\x1b[38;5;21m');
+  });
+
+  it('handles grayscale boundary: r<8 rounds to black (16)', () => {
+    expect(downgradePaletteTo256(synthetic(rgbEsc(5, 5, 5))).cyan).toBe('\x1b[38;5;16m');
+  });
+
+  it('handles grayscale boundary: r>248 rounds to white (231)', () => {
+    expect(downgradePaletteTo256(synthetic(rgbEsc(250, 250, 250))).cyan).toBe('\x1b[38;5;231m');
+  });
+
+  it('leaves malformed escapes untouched (not a truecolor escape)', () => {
+    // Sanity: if an escape doesn't match the parseRgb shape, the function
+    // returns it unchanged rather than throwing.
+    const weird = '\x1b[1;38;5;208m';
+    expect(downgradePaletteTo256(synthetic(weird)).cyan).toBe(weird);
   });
 });

--- a/tests/themes.test.ts
+++ b/tests/themes.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect } from 'vitest';
 import { THEMES, getThemeNames, resolveTheme } from '../src/themes.js';
 
 describe('THEMES', () => {
-  it('has at least 5 themes', () => {
-    expect(Object.keys(THEMES).length).toBeGreaterThanOrEqual(5);
+  it('has at least 7 themes', () => {
+    expect(Object.keys(THEMES).length).toBeGreaterThanOrEqual(7);
   });
 
   it('each theme has all required color keys', () => {
     const requiredKeys = ['cyan', 'magenta', 'yellow', 'green', 'orange', 'red', 'brightBlue', 'gray'];
-    for (const [name, palette] of Object.entries(THEMES)) {
+    for (const [, palette] of Object.entries(THEMES)) {
       for (const key of requiredKeys) {
         expect(palette).toHaveProperty(key);
         expect((palette as Record<string, string>)[key]).toContain('\x1b[38;2;');
@@ -20,11 +20,9 @@ describe('THEMES', () => {
 describe('getThemeNames', () => {
   it('returns all theme names', () => {
     const names = getThemeNames();
-    expect(names).toContain('dracula');
-    expect(names).toContain('nord');
-    expect(names).toContain('tokyo-night');
-    expect(names).toContain('catppuccin');
-    expect(names).toContain('monokai');
+    expect(names).toEqual(
+      expect.arrayContaining(['dracula', 'nord', 'tokyo-night', 'catppuccin', 'monokai', 'gruvbox', 'solarized']),
+    );
   });
 });
 
@@ -33,12 +31,18 @@ describe('resolveTheme', () => {
     expect(resolveTheme(undefined, 'truecolor')).toBeNull();
   });
 
-  it('returns null for non-truecolor modes', () => {
+  it('returns null in named mode (insufficient color fidelity)', () => {
     expect(resolveTheme('dracula', 'named')).toBeNull();
-    expect(resolveTheme('dracula', '256')).toBeNull();
   });
 
-  it('returns palette for valid theme in truecolor mode', () => {
+  it('returns a downgraded 256-color palette in 256 mode', () => {
+    const palette = resolveTheme('dracula', '256');
+    expect(palette).not.toBeNull();
+    expect(palette!.cyan).toMatch(/^\x1b\[38;5;\d+m$/);
+    expect(palette!.magenta).toMatch(/^\x1b\[38;5;\d+m$/);
+  });
+
+  it('returns the raw RGB palette in truecolor mode', () => {
     const palette = resolveTheme('dracula', 'truecolor');
     expect(palette).not.toBeNull();
     expect(palette!.cyan).toContain('\x1b[38;2;');


### PR DESCRIPTION
## Summary

Three small theming/visual polish changes from the v0.4.0 roadmap.

### 1. Themes now work in 256-color terminals
Previously themes silently did nothing for anyone not on truecolor. \`resolveTheme\` now projects each RGB value to the nearest xterm 256 cube index when mode is \`256\`. Named-ANSI mode still returns null by design (8 base hues are not enough fidelity; better to skip than approximate with wrong colors).

### 2. Actionable \`/compact\` hints
\`buildContextBar\` appends \`/compact?\` (dim) at >= 80% fill and \`/compact!\` (red) at >= 90%. Nudges the user to reclaim context before the session stalls. Opt-out via new \`showHint: false\`.

### 3. gruvbox + solarized themes
Adds two of the most-requested palettes. Brings the catalog from 5 to 7.

### Test plan
- 365 tests passing (\`npm test\`)
- \`npm run lint\` clean
- Smoke tested live on this machine across 3 pct tiers (55, 82, 94) and against tokyo-night theme from 256 mode — all render correctly