### PR TITLE
fix(render): use normalized fields in line1 to preserve sanitization

### DIFF
--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -59,24 +59,24 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
     right.push(c.yellow(truncField(activeTask, 30)));
   }
 
-  // Worktree
-  if (display.worktree && input.raw.worktree?.name) {
-    right.push(c.gray(`${icons.tree} ${truncField(input.raw.worktree.name, 15)}`));
+  // Worktree / Agent / Session name / Style — read from the normalized layer,
+  // which has already run sanitizeTermString() over these untrusted values.
+  // Reading input.raw.* directly would bypass that guard and let malformed
+  // stdin JSON inject terminal control sequences.
+  if (display.worktree && input.worktreeName) {
+    right.push(c.gray(`${icons.tree} ${truncField(input.worktreeName, 15)}`));
   }
 
-  // Agent
-  if (display.agent && input.raw.agent?.name) {
-    right.push(c.gray(`${icons.cubes} ${truncField(input.raw.agent.name, 15)}`));
+  if (display.agent && input.agentName) {
+    right.push(c.gray(`${icons.cubes} ${truncField(input.agentName, 15)}`));
   }
 
-  // Session name
-  if (display.sessionName && input.raw.session_name) {
-    right.push(c.dim(truncField(input.raw.session_name, 20)));
+  if (display.sessionName && input.sessionName) {
+    right.push(c.dim(truncField(input.sessionName, 20)));
   }
 
-  // Style
-  if (display.style && input.raw.output_style?.name) {
-    right.push(c.gray(input.raw.output_style.name));
+  if (display.style && input.outputStyle) {
+    right.push(c.gray(input.outputStyle));
   }
 
   // Version


### PR DESCRIPTION
## Summary

Closes the last known holes of the same class as #14 / #15: \`line1.ts\` was reading \`input.raw.worktree?.name\`, \`input.raw.agent?.name\`, \`input.raw.session_name\`, and \`input.raw.output_style?.name\` directly instead of their sanitized counterparts in the normalize layer (\`input.worktreeName\`, \`input.agentName\`, \`input.sessionName\`, \`input.outputStyle\`).

Reading \`raw.*\` bypasses \`sanitizeTermString()\`, so malformed stdin JSON could inject C0/C1/DEL control sequences via any of these four fields.

Flagged as scope-adjacent by Opus during the PR #28 code review.

## Test plan
- 376 tests passing (\`npm test\`)
- \`npm run lint\` clean