### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-23
+
+### Added
+- **Two new themes: `gruvbox` and `solarized`** — both among the most-requested palettes. Catalog is now at 7 themes.
+- **Actionable context hints** — `/compact?` (dim) at ≥80% context fill, `/compact!` (red) at ≥90%, nudging the user to reclaim context before the session stalls. Opt out via the new `showHint: false` option on `buildContextBar`. The `minimal` preset opts out automatically to preserve its tight single-line budget.
+
+### Changed
+- **Themes now work in 256-color terminals.** Previously `resolveTheme` returned null for any mode other than truecolor, silently disabling themes for users on VS Code terminal, tmux without `-2`, or SSH without `COLORTERM=truecolor`. Palettes now project each RGB value to the nearest xterm 256-color cube index (standard Chalk/ansi-styles algorithm). Named-ANSI mode still returns null by design — 8 base hues are not enough fidelity to honour a theme accurately.
+- **GSD integration rewritten** to match the current `get-shit-done` state layout:
+  - Update cache read from shared `~/.cache/gsd/gsd-update-check.json` (GSD #1421's tool-agnostic location), with legacy `~/.claude/cache/` fallback.
+  - Current task is now derived from walking up from `cwd` looking for `.planning/STATE.md`, parsing the YAML frontmatter + `Phase: N of M (name)` line. Formatted as `milestone · status · phase (N/M)`.
+  - `getGsdInfo` signature changed from `(session, claudeDir?)` to `(cwd, opts?)` with `claudeDir` and `sharedCacheFile` as test overrides.
+
 ## [0.3.2] - 2026-04-23
 
 ### Security
@@ -162,7 +175,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GSD session IDs sanitized against path traversal
 - `execFile` used instead of `exec` to prevent shell injection (except terminal width detection where shell redirect is required with procfs-sourced paths)
 
-[Unreleased]: https://github.com/cativo23/lumira/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/cativo23/lumira/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/cativo23/lumira/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/cativo23/lumira/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/cativo23/lumira/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/cativo23/lumira/compare/v0.2.2...v0.3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "lumira — real-time statusline for Claude Code",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ const defaultDeps: Dependencies = {
   parseTranscript: (path) => parseTranscript(path),
   getTokenSpeed: (ctx) => getTokenSpeed(ctx),
   getMemoryInfo: () => getMemoryInfo(),
-  getGsdInfo: (session) => getGsdInfo(session),
+  getGsdInfo: (cwd) => getGsdInfo(cwd),
   getMcpInfo: (cwd) => getMcpInfo(cwd),
   getTermCols: () => getTermCols(),
 };
@@ -44,7 +44,7 @@ export async function main(overrides: Partial<Dependencies> = {}): Promise<strin
 
   const tokenSpeed = deps.getTokenSpeed(input.context_window);
   const memory = deps.getMemoryInfo();
-  const gsd = config.gsd ? deps.getGsdInfo(input.session_id) : null;
+  const gsd = config.gsd ? deps.getGsdInfo(cwd) : null;
   const mcp = deps.getMcpInfo(cwd);
 
   const rawCols = deps.getTermCols();

--- a/src/parsers/gsd.ts
+++ b/src/parsers/gsd.ts
@@ -1,30 +1,129 @@
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import type { GsdInfo } from '../types.js';
 import { sanitizeTermString } from '../normalize.js';
 
