### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-23
+
+### Added
+- **`LUMIRA_DEBUG=1` env flag** for diagnostic logging. Writes to stderr so statusline stdout stays clean. Instruments transcript, GSD, and MCP parsers with decision traces (cache hits/misses, `.planning/STATE.md` resolution, which `.mcp.json` loaded which servers, malformed JSON). Useful when investigating "why doesn't X show up?" reports. Denylist accepts `0`/`false`/`no`/`off` (case-insensitive) for explicit disable.
+
+### Security
+- **`line1` renderer now reads from the normalized input layer** instead of raw stdin JSON. `input.worktreeName`, `input.agentName`, `input.sessionName`, and `input.outputStyle` have already passed through `sanitizeTermString()` (strips C0/C1/DEL control chars). Previously line1 was reading `input.raw.*` directly, bypassing that guard — same class of vulnerability as #14/#15, now closed.
+
 ## [0.4.0] - 2026-04-23
 
 ### Added
@@ -175,7 +183,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GSD session IDs sanitized against path traversal
 - `execFile` used instead of `exec` to prevent shell injection (except terminal width detection where shell redirect is required with procfs-sourced paths)
 
-[Unreleased]: https://github.com/cativo23/lumira/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/cativo23/lumira/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/cativo23/lumira/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/cativo23/lumira/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/cativo23/lumira/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/cativo23/lumira/compare/v0.3.0...v0.3.1

