### PR TITLE
feat(render): OSC 8 hyperlinks for directory and version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **OSC 8 hyperlinks** — the directory (line 1) is now a clickable `file://` link that opens the folder in the OS file manager, and the version tag links to the matching Claude Code npm release page. Modern terminals (iTerm2, WezTerm, Kitty, Alacritty, VS Code, tmux ≥3.4 with passthrough) render them as hyperlinks; terminals without support show plain text. Auto-disabled in Apple_Terminal (which leaks escape markers as text) and `TERM=dumb`. Opt out with `NO_HYPERLINKS=1`; force on with `FORCE_HYPERLINK=1`.
+
+### Fixed
+- **`stripAnsi` now handles the ST (`ESC \`) OSC terminator**, not just BEL. Required so OSC 8 sequences don't leak into `displayWidth()` and throw off terminal-width fitting.
+
 ## [0.5.0] - 2026-04-23
 
 ### Added

--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -67,7 +67,10 @@ export function createColors(mode: ColorMode, theme?: import('../themes.js').The
 }
 
 export function stripAnsi(str: string): string {
-  return str.replace(/\x1b\[\??[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b[()][AB012]/g, '');
+  // OSC sequences terminate with either BEL (\x07) or ST (\x1b\\). OSC 8
+  // hyperlinks use ST, so both terminators must be matched — otherwise the
+  // URL and the wrapping markers leak into displayWidth() calculations.
+  return str.replace(/\x1b\[\??[0-9;]*[a-zA-Z]|\x1b\][\s\S]*?(?:\x07|\x1b\\)|\x1b[()][AB012]/g, '');
 }
 
 export function detectColorMode(): ColorMode {

--- a/src/render/hyperlink.ts
+++ b/src/render/hyperlink.ts
@@ -1,0 +1,46 @@
+// OSC 8 hyperlink support.
+// Sequence: ESC ] 8 ; ; URL ST TEXT ESC ] 8 ; ; ST  (ST = ESC \)
+// Terminals that don't support it render only TEXT; the wrappers are ignored.
+
+let cached: boolean | null = null;
+
+export function resetHyperlinkSupport(): void {
+  cached = null;
+}
+
+// Exposed for tests; prod code should call supportsHyperlinks().
+export function _setHyperlinkSupport(v: boolean | null): void {
+  cached = v;
+}
+
+export function supportsHyperlinks(): boolean {
+  if (cached !== null) return cached;
+
+  // Explicit opt-out (widely-recognised convention).
+  if (process.env['NO_HYPERLINKS'] || process.env['FORCE_HYPERLINK'] === '0') {
+    return (cached = false);
+  }
+  // Explicit opt-in bypasses all heuristics.
+  if (process.env['FORCE_HYPERLINK'] && process.env['FORCE_HYPERLINK'] !== '0') {
+    return (cached = true);
+  }
+
+  const term = process.env['TERM'] ?? '';
+  if (term === 'dumb') return (cached = false);
+
+  // Apple Terminal ignores OSC 8 but doesn't strip it — link markers leak as text.
+  const termProgram = process.env['TERM_PROGRAM'] ?? '';
+  if (termProgram === 'Apple_Terminal') return (cached = false);
+
+  // Statusline output is piped by Claude Code, so process.stdout.isTTY is false
+  // even in a real terminal. Rather than infer from our own stdout, we trust
+  // the TERM/TERM_PROGRAM hints above and emit by default — modern terminals
+  // (iTerm2, WezTerm, Kitty, Alacritty, VS Code, tmux ≥3.4 with passthrough)
+  // all support OSC 8, and unsupported ones merely render plain text.
+  return (cached = true);
+}
+
+export function hyperlink(url: string, text: string): string {
+  if (!supportsHyperlinks()) return text;
+  return `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`;
+}

--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -1,6 +1,8 @@
 import { basename } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { fitSegments, truncField } from './text.js';
 import { getModelName, formatGitChanges, SEP } from './shared.js';
+import { hyperlink } from './hyperlink.js';
 import type { Colors } from './colors.js';
 import type { RenderContext, TranscriptData } from '../types.js';
 
@@ -40,7 +42,11 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
     if (cwd) {
       const dirName = basename(cwd) || cwd;
       const dirLen = cols < 80 ? 12 : cols < 120 ? 20 : 30;
-      left.push(c.brightBlue(`${icons.folder} ${truncField(dirName, dirLen)}`));
+      const label = c.brightBlue(`${icons.folder} ${truncField(dirName, dirLen)}`);
+      // Wrap with OSC 8 so terminals that support it turn the directory into a
+      // clickable file:// link. pathToFileURL handles percent-encoding of
+      // spaces and non-ASCII chars correctly.
+      left.push(hyperlink(pathToFileURL(cwd).href, label));
     }
   }
 
@@ -79,9 +85,12 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
     right.push(c.gray(input.outputStyle));
   }
 
-  // Version
+  // Version — link to the Claude Code npm page for quick changelog lookup.
   if (display.version && input.version) {
-    right.push(c.dim(`v${input.version}`));
+    right.push(hyperlink(
+      `https://www.npmjs.com/package/@anthropic-ai/claude-code/v/${encodeURIComponent(input.version)}`,
+      c.dim(`v${input.version}`),
+    ));
   }
 
   if (left.length === 0 && right.length === 0) return '';