-export function getGsdInfo(session: string, claudeDir: string = join(process.env['CLAUDE_CONFIG_DIR'] || join(homedir(), '.claude'))): GsdInfo | null {
-  let updateAvailable = false;
-  let currentTask: string | undefined;
+// Max directory levels to walk upward looking for .planning/STATE.md
+const STATE_WALK_MAX = 10;
 
-  const cacheFile = join(claudeDir, 'cache', 'gsd-update-check.json');
-  if (existsSync(cacheFile)) { try { if (JSON.parse(readFileSync(cacheFile, 'utf8')).update_available) updateAvailable = true; } catch {} }
+interface GsdState {
+  status?: string;
+  milestone?: string;
+  milestoneName?: string;
+  phaseNum?: string;
+  phaseTotal?: string;
+  phaseName?: string;
+}
 
-  const todosDir = join(claudeDir, 'todos');
-  if (session && existsSync(todosDir)) {
+/**
+ * Parse .planning/STATE.md: YAML frontmatter + `Phase: N of M (name)` line.
+ * Mirrors the format produced by the GSD CLI (get-shit-done >= 1.x).
+ */
+export function parseStateMd(content: string): GsdState {
+  const state: GsdState = {};
+
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (fmMatch) {
+    for (const line of fmMatch[1].split('\n')) {
+      const m = line.match(/^(\w+):\s*(.+)/);
+      if (!m) continue;
+      const [, key, val] = m;
+      const v = val.trim().replace(/^["']|["']$/g, '');
+      if (v === 'null') continue;
+      if (key === 'status') state.status = v;
+      else if (key === 'milestone') state.milestone = v;
+      else if (key === 'milestone_name') state.milestoneName = v;
+    }
+  }
+
+  const phaseMatch = content.match(/^Phase:\s*(\d+)\s+of\s+(\d+)(?:\s+\(([^)]+)\))?/m);
+  if (phaseMatch) {
+    state.phaseNum = phaseMatch[1];
+    state.phaseTotal = phaseMatch[2];
+    state.phaseName = phaseMatch[3];
+  } else if (!state.status) {
+    // Fallback: parse body Status line when frontmatter is absent
+    const bodyStatus = content.match(/^Status:\s*(.+)/m);
+    if (bodyStatus) {
+      const raw = bodyStatus[1].trim().toLowerCase();
+      if (raw.includes('ready to plan') || raw.includes('planning')) state.status = 'planning';
+      else if (raw.includes('execut')) state.status = 'executing';
+      else if (raw.includes('complet') || raw.includes('archived')) state.status = 'complete';
+    }
+  }
+
+  return state;
+}
+
+/** Walk up from `cwd` looking for `.planning/STATE.md`; stop at home or filesystem root. */
+function findStateMd(cwd: string): string | null {
+  const home = homedir();
+  let current = resolve(cwd);
+  for (let i = 0; i < STATE_WALK_MAX; i++) {
+    const candidate = join(current, '.planning', 'STATE.md');
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(current);
+    if (parent === current || current === home) break;
+    current = parent;
+  }
+  return null;
+}
+
+/** Format a GSD state into a compact status string: `milestone · status · phase`. */
+function formatState(s: GsdState): string {
+  const parts: string[] = [];
+  if (s.milestone || s.milestoneName) {
+    const ver = s.milestone ?? '';
+    const name = s.milestoneName && s.milestoneName !== 'milestone' ? s.milestoneName : '';
+    const ms = [ver, name].filter(Boolean).join(' ');
+    if (ms) parts.push(ms);
+  }
+  if (s.status) parts.push(s.status);
+  if (s.phaseNum && s.phaseTotal) {
+    const phase = s.phaseName ? `${s.phaseName} (${s.phaseNum}/${s.phaseTotal})` : `ph ${s.phaseNum}/${s.phaseTotal}`;
+    parts.push(phase);
+  }
+  return parts.join(' · ');
+}
+
+/**
+ * Read GSD update-check cache. Checks the shared tool-agnostic cache first
+ * (`~/.cache/gsd/`, introduced by GSD #1421), then falls back to the legacy
+ * per-runtime location (`~/.claude/cache/`) for older GSD installs.
+ */
+function readUpdateCache(sharedCacheFile: string, legacyCacheFile: string): boolean {
+  for (const file of [sharedCacheFile, legacyCacheFile]) {
+    if (!existsSync(file)) continue;
     try {
-      const sanitized = (session || '').replace(/[^\w-]/g, '');
-      const files = readdirSync(todosDir).filter(f => f.startsWith(sanitized) && f.includes('-agent-') && f.endsWith('.json'))
-        .map(f => ({ name: f, mtime: statSync(join(todosDir, f)).mtime })).sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
-      if (files.length > 0) {
-        const todoPath = join(todosDir, files[0].name);
-        if (!resolve(todoPath).startsWith(resolve(todosDir))) return null;
-        const todos = JSON.parse(readFileSync(resolve(todoPath), 'utf8'));
-        const ip = todos.find((t: { status: string; activeForm?: string }) => t.status === 'in_progress');
-        if (ip?.activeForm) currentTask = sanitizeTermString(String(ip.activeForm));
-      }
-    } catch {}
+      const parsed = JSON.parse(readFileSync(file, 'utf8')) as { update_available?: boolean };
+      if (parsed.update_available) return true;
+    } catch { /* ignore malformed */ }
+  }
+  return false;
+}
+
+export interface GsdInfoOptions {
+  /** Per-runtime claude config dir (holds `cache/gsd-update-check.json` in old GSD). */
+  claudeDir?: string;
+  /** Tool-agnostic shared cache file path. Overridable for tests. */
+  sharedCacheFile?: string;
+}
+
+export function getGsdInfo(cwd: string, opts: GsdInfoOptions = {}): GsdInfo | null {
+  const claudeDir = opts.claudeDir ?? process.env['CLAUDE_CONFIG_DIR'] ?? join(homedir(), '.claude');
+  const sharedCacheFile = opts.sharedCacheFile ?? join(homedir(), '.cache', 'gsd', 'gsd-update-check.json');
+  const legacyCacheFile = join(claudeDir, 'cache', 'gsd-update-check.json');
+  const updateAvailable = readUpdateCache(sharedCacheFile, legacyCacheFile);
+
+  let currentTask: string | undefined;
+  const stateFile = findStateMd(cwd || process.cwd());
+  if (stateFile) {
+    try {
+      const state = parseStateMd(readFileSync(stateFile, 'utf8'));
+      const formatted = formatState(state);
+      if (formatted) currentTask = sanitizeTermString(formatted);
+    } catch { /* ignore */ }
   }
 
   if (!updateAvailable && !currentTask) return null;

--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -31,8 +31,12 @@ export function createColors(mode: ColorMode, theme?: import('../themes.js').The
     brightBlue: wrap('\x1b[94m'), dim: wrap('\x1b[2m'), bold: wrap('\x1b[1m'),
   };
 
-  // Theme overrides (truecolor only — resolveTheme returns null otherwise)
-  if (theme && mode === 'truecolor') {
+  // Theme overrides: applied for both truecolor and 256-color modes.
+  // `resolveTheme` projects the palette's RGB values to 256-color indices when
+  // mode is '256', and returns null for 'named' mode (named ANSI has only 8
+  // base hues — not enough fidelity to honour a theme accurately, so we fall
+  // back to built-in defaults instead of approximating with wrong colors).
+  if (theme && (mode === 'truecolor' || mode === '256')) {
     return {
       ...named,
       cyan: wrap(theme.cyan), magenta: wrap(theme.magenta),

--- a/src/render/minimal.ts
+++ b/src/render/minimal.ts
@@ -38,7 +38,10 @@ export function renderMinimal(ctx: RenderContext, c: Colors): string {
 
   // Context bar
   if (display.contextBar) {
-    parts.push(buildContextBar(input.context.usedPercentage, c, { segments: 10, iconSet: icons }));
+    // `showHint: false` — the minimal preset targets tight single-line terminals,
+    // where the /compact hint's ~10 trailing chars pushes truncation earlier. Users
+    // on minimal can still read the blinking skull icon as an at-risk signal.
+    parts.push(buildContextBar(input.context.usedPercentage, c, { segments: 10, iconSet: icons, showHint: false }));
   }
 
   // Only add these if cols >= 60

--- a/src/render/shared.ts
+++ b/src/render/shared.ts
@@ -17,11 +17,14 @@ export interface ContextBarOpts {
   segments?: number;
   showIcons?: boolean;
   iconSet?: IconSet;
+  /** When true (default), append an actionable hint like `/compact?` at high fill. */
+  showHint?: boolean;
 }
 
 export function buildContextBar(pct: number, c: Colors, opts?: ContextBarOpts): string {
   const segments = opts?.segments ?? 20;
   const showIcons = opts?.showIcons ?? true;
+  const showHint = opts?.showHint ?? true;
   const ic = opts?.iconSet ?? NERD_ICONS;
 
   const filled = Math.round((pct / 100) * segments);
@@ -34,9 +37,17 @@ export function buildContextBar(pct: number, c: Colors, opts?: ContextBarOpts): 
     else if (pct >= 65) icon = c.orange(ic.fire);
   }
 
+  // Actionable hint at high fill — nudges the user to reclaim context before
+  // the session stalls. Thresholds align with the color/icon tiers above.
+  let hint = '';
+  if (showHint) {
+    if (pct >= 90) hint = ' ' + c.red('/compact!');
+    else if (pct >= 80) hint = ' ' + c.dim('/compact?');
+  }
+
   const pctStr = colorFn(`${pct < 10 ? pct.toFixed(1) : pct.toFixed(0)}%`);
 
-  return `${bar} ${pctStr}${icon ? ' ' + icon : ''}`;
+  return `${bar} ${pctStr}${icon ? ' ' + icon : ''}${hint}`;
 }
 
 export function formatGitChanges(git: GitStatus, c: Colors): string[] {

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -1,9 +1,11 @@
 import type { ColorMode } from './render/colors.js';
 
 /**
- * A theme defines truecolor overrides for each named color.
- * At runtime, if the user selects a theme AND their terminal supports
- * truecolor/256, these values replace the defaults in createColors.
+ * A theme defines truecolor RGB values for each named color.
+ * At runtime:
+ * - truecolor terminals get the exact RGB via `\x1b[38;2;r;g;bm`
+ * - 256-color terminals get the nearest xterm 256-color index via `\x1b[38;5;Nm`
+ * - named-ANSI terminals fall back to defaults (themes are not applied)
  */
 export interface ThemePalette {
   cyan: string;
@@ -16,8 +18,53 @@ export interface ThemePalette {
   gray: string;
 }
 
+interface RGB { r: number; g: number; b: number; }
+
 function rgb(r: number, g: number, b: number): string {
   return `\x1b[38;2;${r};${g};${b}m`;
+}
+
+/** Parse a truecolor escape `\x1b[38;2;R;G;Bm` back into RGB components. */
+function parseRgb(escape: string): RGB | null {
+  const m = escape.match(/^\x1b\[38;2;(\d+);(\d+);(\d+)m$/);
+  if (!m) return null;
+  return { r: parseInt(m[1], 10), g: parseInt(m[2], 10), b: parseInt(m[3], 10) };
+}
+
+/**
+ * Convert an RGB triple to the nearest xterm 256-color index (0..255).
+ * Uses the standard 6×6×6 color cube (indices 16..231) plus grayscale ramp
+ * (232..255). Algorithm follows Chalk/ansi-styles conventions.
+ */
+function rgbTo256(r: number, g: number, b: number): number {
+  // Grayscale shortcut when r≈g≈b
+  if (r === g && g === b) {
+    if (r < 8) return 16;
+    if (r > 248) return 231;
+    return Math.round((r - 8) / 247 * 24) + 232;
+  }
+  const cube = (v: number) => Math.round(v / 255 * 5);
+  return 16 + 36 * cube(r) + 6 * cube(g) + cube(b);
+}
+
+function rgbEscapeTo256(escape: string): string {
+  const c = parseRgb(escape);
+  if (!c) return escape;
+  return `\x1b[38;5;${rgbTo256(c.r, c.g, c.b)}m`;
+}
+
+/** Project a truecolor-only palette to 256-color escapes. */
+export function downgradePaletteTo256(p: ThemePalette): ThemePalette {
+  return {
+    cyan: rgbEscapeTo256(p.cyan),
+    magenta: rgbEscapeTo256(p.magenta),
+    yellow: rgbEscapeTo256(p.yellow),
+    green: rgbEscapeTo256(p.green),
+    orange: rgbEscapeTo256(p.orange),
+    red: rgbEscapeTo256(p.red),
+    brightBlue: rgbEscapeTo256(p.brightBlue),
+    gray: rgbEscapeTo256(p.gray),
+  };
 }
 
 export const THEMES: Record<string, ThemePalette> = {
@@ -71,6 +118,26 @@ export const THEMES: Record<string, ThemePalette> = {
     brightBlue: rgb(102, 217, 239),
     gray: rgb(117, 113, 94),
   },
+  gruvbox: {
+    cyan: rgb(131, 165, 152),
+    magenta: rgb(211, 134, 155),
+    yellow: rgb(215, 153, 33),
+    green: rgb(152, 151, 26),
+    orange: rgb(214, 93, 14),
+    red: rgb(204, 36, 29),
+    brightBlue: rgb(69, 133, 136),
+    gray: rgb(146, 131, 116),
+  },
+  solarized: {
+    cyan: rgb(42, 161, 152),
+    magenta: rgb(211, 54, 130),
+    yellow: rgb(181, 137, 0),
+    green: rgb(133, 153, 0),
+    orange: rgb(203, 75, 22),
+    red: rgb(220, 50, 47),
+    brightBlue: rgb(38, 139, 210),
+    gray: rgb(101, 123, 131),
+  },
 };
 
 export function getThemeNames(): string[] {
@@ -79,7 +146,13 @@ export function getThemeNames(): string[] {
 
 export function resolveTheme(name: string | undefined, mode: ColorMode): ThemePalette | null {
   if (!name) return null;
-  // Themes only apply in truecolor mode — they use RGB values
-  if (mode !== 'truecolor') return null;
-  return THEMES[name.toLowerCase()] ?? null;
+  const base = THEMES[name.toLowerCase()];
+  if (!base) return null;
+  // Truecolor terminals get the exact palette; 256-color terminals get a
+  // nearest-index projection. Named-ANSI terminals cannot represent arbitrary
+  // palettes — fall back to built-in defaults rather than lying with mismatched
+  // named colors (only 8 base hues available).
+  if (mode === 'truecolor') return base;
+  if (mode === '256') return downgradePaletteTo256(base);
+  return null;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -238,7 +238,7 @@ export interface Dependencies {
   parseTranscript: (path: string) => Promise<TranscriptData>;
   getTokenSpeed: (contextWindow: ClaudeCodeInput['context_window']) => number | null;
   getMemoryInfo: () => MemoryInfo | null;
-  getGsdInfo: (session: string) => GsdInfo | null;
+  getGsdInfo: (cwd: string) => GsdInfo | null;
   getMcpInfo: (cwd: string) => McpInfo | null;
   getTermCols: () => number;
   loadConfig?: () => HudConfig;

--- a/tests/parsers/gsd.test.ts
+++ b/tests/parsers/gsd.test.ts
@@ -2,47 +2,108 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { getGsdInfo } from '../../src/parsers/gsd.js';
+import { getGsdInfo, parseStateMd } from '../../src/parsers/gsd.js';
+
+describe('parseStateMd', () => {
+  it('parses YAML frontmatter (milestone, status, name)', () => {
+    const content = `---
+milestone: v2.0
+milestone_name: "Automation Phase"
+status: executing
+---
+
+# body`;
+    const s = parseStateMd(content);
+    expect(s.milestone).toBe('v2.0');
+    expect(s.milestoneName).toBe('Automation Phase');
+    expect(s.status).toBe('executing');
+  });
+
+  it('parses Phase: N of M (name) line', () => {
+    const content = `---\nstatus: planning\n---\n\nPhase: 9 of 12 (multi-role-permissions)`;
+    const s = parseStateMd(content);
+    expect(s.phaseNum).toBe('9');
+    expect(s.phaseTotal).toBe('12');
+    expect(s.phaseName).toBe('multi-role-permissions');
+  });
+
+  it('falls back to body Status when frontmatter is absent', () => {
+    const content = `# State\n\nStatus: Ready to plan phase 3`;
+    expect(parseStateMd(content).status).toBe('planning');
+  });
+
+  it('treats `null` frontmatter values as absent', () => {
+    const content = `---\nstatus: null\nmilestone: v1.0\n---`;
+    const s = parseStateMd(content);
+    expect(s.status).toBeUndefined();
+    expect(s.milestone).toBe('v1.0');
+  });
+});
 
 describe('getGsdInfo', () => {
   let dir: string;
-  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'gsd-')); mkdirSync(join(dir, 'cache'), { recursive: true }); mkdirSync(join(dir, 'todos'), { recursive: true }); });
-  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
-
-  it('returns null when no data', () => { expect(getGsdInfo('s', dir)).toBeNull(); });
-  it('detects update available', () => {
-    writeFileSync(join(dir, 'cache', 'gsd-update-check.json'), '{"update_available":true}');
-    expect(getGsdInfo('s', dir)?.updateAvailable).toBe(true);
+  let claudeDir: string;
+  let opts: { claudeDir: string; sharedCacheFile: string };
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'gsd-cwd-'));
+    claudeDir = mkdtempSync(join(tmpdir(), 'gsd-claude-'));
+    mkdirSync(join(claudeDir, 'cache'), { recursive: true });
+    // Point shared cache at a path inside claudeDir so tests don't read the
+    // real ~/.cache/gsd on the dev machine.
+    opts = { claudeDir, sharedCacheFile: join(claudeDir, 'shared-cache.json') };
   });
-  it('reads current task', () => {
-    writeFileSync(join(dir, 'todos', 's-agent-1.json'), JSON.stringify([{ status: 'in_progress', activeForm: 'Building X' }]));
-    expect(getGsdInfo('s', dir)?.currentTask).toBe('Building X');
-  });
-
-  it('sanitizes session ID with special characters', () => {
-    writeFileSync(join(dir, 'todos', 'abc-agent-1.json'), JSON.stringify([{ status: 'in_progress', activeForm: 'Task' }]));
-    // ../evil gets sanitized to empty or safe string — should not match
-    expect(getGsdInfo('../evil', dir)).toBeNull();
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(claudeDir, { recursive: true, force: true });
   });
 
-  it('sanitizes session ID with slashes', () => {
-    expect(getGsdInfo('../../etc/passwd', dir)).toBeNull();
+  it('returns null when no STATE.md and no update cache', () => {
+    expect(getGsdInfo(dir, opts)).toBeNull();
   });
 
-  it('handles malformed JSON in cache file', () => {
-    writeFileSync(join(dir, 'cache', 'gsd-update-check.json'), 'not json');
-    expect(getGsdInfo('s', dir)).toBeNull();
+  it('reads update_available from legacy per-runtime cache', () => {
+    writeFileSync(join(claudeDir, 'cache', 'gsd-update-check.json'), '{"update_available":true}');
+    expect(getGsdInfo(dir, opts)?.updateAvailable).toBe(true);
   });
 
-  it('handles malformed JSON in todos file', () => {
-    writeFileSync(join(dir, 'todos', 's-agent-1.json'), 'broken json');
-    expect(getGsdInfo('s', dir)).toBeNull();
+  it('reads GSD state from nearest .planning/STATE.md walking up from cwd', () => {
+    const projectRoot = join(dir, 'project');
+    const nested = join(projectRoot, 'src', 'deeply', 'nested');
+    mkdirSync(join(projectRoot, '.planning'), { recursive: true });
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(
+      join(projectRoot, '.planning', 'STATE.md'),
+      `---\nmilestone: v1.2\nstatus: executing\n---\n\nPhase: 3 of 5 (auth)`,
+    );
+    const info = getGsdInfo(nested, opts);
+    expect(info?.currentTask).toContain('v1.2');
+    expect(info?.currentTask).toContain('executing');
+    expect(info?.currentTask).toContain('auth (3/5)');
   });
 
-  it('sanitizes control characters from currentTask', () => {
-    const malicious = 'Safe\x1b[31mPart\x00\x07\x7fend';
-    writeFileSync(join(dir, 'todos', 's-agent-1.json'), JSON.stringify([{ status: 'in_progress', activeForm: malicious }]));
-    const task = getGsdInfo('s', dir)?.currentTask ?? '';
+  it('stops walking at home directory', () => {
+    // cwd is a tmpdir outside any .planning ancestor
+    expect(getGsdInfo(dir, opts)).toBeNull();
+  });
+
+  it('handles malformed JSON in cache gracefully', () => {
+    writeFileSync(join(claudeDir, 'cache', 'gsd-update-check.json'), 'not json');
+    expect(getGsdInfo(dir, opts)).toBeNull();
+  });
+
+  it('handles malformed STATE.md gracefully', () => {
+    mkdirSync(join(dir, '.planning'), { recursive: true });
+    writeFileSync(join(dir, '.planning', 'STATE.md'), '');
+    expect(getGsdInfo(dir, opts)).toBeNull();
+  });
+
+  it('sanitizes control characters from formatted state', () => {
+    mkdirSync(join(dir, '.planning'), { recursive: true });
+    writeFileSync(
+      join(dir, '.planning', 'STATE.md'),
+      `---\nmilestone: v1.0\nmilestone_name: "Safe\x1b[31mPart\x00end"\nstatus: executing\n---`,
+    );
+    const task = getGsdInfo(dir, opts)?.currentTask ?? '';
     expect(task).not.toMatch(/[\x00-\x1f\x7f-\x9f]/);
     expect(task).toContain('Safe');
     expect(task).toContain('end');

--- a/tests/render/shared.test.ts
+++ b/tests/render/shared.test.ts
@@ -111,6 +111,17 @@ describe('buildContextBar — compact hint', () => {
     expect(bar).not.toContain('/compact');
   });
 
+  it('shows /compact? at exactly 80% (boundary inclusive)', () => {
+    const bar = stripAnsi(buildContextBar(80, c));
+    expect(bar).toContain('/compact?');
+    expect(bar).not.toContain('/compact!');
+  });
+
+  it('shows /compact! at exactly 90% (boundary inclusive)', () => {
+    const bar = stripAnsi(buildContextBar(90, c));
+    expect(bar).toContain('/compact!');
+  });
+
   it('hides compact hint when showHint=false', () => {
     const bar = stripAnsi(buildContextBar(95, c, { showHint: false }));
     expect(bar).not.toContain('/compact');

--- a/tests/render/shared.test.ts
+++ b/tests/render/shared.test.ts
@@ -94,6 +94,29 @@ describe('formatGitChanges', () => {
   });
 });
 
+describe('buildContextBar — compact hint', () => {
+  it('shows /compact? hint at 80-89%', () => {
+    const bar = stripAnsi(buildContextBar(85, c));
+    expect(bar).toContain('/compact?');
+    expect(bar).not.toContain('/compact!');
+  });
+
+  it('shows /compact! hint at 90%+', () => {
+    const bar = stripAnsi(buildContextBar(95, c));
+    expect(bar).toContain('/compact!');
+  });
+
+  it('does not show compact hint below 80%', () => {
+    const bar = stripAnsi(buildContextBar(70, c));
+    expect(bar).not.toContain('/compact');
+  });
+
+  it('hides compact hint when showHint=false', () => {
+    const bar = stripAnsi(buildContextBar(95, c, { showHint: false }));
+    expect(bar).not.toContain('/compact');
+  });
+});
+
 describe('SEP constants', () => {
   it('SEP uses Unicode pipe', () => {
     expect(SEP).toContain('\u2502');

--- a/tests/themes.test.ts
+++ b/tests/themes.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { THEMES, getThemeNames, resolveTheme } from '../src/themes.js';
+import { THEMES, getThemeNames, resolveTheme, downgradePaletteTo256, type ThemePalette } from '../src/themes.js';
+
+// Build a synthetic palette where every color slot is the same RGB triple.
+// Used to exercise rgbTo256 indirectly through downgradePaletteTo256.
+function synthetic(escape: string): ThemePalette {
+  return {
+    cyan: escape, magenta: escape, yellow: escape, green: escape,
+    orange: escape, red: escape, brightBlue: escape, gray: escape,
+  };
+}
+const rgbEsc = (r: number, g: number, b: number) => `\x1b[38;2;${r};${g};${b}m`;
 
 describe('THEMES', () => {
   it('has at least 7 themes', () => {
@@ -55,5 +65,49 @@ describe('resolveTheme', () => {
 
   it('returns null for unknown theme', () => {
     expect(resolveTheme('nonexistent', 'truecolor')).toBeNull();
+  });
+});
+
+describe('downgradePaletteTo256 (rgbTo256 projection)', () => {
+  it('maps pure black (0,0,0) to xterm index 16', () => {
+    expect(downgradePaletteTo256(synthetic(rgbEsc(0, 0, 0))).cyan).toBe('\x1b[38;5;16m');
+  });
+
+  it('maps pure white (255,255,255) to xterm index 231', () => {
+    expect(downgradePaletteTo256(synthetic(rgbEsc(255, 255, 255))).cyan).toBe('\x1b[38;5;231m');
+  });
+
+  it('maps mid-gray (128,128,128) into the grayscale ramp (232-255)', () => {
+    const m = downgradePaletteTo256(synthetic(rgbEsc(128, 128, 128))).cyan.match(/38;5;(\d+)m/);
+    const idx = parseInt(m![1], 10);
+    expect(idx).toBeGreaterThanOrEqual(232);
+    expect(idx).toBeLessThanOrEqual(255);
+  });
+
+  it('maps pure red (255,0,0) to cube index 196', () => {
+    expect(downgradePaletteTo256(synthetic(rgbEsc(255, 0, 0))).cyan).toBe('\x1b[38;5;196m');
+  });
+
+  it('maps pure green (0,255,0) to cube index 46', () => {
+    expect(downgradePaletteTo256(synthetic(rgbEsc(0, 255, 0))).cyan).toBe('\x1b[38;5;46m');
+  });
+
+  it('maps pure blue (0,0,255) to cube index 21', () => {
+    expect(downgradePaletteTo256(synthetic(rgbEsc(0, 0, 255))).cyan).toBe('\x1b[38;5;21m');
+  });
+
+  it('handles grayscale boundary: r<8 rounds to black (16)', () => {
+    expect(downgradePaletteTo256(synthetic(rgbEsc(5, 5, 5))).cyan).toBe('\x1b[38;5;16m');
+  });
+
+  it('handles grayscale boundary: r>248 rounds to white (231)', () => {
+    expect(downgradePaletteTo256(synthetic(rgbEsc(250, 250, 250))).cyan).toBe('\x1b[38;5;231m');
+  });
+
+  it('leaves malformed escapes untouched (not a truecolor escape)', () => {
+    // Sanity: if an escape doesn't match the parseRgb shape, the function
+    // returns it unchanged rather than throwing.
+    const weird = '\x1b[1;38;5;208m';
+    expect(downgradePaletteTo256(synthetic(weird)).cyan).toBe(weird);
   });
 });

--- a/tests/themes.test.ts
+++ b/tests/themes.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect } from 'vitest';
 import { THEMES, getThemeNames, resolveTheme } from '../src/themes.js';
 
 describe('THEMES', () => {
-  it('has at least 5 themes', () => {
-    expect(Object.keys(THEMES).length).toBeGreaterThanOrEqual(5);
+  it('has at least 7 themes', () => {
+    expect(Object.keys(THEMES).length).toBeGreaterThanOrEqual(7);
   });
 
   it('each theme has all required color keys', () => {
     const requiredKeys = ['cyan', 'magenta', 'yellow', 'green', 'orange', 'red', 'brightBlue', 'gray'];
-    for (const [name, palette] of Object.entries(THEMES)) {
+    for (const [, palette] of Object.entries(THEMES)) {
       for (const key of requiredKeys) {
         expect(palette).toHaveProperty(key);
         expect((palette as Record<string, string>)[key]).toContain('\x1b[38;2;');
@@ -20,11 +20,9 @@ describe('THEMES', () => {
 describe('getThemeNames', () => {
   it('returns all theme names', () => {
     const names = getThemeNames();
-    expect(names).toContain('dracula');
-    expect(names).toContain('nord');
-    expect(names).toContain('tokyo-night');
-    expect(names).toContain('catppuccin');
-    expect(names).toContain('monokai');
+    expect(names).toEqual(
+      expect.arrayContaining(['dracula', 'nord', 'tokyo-night', 'catppuccin', 'monokai', 'gruvbox', 'solarized']),
+    );
   });
 });
 
@@ -33,12 +31,18 @@ describe('resolveTheme', () => {
     expect(resolveTheme(undefined, 'truecolor')).toBeNull();
   });
 
-  it('returns null for non-truecolor modes', () => {
+  it('returns null in named mode (insufficient color fidelity)', () => {
     expect(resolveTheme('dracula', 'named')).toBeNull();
-    expect(resolveTheme('dracula', '256')).toBeNull();
   });
 
-  it('returns palette for valid theme in truecolor mode', () => {
+  it('returns a downgraded 256-color palette in 256 mode', () => {
+    const palette = resolveTheme('dracula', '256');
+    expect(palette).not.toBeNull();
+    expect(palette!.cyan).toMatch(/^\x1b\[38;5;\d+m$/);
+    expect(palette!.magenta).toMatch(/^\x1b\[38;5;\d+m$/);
+  });
+
+  it('returns the raw RGB palette in truecolor mode', () => {
     const palette = resolveTheme('dracula', 'truecolor');
     expect(palette).not.toBeNull();
     expect(palette!.cyan).toContain('\x1b[38;2;');


### PR DESCRIPTION
## Release v0.4.0

### Added
- Two new themes: \`gruvbox\` and \`solarized\` (catalog now at 7).
- Actionable \`/compact?\` / \`/compact!\` hints at ≥80% / ≥90% context fill. Minimal preset opts out automatically.

### Changed
- **Themes now work in 256-color terminals** — previously silently disabled unless truecolor. RGB values project to nearest xterm 256-color cube index. Named-ANSI mode still falls back to defaults (insufficient fidelity).
- **GSD integration rewritten** to match the current \`get-shit-done\` state layout — reads from shared \`~/.cache/gsd/\` (#1421), walks up from \`cwd\` looking for \`.planning/STATE.md\`, formats as \`milestone · status · phase\`. \`getGsdInfo\` signature changed from \`(session, claudeDir?)\` to \`(cwd, opts?)\`.

---
Merging this PR triggers the release workflow, tags \`v0.4.0\`, and publishes to npm.