--- a/README.md
+++ b/README.md
@@ -170,6 +170,14 @@ npm run lint         # Type check
 npm run build        # Compile to dist/
 ```
 
+### Debugging
+
+Set `LUMIRA_DEBUG=1` to trace parser decisions on stderr — cache hits, GSD state-file resolution, MCP server loads. Useful when investigating "why doesn't X show up?" reports. Stdout stays clean so it doesn't corrupt the statusline.
+
+```bash
+LUMIRA_DEBUG=1 claude    # or export LUMIRA_DEBUG=1
+```
+
 ## Credits
 
 Inspired by [claude-hud](https://github.com/jarrodwatts/claude-hud). Migrated from [claude-setup](https://github.com/cativo23/claude-setup) statusline.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "lumira — real-time statusline for Claude Code",
   "type": "module",
   "main": "dist/index.js",

--- a/src/parsers/gsd.ts
+++ b/src/parsers/gsd.ts
@@ -3,6 +3,9 @@ import { join, dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import type { GsdInfo } from '../types.js';
 import { sanitizeTermString } from '../normalize.js';
+import { debug } from '../utils/debug.js';
+
+const log = debug('gsd');
 
 // Max directory levels to walk upward looking for .planning/STATE.md
 const STATE_WALK_MAX = 10;
@@ -93,11 +96,18 @@ function formatState(s: GsdState): string {
  * per-runtime location (`~/.claude/cache/`) for older GSD installs.
  */
 function readUpdateCache(sharedCacheFile: string, legacyCacheFile: string): boolean {
-  for (const file of [sharedCacheFile, legacyCacheFile]) {
+  const candidates: Array<[string, string]> = [
+    ['shared', sharedCacheFile],
+    ['legacy', legacyCacheFile],
+  ];
+  for (const [source, file] of candidates) {
     if (!existsSync(file)) continue;
     try {
       const parsed = JSON.parse(readFileSync(file, 'utf8')) as { update_available?: boolean };
-      if (parsed.update_available) return true;
+      if (parsed.update_available) {
+        log('update cache:', source, file);
+        return true;
+      }
     } catch { /* ignore malformed */ }
   }
   return false;
@@ -119,11 +129,19 @@ export function getGsdInfo(cwd: string, opts: GsdInfoOptions = {}): GsdInfo | nu
   let currentTask: string | undefined;
   const stateFile = findStateMd(cwd || process.cwd());
   if (stateFile) {
+    log('STATE.md found:', stateFile);
     try {
       const state = parseStateMd(readFileSync(stateFile, 'utf8'));
       const formatted = formatState(state);
-      if (formatted) currentTask = sanitizeTermString(formatted);
-    } catch { /* ignore */ }
+      if (formatted) {
+        currentTask = sanitizeTermString(formatted);
+        log('state parsed:', state);
+      }
+    } catch (err) {
+      log('STATE.md parse error:', (err as Error).message);
+    }
+  } else {
+    log('no STATE.md found walking up from:', cwd || process.cwd());
   }
 
   if (!updateAvailable && !currentTask) return null;

--- a/src/parsers/gsd.ts
+++ b/src/parsers/gsd.ts
@@ -144,6 +144,9 @@ export function getGsdInfo(cwd: string, opts: GsdInfoOptions = {}): GsdInfo | nu
     log('no STATE.md found walking up from:', cwd || process.cwd());
   }
 
-  if (!updateAvailable && !currentTask) return null;
+  if (!updateAvailable && !currentTask) {
+    log('no gsd signal — update=false, task=none (line4 will be empty)');
+    return null;
+  }
   return { updateAvailable, currentTask };
 }

--- a/src/parsers/mcp.ts
+++ b/src/parsers/mcp.ts
@@ -2,6 +2,9 @@ import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { McpInfo, McpServerInfo } from '../types.js';
+import { debug } from '../utils/debug.js';
+
+const log = debug('mcp');
 
 /**
  * Read MCP server configurations from .mcp.json files.
@@ -20,13 +23,16 @@ export function getMcpInfo(cwd: string): McpInfo | null {
     try {
       const raw = JSON.parse(readFileSync(p, 'utf8'));
       const mcpServers = raw?.mcpServers ?? {};
+      const added: string[] = [];
       for (const name of Object.keys(mcpServers)) {
         // Avoid duplicates if same server in both files
         if (servers.some(s => s.name === name)) continue;
         servers.push({ name, status: 'ok' });
+        added.push(name);
       }
-    } catch {
-      // Malformed JSON — skip
+      if (log.enabled && added.length > 0) log('loaded from', p, added);
+    } catch (err) {
+      log('malformed JSON:', p, (err as Error).message);
     }
   }
 

--- a/src/parsers/mcp.ts
+++ b/src/parsers/mcp.ts
@@ -30,6 +30,8 @@ export function getMcpInfo(cwd: string): McpInfo | null {
         servers.push({ name, status: 'ok' });
         added.push(name);
       }
+      // SECURITY: only log server names. `raw.mcpServers[name]` values contain
+      // `env` / `args` which often carry API tokens — never log the raw object.
       if (log.enabled && added.length > 0) log('loaded from', p, added);
     } catch (err) {
       log('malformed JSON:', p, (err as Error).message);

--- a/src/parsers/transcript.ts
+++ b/src/parsers/transcript.ts
@@ -6,6 +6,9 @@ import type { TranscriptData, ToolEntry, AgentEntry, TodoEntry, TodoStatus, Thin
 import { EMPTY_TRANSCRIPT } from '../types.js';
 import { isMtimeFresh, getMtimeState, type MtimeState } from '../utils/cache.js';
 import { sanitizeTermString } from '../normalize.js';
+import { debug } from '../utils/debug.js';
+
+const log = debug('transcript');
 
 const transcriptCache = new Map<string, { result: TranscriptData; mtime: MtimeState }>();
 
@@ -39,16 +42,24 @@ export function extractToolTarget(toolName: string, input: Record<string, unknow
 
 export async function parseTranscript(transcriptPath: string): Promise<TranscriptData> {
   const result: TranscriptData = { ...EMPTY_TRANSCRIPT, tools: [], agents: [], todos: [] };
-  if (!transcriptPath || !existsSync(transcriptPath)) return result;
+  if (!transcriptPath || !existsSync(transcriptPath)) {
+    if (log.enabled) log('skip — transcript path missing or nonexistent:', transcriptPath || '(empty)');
+    return result;
+  }
 
   const resolved = resolve(transcriptPath);
-  if (!resolved.startsWith(homedir()) && !resolved.startsWith(tmpdir())) return result;
+  if (!resolved.startsWith(homedir()) && !resolved.startsWith(tmpdir())) {
+    log('skip — path outside allowed roots:', resolved);
+    return result;
+  }
 
   const currentMtime = getMtimeState(transcriptPath);
   const cached = transcriptCache.get(resolved);
   if (currentMtime && cached && isMtimeFresh(transcriptPath, cached.mtime)) {
+    log('cache hit:', resolved);
     return cached.result;
   }
+  const parseStart = log.enabled ? Date.now() : 0;
 
   const toolMap = new Map<string, ToolEntry>();
   const agentMap = new Map<string, AgentEntry>();
@@ -143,6 +154,15 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   result.thinkingEffort = thinkingEffort;
   if (currentMtime) {
     transcriptCache.set(resolved, { result, mtime: currentMtime });
+  }
+  if (log.enabled) {
+    log('parsed', resolved, {
+      tools: result.tools.length,
+      agents: result.agents.length,
+      todos: result.todos.length,
+      thinkingEffort: result.thinkingEffort || null,
+      durationMs: Date.now() - parseStart,
+    });
   }
   return result;
 }

--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -59,24 +59,24 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
     right.push(c.yellow(truncField(activeTask, 30)));
   }
 
-  // Worktree
-  if (display.worktree && input.raw.worktree?.name) {
-    right.push(c.gray(`${icons.tree} ${truncField(input.raw.worktree.name, 15)}`));
+  // Worktree / Agent / Session name / Style — read from the normalized layer,
+  // which has already run sanitizeTermString() over these untrusted values.
+  // Reading input.raw.* directly would bypass that guard and let malformed
+  // stdin JSON inject terminal control sequences.
+  if (display.worktree && input.worktreeName) {
+    right.push(c.gray(`${icons.tree} ${truncField(input.worktreeName, 15)}`));
   }
 
-  // Agent
-  if (display.agent && input.raw.agent?.name) {
-    right.push(c.gray(`${icons.cubes} ${truncField(input.raw.agent.name, 15)}`));
+  if (display.agent && input.agentName) {
+    right.push(c.gray(`${icons.cubes} ${truncField(input.agentName, 15)}`));
   }
 
-  // Session name
-  if (display.sessionName && input.raw.session_name) {
-    right.push(c.dim(truncField(input.raw.session_name, 20)));
+  if (display.sessionName && input.sessionName) {
+    right.push(c.dim(truncField(input.sessionName, 20)));
   }
 
-  // Style
-  if (display.style && input.raw.output_style?.name) {
-    right.push(c.gray(input.raw.output_style.name));
+  if (display.style && input.outputStyle) {
+    right.push(c.gray(input.outputStyle));
   }
 
   // Version

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,0 +1,54 @@
+/**
+ * Lightweight debug logger gated on the `LUMIRA_DEBUG` env var.
+ *
+ * Statusline stdout must stay clean (Claude Code parses it), so diagnostic
+ * output goes to stderr. No-op when `LUMIRA_DEBUG` is unset/empty/"0"/"false",
+ * so the branch is effectively free in production.
+ *
+ * Usage:
+ *   const log = debug('transcript');
+ *   log('cache hit %s', resolved);   // [lumira:transcript] cache hit /path
+ *   log({ lines, durationMs });      // [lumira:transcript] { lines: 420, durationMs: 3 }
+ *
+ * Enable with:
+ *   LUMIRA_DEBUG=1 claude      # or export LUMIRA_DEBUG=1
+ */
+
+function debugEnabled(): boolean {
+  const v = process.env['LUMIRA_DEBUG'];
+  if (!v) return false;
+  const lower = v.toLowerCase();
+  return lower !== '0' && lower !== 'false' && lower !== '';
+}
+
+function format(args: unknown[]): string {
+  return args
+    .map((a) => {
+      if (typeof a === 'string') return a;
+      try {
+        return JSON.stringify(a);
+      } catch {
+        return String(a);
+      }
+    })
+    .join(' ');
+}
+
+export interface DebugLogger {
+  (...args: unknown[]): void;
+  /** True when LUMIRA_DEBUG is active — skip expensive formatting branches. */
+  readonly enabled: boolean;
+}
+
+export function debug(namespace: string): DebugLogger {
+  const enabled = debugEnabled();
+  const prefix = `[lumira:${namespace}]`;
+  const log: DebugLogger = Object.assign(
+    (...args: unknown[]) => {
+      if (!enabled) return;
+      process.stderr.write(`${prefix} ${format(args)}\n`);
+    },
+    { enabled },
+  );
+  return log;
+}

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -2,23 +2,29 @@
  * Lightweight debug logger gated on the `LUMIRA_DEBUG` env var.
  *
  * Statusline stdout must stay clean (Claude Code parses it), so diagnostic
- * output goes to stderr. No-op when `LUMIRA_DEBUG` is unset/empty/"0"/"false",
- * so the branch is effectively free in production.
+ * output goes to stderr. No-op when `LUMIRA_DEBUG` is unset or set to a
+ * denylisted value (`0`, `false`, `no`, `off`, empty), so the branch is
+ * effectively free in production.
+ *
+ * Args are space-joined; objects serialize via `JSON.stringify`. Unserializable
+ * values (circular refs, BigInt, getters-that-throw) are annotated as
+ * `<unserializable:...>` rather than silently becoming generic `[object Object]`.
  *
  * Usage:
  *   const log = debug('transcript');
- *   log('cache hit %s', resolved);   // [lumira:transcript] cache hit /path
- *   log({ lines, durationMs });      // [lumira:transcript] { lines: 420, durationMs: 3 }
+ *   log('cache hit:', resolved);     // [lumira:transcript] cache hit: /path
+ *   log({ lines, durationMs });      // [lumira:transcript] {"lines":420,"durationMs":3}
  *
  * Enable with:
  *   LUMIRA_DEBUG=1 claude      # or export LUMIRA_DEBUG=1
  */
 
+const FALSY_VALUES = new Set(['', '0', 'false', 'no', 'off']);
+
 function debugEnabled(): boolean {
   const v = process.env['LUMIRA_DEBUG'];
   if (!v) return false;
-  const lower = v.toLowerCase();
-  return lower !== '0' && lower !== 'false' && lower !== '';
+  return !FALSY_VALUES.has(v.toLowerCase());
 }
 
 function format(args: unknown[]): string {
@@ -28,7 +34,9 @@ function format(args: unknown[]): string {
       try {
         return JSON.stringify(a);
       } catch {
-        return String(a);
+        // Circular refs, BigInt, getter-that-throws, etc. Annotate explicitly
+        // so a real bug doesn't silently degrade to generic String coercion.
+        return `<unserializable:${String(a)}>`;
       }
     })
     .join(' ');

--- a/tests/utils/debug.test.ts
+++ b/tests/utils/debug.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { debug } from '../../src/utils/debug.js';
+
+describe('debug', () => {
+  let originalEnv: string | undefined;
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    originalEnv = process.env['LUMIRA_DEBUG'];
+    writeSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env['LUMIRA_DEBUG'];
+    else process.env['LUMIRA_DEBUG'] = originalEnv;
+    writeSpy.mockRestore();
+  });
+
+  it('is silent when LUMIRA_DEBUG is unset', () => {
+    delete process.env['LUMIRA_DEBUG'];
+    const log = debug('test');
+    expect(log.enabled).toBe(false);
+    log('hello', { a: 1 });
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  it('is silent for falsy string values (0, false, empty)', () => {
+    for (const v of ['0', 'false', '', 'FALSE']) {
+      process.env['LUMIRA_DEBUG'] = v;
+      const log = debug('test');
+      expect(log.enabled).toBe(false);
+      log('should not write');
+    }
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  it('writes to stderr when LUMIRA_DEBUG=1', () => {
+    process.env['LUMIRA_DEBUG'] = '1';
+    const log = debug('transcript');
+    expect(log.enabled).toBe(true);
+    log('hello world');
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    const output = writeSpy.mock.calls[0][0] as string;
+    expect(output).toContain('[lumira:transcript]');
+    expect(output).toContain('hello world');
+    expect(output.endsWith('\n')).toBe(true);
+  });
+
+  it('serializes objects via JSON.stringify', () => {
+    process.env['LUMIRA_DEBUG'] = '1';
+    const log = debug('ns');
+    log('parsed', { tools: 5, durationMs: 12 });
+    const output = writeSpy.mock.calls[0][0] as string;
+    expect(output).toContain('{"tools":5,"durationMs":12}');
+  });
+
+  it('handles circular references gracefully (falls back to String)', () => {
+    process.env['LUMIRA_DEBUG'] = '1';
+    const log = debug('ns');
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    log(circular);
+    // Should not throw; output falls back to String(obj)
+    expect(writeSpy).toHaveBeenCalled();
+  });
+
+  it('accepts any truthy non-sentinel value', () => {
+    for (const v of ['1', 'true', 'yes', 'anything']) {
+      process.env['LUMIRA_DEBUG'] = v;
+      const log = debug('ns');
+      expect(log.enabled).toBe(true);
+    }
+  });
+});

--- a/tests/utils/debug.test.ts
+++ b/tests/utils/debug.test.ts
@@ -24,8 +24,8 @@ describe('debug', () => {
     expect(writeSpy).not.toHaveBeenCalled();
   });
 
-  it('is silent for falsy string values (0, false, empty)', () => {
-    for (const v of ['0', 'false', '', 'FALSE']) {
+  it('is silent for falsy string values (0, false, empty, no, off, case-insensitive)', () => {
+    for (const v of ['0', 'false', '', 'FALSE', 'no', 'NO', 'off', 'Off']) {
       process.env['LUMIRA_DEBUG'] = v;
       const log = debug('test');
       expect(log.enabled).toBe(false);
@@ -54,18 +54,19 @@ describe('debug', () => {
     expect(output).toContain('{"tools":5,"durationMs":12}');
   });
 
-  it('handles circular references gracefully (falls back to String)', () => {
+  it('annotates unserializable values explicitly', () => {
     process.env['LUMIRA_DEBUG'] = '1';
     const log = debug('ns');
     const circular: Record<string, unknown> = {};
     circular.self = circular;
     log(circular);
-    // Should not throw; output falls back to String(obj)
-    expect(writeSpy).toHaveBeenCalled();
+    const output = writeSpy.mock.calls[0][0] as string;
+    // Explicit marker so a genuine serialization bug doesn't degrade silently.
+    expect(output).toContain('<unserializable:');
   });
 
-  it('accepts any truthy non-sentinel value', () => {
-    for (const v of ['1', 'true', 'yes', 'anything']) {
+  it('accepts any truthy value outside the denylist', () => {
+    for (const v of ['1', 'true', 'anything']) {
       process.env['LUMIRA_DEBUG'] = v;
       const log = debug('ns');
       expect(log.enabled).toBe(true);


### PR DESCRIPTION
## Release v0.5.0

### Added
- **\`LUMIRA_DEBUG=1\` env flag** — diagnostic logging on stderr for transcript, GSD, and MCP parsers. Silent by default. Accepts \`0\`/\`false\`/\`no\`/\`off\` to disable.

### Security
- **line1 renderer uses normalized fields** — closes the last sanitization bypass (\`input.raw.*\` reads in worktree/agent/sessionName/style segments). Same class as #14/#15.

---
Merging this PR triggers the release workflow, tags \`v0.5.0\`, and publishes to npm.