--- a/tests/render/hyperlink.test.ts
+++ b/tests/render/hyperlink.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { hyperlink, supportsHyperlinks, resetHyperlinkSupport, _setHyperlinkSupport } from '../../src/render/hyperlink.js';
+import { stripAnsi } from '../../src/render/colors.js';
+
+describe('hyperlink', () => {
+  const envKeys = ['NO_HYPERLINKS', 'FORCE_HYPERLINK', 'TERM', 'TERM_PROGRAM'] as const;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of envKeys) saved[k] = process.env[k];
+    for (const k of envKeys) delete process.env[k];
+    resetHyperlinkSupport();
+  });
+
+  afterEach(() => {
+    for (const k of envKeys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    resetHyperlinkSupport();
+  });
+
+  it('wraps text with OSC 8 sequence when supported', () => {
+    _setHyperlinkSupport(true);
+    const out = hyperlink('https://example.com', 'click');
+    expect(out).toBe('\x1b]8;;https://example.com\x1b\\click\x1b]8;;\x1b\\');
+  });
+
+  it('returns plain text when unsupported', () => {
+    _setHyperlinkSupport(false);
+    expect(hyperlink('https://example.com', 'click')).toBe('click');
+  });
+
+  it('disables in Apple_Terminal (leaks markers as text)', () => {
+    process.env['TERM_PROGRAM'] = 'Apple_Terminal';
+    expect(supportsHyperlinks()).toBe(false);
+  });
+
+  it('disables when TERM=dumb', () => {
+    process.env['TERM'] = 'dumb';
+    expect(supportsHyperlinks()).toBe(false);
+  });
+
+  it('disables when NO_HYPERLINKS is set', () => {
+    process.env['NO_HYPERLINKS'] = '1';
+    expect(supportsHyperlinks()).toBe(false);
+  });
+
+  it('disables when FORCE_HYPERLINK=0', () => {
+    process.env['FORCE_HYPERLINK'] = '0';
+    expect(supportsHyperlinks()).toBe(false);
+  });
+
+  it('force-enables with FORCE_HYPERLINK=1 even in Apple_Terminal', () => {
+    process.env['TERM_PROGRAM'] = 'Apple_Terminal';
+    process.env['FORCE_HYPERLINK'] = '1';
+    expect(supportsHyperlinks()).toBe(true);
+  });
+
+  it('defaults to enabled in modern terminals', () => {
+    process.env['TERM'] = 'xterm-256color';
+    expect(supportsHyperlinks()).toBe(true);
+  });
+
+  it('stripAnsi removes OSC 8 wrappers (ST terminator)', () => {
+    const wrapped = hyperlink.bind(null);
+    _setHyperlinkSupport(true);
+    const s = wrapped('https://example.com', 'click');
+    expect(stripAnsi(s)).toBe('click');
+  });
+
+  it('stripAnsi removes OSC sequences with BEL terminator too', () => {
+    const bel = '\x1b]8;;https://example.com\x07text\x1b]8;;\x07';
+    expect(stripAnsi(bel)).toBe('text');
+  });
+});


### PR DESCRIPTION
## Summary
- Directory on line 1 becomes a clickable \`file://\` link; version tag links to the matching Claude Code npm release page.
- New \`src/render/hyperlink.ts\` with opt-in/out via \`NO_HYPERLINKS\` / \`FORCE_HYPERLINK\`; auto-disabled in Apple_Terminal and \`TERM=dumb\`.
- Extended \`stripAnsi\` to match the ST (\`ESC \\\`) terminator so OSC 8 sequences don't leak into \`displayWidth\`.

## Test plan
- [x] 10 new unit tests in \`tests/render/hyperlink.test.ts\` (support detection, env override, stripAnsi ST)
- [x] Full suite green: 392 tests pass
- [x] Typecheck clean
- [ ] Manual: verify clickable link in iTerm2 / WezTerm / VS Code terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)