### PR TITLE
feat(render): powerline renderer for line 1 with 7 style presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Powerline renderer for line 1** — opt-in via `style: "powerline"` (or `--powerline`). Seven separator presets: `arrow`, `flame`, `slant`, `round` (with caps + thin internal sep), `diamond` (per-segment pills), `compatible` (unicode `▶`, no Nerd Font needed), and `plain` (color blocks only). Pick with `powerline.style` in config or `--powerline-style=<name>` on CLI. `auto` picks `arrow` when Nerd Font is available, otherwise `compatible`. Per-theme powerline palettes can be declared on `ThemePalette.powerline`; themes without one get an auto-derived palette (darkened fg hues). Includes **git-dirty bg swap** (branch segment turns red when staged/modified/untracked > 0) and **priority-based eviction** (drops `version` → `task` → `dir` first when the terminal is narrow). Named-ANSI terminals fall back to the classic renderer — powerline needs RGB backgrounds and named-ANSI has only 8 base hues.
 - **OSC 8 hyperlinks** — the directory (line 1) is now a clickable `file://` link that opens the folder in the OS file manager, and the version tag links to the matching Claude Code npm release page. Modern terminals (iTerm2, WezTerm, Kitty, Alacritty, VS Code, tmux ≥3.4 with passthrough) render them as hyperlinks; terminals without support show plain text. Auto-disabled in Apple_Terminal (which leaks escape markers as text) and `TERM=dumb`. Opt out with `NO_HYPERLINKS=1`; force on with `FORCE_HYPERLINK=1`.
 
 ### Fixed

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,6 +50,14 @@ function mergeConfig(rawIn: Record<string, unknown>): HudConfig {
   if (typeof raw.theme === 'string' && raw.theme.length > 0) result.theme = raw.theme;
   const validIcons = ['nerd', 'emoji', 'none'] as const;
   if (validIcons.includes(raw.icons as never)) result.icons = raw.icons as HudConfig['icons'];
+  if (raw.style === 'classic' || raw.style === 'powerline') result.style = raw.style;
+  if (raw.powerline && typeof raw.powerline === 'object') {
+    const plRaw = raw.powerline as Record<string, unknown>;
+    const validPlStyles = ['arrow', 'flame', 'slant', 'round', 'diamond', 'compatible', 'plain', 'auto'] as const;
+    if (validPlStyles.includes(plRaw.style as never)) {
+      result.powerline = { style: plRaw.style as NonNullable<HudConfig['powerline']>['style'] };
+    }
+  }
   return result;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,11 +124,19 @@ export function mergeCliFlags(config: HudConfig, argv: string[]): HudConfig {
   if (argv.includes('--minimal')) applyPreset(r, 'minimal');
   if (argv.includes('--balanced')) applyPreset(r, 'balanced');
   if (argv.includes('--full')) applyPreset(r, 'full');
+  if (argv.includes('--powerline')) r.style = 'powerline';
+  if (argv.includes('--classic'))   r.style = 'classic';
   for (const arg of argv) {
     const presetMatch = arg.match(/^--preset[= ]?(full|balanced|minimal)$/);
     if (presetMatch) { applyPreset(r, presetMatch[1] as NonNullable<HudConfig['preset']>); continue; }
     const iconsMatch = arg.match(/^--icons[= ]?(nerd|emoji|none)$/);
     if (iconsMatch) { r.icons = iconsMatch[1] as HudConfig['icons']; continue; }
+    const plStyleMatch = arg.match(/^--powerline-style[= ](arrow|flame|slant|round|diamond|compatible|plain|auto)$/);
+    if (plStyleMatch) {
+      r.style = 'powerline';
+      r.powerline = { ...(r.powerline ?? {}), style: plStyleMatch[1] as NonNullable<HudConfig['powerline']>['style'] };
+      continue;
+    }
   }
   return r;
 }

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -4,6 +4,7 @@ import { renderLine2 } from './line2.js';
 import { renderLine3 } from './line3.js';
 import { renderLine4 } from './line4.js';
 import { renderMinimal } from './minimal.js';
+import { renderPowerlineLine1 } from './powerline-line1.js';
 import { resolveTheme } from '../themes.js';
 import type { RenderContext } from '../types.js';
 
@@ -17,8 +18,12 @@ export function render(ctx: RenderContext): string {
     return renderMinimal(ctx, c);
   }
 
+  // Powerline mode requires RGB bg escapes; named-ANSI terminals can't
+  // represent arbitrary backgrounds faithfully, so fall back to classic line1.
+  const wantsPowerline = ctx.config.style === 'powerline' && colorMode !== 'named';
+
   const lines: string[] = [];
-  lines.push(renderLine1(ctx, c));
+  lines.push(wantsPowerline ? renderPowerlineLine1(ctx, colorMode, theme) : renderLine1(ctx, c));
   lines.push(renderLine2(ctx, c));
   const l3 = renderLine3(ctx, c);
   if (l3) lines.push(l3);

--- a/src/render/powerline-line1.ts
+++ b/src/render/powerline-line1.ts
@@ -1,0 +1,121 @@
+import { basename } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { getModelName } from './shared.js';
+import { truncField } from './text.js';
+import { hyperlink } from './hyperlink.js';
+import {
+  renderPowerline,
+  resolveStyle,
+  type PowerlineSegment,
+  type PowerlineStyleName,
+} from './powerline.js';
+import type { ColorMode } from './colors.js';
+import type { RenderContext, TranscriptData } from '../types.js';
+import {
+  type PowerlinePalette,
+  derivePowerlinePalette,
+  DEFAULT_POWERLINE_PALETTE,
+  type ThemePalette,
+} from '../themes.js';
+
+function getActiveTodo(transcript: TranscriptData): string | undefined {
+  const inProgress = transcript.todos.filter(t => t.status === 'in_progress');
+  return inProgress[0]?.content;
+}
+
+/**
+ * Build the line1 segment list for the powerline renderer. Segment priorities
+ * control which get dropped first when the terminal is narrow:
+ *   model:   100  (always kept)
+ *   branch:   80
+ *   dir:      60
+ *   task:     40
+ *   version:  20  (dropped first)
+ */
+function buildSegments(ctx: RenderContext, palette: PowerlinePalette): PowerlineSegment[] {
+  const { input, git, transcript, config: { display }, icons } = ctx;
+  const segments: PowerlineSegment[] = [];
+
+  if (display.model) {
+    const modelName = getModelName(input.raw.model);
+    if (modelName) {
+      segments.push({
+        text: modelName,
+        icon: icons.model,
+        bg: palette.modelBg,
+        fg: palette.fg,
+        priority: 100,
+      });
+    }
+  }
+
+  const branchName = input.gitBranch || git.branch;
+  if (display.branch && branchName) {
+    const dirty = git.staged + git.modified + git.untracked > 0;
+    // Signal git state via bg swap — robbed from powerline-go's RepoCleanBg /
+    // RepoDirtyBg distinction. Cleaner than appending status chars post-branch.
+    let label = truncField(branchName, 40);
+    if (display.gitChanges && dirty) {
+      const badges: string[] = [];
+      if (git.staged > 0)    badges.push(`+${git.staged}`);
+      if (git.modified > 0)  badges.push(`!${git.modified}`);
+      if (git.untracked > 0) badges.push(`?${git.untracked}`);
+      if (badges.length) label += ' ' + badges.join(' ');
+    }
+    segments.push({
+      text: label,
+      icon: icons.branch,
+      bg: dirty ? palette.branchDirtyBg : palette.branchCleanBg,
+      fg: palette.fg,
+      priority: 80,
+    });
+  }
+
+  if (display.directory && input.cwd) {
+    const dirName = basename(input.cwd) || input.cwd;
+    segments.push({
+      text: hyperlink(pathToFileURL(input.cwd).href, truncField(dirName, 30)),
+      icon: icons.folder,
+      bg: palette.dirBg,
+      fg: palette.fg,
+      priority: 60,
+    });
+  }
+
+  const activeTask = getActiveTodo(transcript);
+  if (activeTask) {
+    segments.push({
+      text: truncField(activeTask, 30),
+      bg: palette.taskBg,
+      fg: palette.fg,
+      priority: 40,
+    });
+  }
+
+  if (display.version && input.version) {
+    segments.push({
+      text: hyperlink(
+        `https://www.npmjs.com/package/@anthropic-ai/claude-code/v/${encodeURIComponent(input.version)}`,
+        `v${input.version}`,
+      ),
+      bg: palette.versionBg,
+      fg: palette.fg,
+      priority: 20,
+    });
+  }
+
+  return segments;
+}
+
+/** Render line1 in powerline style. Caller must ensure mode != 'named'. */
+export function renderPowerlineLine1(ctx: RenderContext, mode: ColorMode, theme: ThemePalette | null): string {
+  const palette = theme
+    ? (theme.powerline ?? derivePowerlinePalette(theme))
+    : DEFAULT_POWERLINE_PALETTE;
+  const styleName = (ctx.config.powerline?.style ?? 'auto') as PowerlineStyleName;
+  const hasNerdFont = (ctx.config.icons ?? 'nerd') === 'nerd';
+  const style = resolveStyle(styleName, hasNerdFont);
+  const segments = buildSegments(ctx, palette);
+  if (segments.length === 0) return '';
+  return renderPowerline(segments, style, mode, ctx.cols);
+}

--- a/src/render/powerline.ts
+++ b/src/render/powerline.ts
@@ -1,0 +1,174 @@
+import type { ColorMode } from './colors.js';
+import { displayWidth, truncField } from './text.js';
+import { type RGB, rgbTo256Index } from '../themes.js';
+
+// Powerline renderer — segment-based with colored backgrounds and glyph
+// separators that blend adjacent segment colors. See research notes: all
+// common implementations (powerline-go, oh-my-posh, vim-airline) agree on
+// `sep.fg = current.bg, sep.bg = next.bg` to produce the blend effect.
+
+const RESET = '\x1b[0m';
+const RESET_BG = '\x1b[49m';
+
+export interface PowerlineSegment {
+  text: string;
+  icon?: string;
+  bg: RGB;
+  fg?: RGB;
+  /** Lower = dropped first when terminal width is exceeded. */
+  priority: number;
+}
+
+export type PowerlineStyleName =
+  | 'arrow' | 'flame' | 'slant' | 'round' | 'diamond'
+  | 'compatible' | 'plain' | 'auto';
+
+interface Style {
+  leftCap?: string;
+  sep?: string;
+  rightCap?: string;
+  /** True = diamond mode: each segment is isolated with its own caps + a space gap. */
+  gap?: boolean;
+  /** Visual width cost of a separator glyph (Nerd Font glyphs are 1 col). */
+  sepWidth: number;
+}
+
+export const POWERLINE_STYLES: Record<Exclude<PowerlineStyleName, 'auto'>, Style> = {
+  arrow:      { sep: '', sepWidth: 1 },
+  flame:      { sep: '', sepWidth: 1 },
+  slant:      { sep: '', sepWidth: 1 },
+  // Round uses thin `` between same-pill segments and `` at
+  // bg transitions. We always use `` here because each lumira segment
+  // has a distinct bg — the thin variant would only apply if we re-used a bg.
+  round:      { leftCap: '', sep: '', rightCap: '', sepWidth: 1 },
+  diamond:    { leftCap: '', rightCap: '', gap: true, sepWidth: 2 },
+  compatible: { sep: '▶', sepWidth: 1 },
+  plain:      { sep: ' ', sepWidth: 1 },
+};
+
+export function resolveStyle(name: PowerlineStyleName, hasNerdFont: boolean): Style {
+  if (name === 'auto') return hasNerdFont ? POWERLINE_STYLES.arrow : POWERLINE_STYLES.compatible;
+  return POWERLINE_STYLES[name] ?? POWERLINE_STYLES.arrow;
+}
+
+function bgEscape(c: RGB, mode: ColorMode): string {
+  if (mode === 'truecolor') return `\x1b[48;2;${c.r};${c.g};${c.b}m`;
+  if (mode === '256') return `\x1b[48;5;${rgbTo256Index(c.r, c.g, c.b)}m`;
+  // named mode caller shouldn't reach here — powerline falls back to classic
+  return '';
+}
+
+function fgEscape(c: RGB, mode: ColorMode): string {
+  if (mode === 'truecolor') return `\x1b[38;2;${c.r};${c.g};${c.b}m`;
+  if (mode === '256') return `\x1b[38;5;${rgbTo256Index(c.r, c.g, c.b)}m`;
+  return '';
+}
+
+const DEFAULT_FG: RGB = { r: 255, g: 255, b: 255 };
+
+/** Width of a rendered segment's visible text (not including separators/caps). */
+function segTextWidth(seg: PowerlineSegment): number {
+  const body = seg.icon ? `${seg.icon} ${seg.text}` : seg.text;
+  // One leading + one trailing space of padding per segment.
+  return 2 + displayWidth(body);
+}
+
+/** Total visible width the segment list would render to, given a style. */
+export function powerlineWidth(segments: PowerlineSegment[], style: Style): number {
+  if (segments.length === 0) return 0;
+  const bodyW = segments.reduce((sum, s) => sum + segTextWidth(s), 0);
+
+  if (style.gap) {
+    // diamond: leftCap + body + rightCap per segment, space between segments.
+    return segments.length * (style.sepWidth + 0) // caps already included in sepWidth=2
+      + bodyW
+      + (segments.length - 1); // spaces between pills
+  }
+  // continuous: optional leftCap, N-1 seps between, 1 sep at end (or rightCap),
+  // plus body width.
+  let w = bodyW;
+  if (style.leftCap) w += 1;
+  w += (segments.length - 1) * style.sepWidth;
+  // Terminator glyph — either the style's sep char or the rightCap.
+  w += 1;
+  return w;
+}
+
+/**
+ * Drop lowest-priority segments until the projected width fits within `cols`.
+ * Always preserves the highest-priority segment (typically the model name).
+ */
+export function applyPriorityEviction(
+  segments: PowerlineSegment[],
+  style: Style,
+  cols: number,
+): PowerlineSegment[] {
+  if (segments.length === 0) return segments;
+  const safeCols = Math.max(1, cols - 4);
+  let kept = [...segments];
+  while (kept.length > 1 && powerlineWidth(kept, style) > safeCols) {
+    // Find lowest-priority segment and drop it (preserves insertion order of rest).
+    let lowestIdx = 0;
+    let lowest = kept[0].priority;
+    for (let i = 1; i < kept.length; i++) {
+      if (kept[i].priority < lowest) { lowest = kept[i].priority; lowestIdx = i; }
+    }
+    kept.splice(lowestIdx, 1);
+  }
+  // If still over budget with one segment, truncate its text.
+  if (kept.length === 1 && powerlineWidth(kept, style) > safeCols) {
+    const seg = kept[0];
+    const budget = Math.max(1, safeCols - (style.leftCap ? 1 : 0) - 1 - 2 - (seg.icon ? displayWidth(seg.icon) + 1 : 0));
+    kept = [{ ...seg, text: truncField(seg.text, budget) }];
+  }
+  return kept;
+}
+
+export function renderPowerline(
+  segments: PowerlineSegment[],
+  style: Style,
+  mode: ColorMode,
+  cols: number,
+): string {
+  if (segments.length === 0) return '';
+  const fitted = applyPriorityEviction(segments, style, cols);
+  const out: string[] = [];
+
+  const body = (seg: PowerlineSegment) => {
+    const fg = seg.fg ?? DEFAULT_FG;
+    const parts = [bgEscape(seg.bg, mode), fgEscape(fg, mode), ' '];
+    if (seg.icon) { parts.push(seg.icon, ' '); }
+    parts.push(seg.text, ' ');
+    return parts.join('');
+  };
+
+  if (style.gap) {
+    // Diamond: each segment is a self-contained pill.
+    for (let i = 0; i < fitted.length; i++) {
+      const seg = fitted[i];
+      out.push(fgEscape(seg.bg, mode), style.leftCap!);
+      out.push(body(seg));
+      out.push(RESET_BG, fgEscape(seg.bg, mode), style.rightCap!, RESET);
+      if (i < fitted.length - 1) out.push(' ');
+    }
+    return out.join('');
+  }
+
+  // Continuous mode.
+  if (style.leftCap) {
+    out.push(fgEscape(fitted[0].bg, mode), style.leftCap);
+  }
+  for (let i = 0; i < fitted.length; i++) {
+    const seg = fitted[i];
+    out.push(body(seg));
+    if (i < fitted.length - 1) {
+      const next = fitted[i + 1];
+      // sep.fg = current.bg, sep.bg = next.bg — the classic powerline blend.
+      out.push(bgEscape(next.bg, mode), fgEscape(seg.bg, mode), style.sep!);
+    }
+  }
+  // Terminator: transition from last seg's bg back to the default bg.
+  const last = fitted[fitted.length - 1];
+  out.push(RESET_BG, fgEscape(last.bg, mode), style.rightCap ?? style.sep!, RESET);
+  return out.join('');
+}

--- a/src/render/powerline.ts
+++ b/src/render/powerline.ts
@@ -1,5 +1,6 @@
 import type { ColorMode } from './colors.js';
 import { displayWidth, truncField } from './text.js';
+import { stripAnsi } from './colors.js';
 import { type RGB, rgbTo256Index } from '../themes.js';
 
 // Powerline renderer — segment-based with colored backgrounds and glyph
@@ -42,7 +43,10 @@ export const POWERLINE_STYLES: Record<Exclude<PowerlineStyleName, 'auto'>, Style
   // has a distinct bg — the thin variant would only apply if we re-used a bg.
   round:      { leftCap: '', sep: '', rightCap: '', sepWidth: 1 },
   diamond:    { leftCap: '', rightCap: '', gap: true, sepWidth: 2 },
-  compatible: { sep: '▶', sepWidth: 1 },
+  // `▶` (U+25B6) sits in the 0x25A0–0x25FF range which displayWidth treats as
+  // double-width. Must match that assumption or powerlineWidth drifts from
+  // the actual rendered width.
+  compatible: { sep: '▶', sepWidth: 2 },
   plain:      { sep: ' ', sepWidth: 1 },
 };
 
@@ -89,8 +93,10 @@ export function powerlineWidth(segments: PowerlineSegment[], style: Style): numb
   let w = bodyW;
   if (style.leftCap) w += 1;
   w += (segments.length - 1) * style.sepWidth;
-  // Terminator glyph — either the style's sep char or the rightCap.
-  w += 1;
+  // Terminator glyph — rightCap is always 1 col (Nerd Font PUA), while sep
+  // can be wider (e.g. `▶` for compatible). Use sepWidth when the terminator
+  // is a sep, otherwise 1.
+  w += style.rightCap ? 1 : style.sepWidth;
   return w;
 }
 
@@ -107,10 +113,14 @@ export function applyPriorityEviction(
   const safeCols = Math.max(1, cols - 4);
   let kept = [...segments];
   while (kept.length > 1 && powerlineWidth(kept, style) > safeCols) {
-    // Find lowest-priority segment and drop it (preserves insertion order of rest).
-    let lowestIdx = 0;
-    let lowest = kept[0].priority;
-    for (let i = 1; i < kept.length; i++) {
+    // Find lowest-priority segment, scanning right-to-left so ties resolve in
+    // favour of earlier-inserted (higher-importance) segments. With strict `<`
+    // and a left-to-right scan, equal priorities would drop the model first —
+    // violating the exported contract that the highest-priority segment is
+    // preserved.
+    let lowestIdx = kept.length - 1;
+    let lowest = kept[lowestIdx].priority;
+    for (let i = kept.length - 2; i >= 0; i--) {
       if (kept[i].priority < lowest) { lowest = kept[i].priority; lowestIdx = i; }
     }
     kept.splice(lowestIdx, 1);
@@ -118,8 +128,20 @@ export function applyPriorityEviction(
   // If still over budget with one segment, truncate its text.
   if (kept.length === 1 && powerlineWidth(kept, style) > safeCols) {
     const seg = kept[0];
-    const budget = Math.max(1, safeCols - (style.leftCap ? 1 : 0) - 1 - 2 - (seg.icon ? displayWidth(seg.icon) + 1 : 0));
-    kept = [{ ...seg, text: truncField(seg.text, budget) }];
+    // Chrome = fixed cost the style adds around segment content. Must match
+    // `powerlineWidth` for a one-segment case, otherwise the truncated result
+    // can still exceed safeCols by one column (notably for diamond, which has
+    // two caps vs arrow's single terminator).
+    const terminatorW = style.rightCap ? 1 : style.sepWidth;
+    const chrome = style.gap
+      ? 2 /* leftCap + rightCap */ + 2 /* padding */
+      : (style.leftCap ? 1 : 0) + terminatorW + 2 /* padding */;
+    const iconCost = seg.icon ? displayWidth(seg.icon) + 1 : 0;
+    const budget = Math.max(1, safeCols - chrome - iconCost);
+    // Strip ANSI/OSC 8 wrappers before truncating — truncField iterates raw
+    // code points and would otherwise cut mid-escape. Safe on plain strings
+    // too (stripAnsi is a no-op when no escapes are present).
+    kept = [{ ...seg, text: truncField(stripAnsi(seg.text), budget) }];
   }
   return kept;
 }

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -81,8 +81,88 @@ export function downgradePaletteTo256(p: ThemePalette): ThemePalette {
     red: rgbEscapeTo256(p.red),
     brightBlue: rgbEscapeTo256(p.brightBlue),
     gray: rgbEscapeTo256(p.gray),
+    // powerline stores raw RGB triples (projected to 256 at render time by
+    // rgbTo256Index), so pass it through as-is — no escape conversion needed.
+    ...(p.powerline ? { powerline: p.powerline } : {}),
   };
 }
+
+// Hand-curated powerline palettes per theme. Auto-derivation (darken fg by
+// ~55%) produced muddy/indistinguishable bgs for low-saturation themes like
+// Nord and Solarized. These swatches are picked from each theme's official
+// palette — darker enough so white text stays legible, distinct hues so
+// segments are visually separable.
+const WHITE: RGB = { r: 255, g: 255, b: 255 };
+
+const DRACULA_POWERLINE: PowerlinePalette = {
+  modelBg:       { r: 62,  g: 90,  b: 106 },  // dark cyan
+  dirBg:         { r: 68,  g: 71,  b: 90  },  // currentLine #44475a
+  branchCleanBg: { r: 126, g: 61,  b: 124 },  // dark pink
+  branchDirtyBg: { r: 139, g: 50,  b: 50  },  // dark red
+  taskBg:        { r: 138, g: 108, b: 42  },  // dark yellow
+  versionBg:     { r: 58,  g: 61,  b: 74  },
+  fg: WHITE,
+};
+
+const NORD_POWERLINE: PowerlinePalette = {
+  modelBg:       { r: 94,  g: 127, b: 150 },  // frost muted
+  dirBg:         { r: 76,  g: 86,  b: 106 },  // nord3
+  branchCleanBg: { r: 109, g: 90,  b: 130 },  // aurora purple dimmed
+  branchDirtyBg: { r: 142, g: 72,  b: 80  },  // aurora red dimmed
+  taskBg:        { r: 160, g: 101, b: 58  },  // aurora orange dimmed
+  versionBg:     { r: 59,  g: 66,  b: 82  },  // nord1
+  fg: WHITE,
+};
+
+const TOKYO_NIGHT_POWERLINE: PowerlinePalette = {
+  modelBg:       { r: 42,  g: 58,  b: 96  },
+  dirBg:         { r: 61,  g: 78,  b: 138 },
+  branchCleanBg: { r: 90,  g: 63,  b: 140 },
+  branchDirtyBg: { r: 166, g: 58,  b: 75  },
+  taskBg:        { r: 138, g: 106, b: 46  },
+  versionBg:     { r: 39,  g: 43,  b: 58  },
+  fg: WHITE,
+};
+
+const CATPPUCCIN_POWERLINE: PowerlinePalette = {
+  modelBg:       { r: 58,  g: 98,  b: 116 },  // dark teal
+  dirBg:         { r: 74,  g: 90,  b: 154 },  // dark blue
+  branchCleanBg: { r: 122, g: 90,  b: 168 },  // dark mauve
+  branchDirtyBg: { r: 160, g: 72,  b: 86  },  // dark red
+  taskBg:        { r: 160, g: 102, b: 58  },  // dark peach
+  versionBg:     { r: 49,  g: 50,  b: 68  },  // surface0
+  fg: WHITE,
+};
+
+const MONOKAI_POWERLINE: PowerlinePalette = {
+  modelBg:       { r: 42,  g: 93,  b: 110 },  // dark cyan
+  dirBg:         { r: 73,  g: 72,  b: 62  },  // bg variant
+  branchCleanBg: { r: 140, g: 30,  b: 73  },  // dark pink
+  branchDirtyBg: { r: 166, g: 56,  b: 37  },  // dark orange-red
+  taskBg:        { r: 133, g: 107, b: 42  },  // dark yellow
+  versionBg:     { r: 39,  g: 40,  b: 34  },  // bg
+  fg: WHITE,
+};
+
+const GRUVBOX_POWERLINE: PowerlinePalette = {
+  modelBg:       { r: 60,  g: 91,  b: 95  },  // dark aqua
+  dirBg:         { r: 80,  g: 73,  b: 69  },  // bg2
+  branchCleanBg: { r: 131, g: 61,  b: 106 },  // dark purple
+  branchDirtyBg: { r: 157, g: 43,  b: 34  },  // dark red
+  taskBg:        { r: 160, g: 104, b: 21  },  // dark yellow
+  versionBg:     { r: 60,  g: 56,  b: 54  },  // bg1
+  fg: WHITE,
+};
+
+const SOLARIZED_POWERLINE: PowerlinePalette = {
+  modelBg:       { r: 31,  g: 109, b: 103 },  // dark cyan
+  dirBg:         { r: 30,  g: 88,  b: 126 },  // dark blue
+  branchCleanBg: { r: 141, g: 40,  b: 87  },  // dark magenta
+  branchDirtyBg: { r: 168, g: 32,  b: 31  },  // dark red
+  taskBg:        { r: 138, g: 79,  b: 17  },  // dark orange
+  versionBg:     { r: 7,   g: 54,  b: 66  },  // base02
+  fg: WHITE,
+};
 
 export const THEMES: Record<string, ThemePalette> = {
   dracula: {
@@ -94,6 +174,7 @@ export const THEMES: Record<string, ThemePalette> = {
     red: rgb(255, 85, 85),
     brightBlue: rgb(189, 147, 249),
     gray: rgb(98, 114, 164),
+    powerline: DRACULA_POWERLINE,
   },
   nord: {
     cyan: rgb(136, 192, 208),
@@ -104,6 +185,7 @@ export const THEMES: Record<string, ThemePalette> = {
     red: rgb(191, 97, 106),
     brightBlue: rgb(129, 161, 193),
     gray: rgb(76, 86, 106),
+    powerline: NORD_POWERLINE,
   },
   'tokyo-night': {
     cyan: rgb(125, 207, 255),
@@ -114,6 +196,7 @@ export const THEMES: Record<string, ThemePalette> = {
     red: rgb(247, 118, 142),
     brightBlue: rgb(122, 162, 247),
     gray: rgb(86, 95, 137),
+    powerline: TOKYO_NIGHT_POWERLINE,
   },
   catppuccin: {
     cyan: rgb(137, 220, 235),
@@ -124,6 +207,7 @@ export const THEMES: Record<string, ThemePalette> = {
     red: rgb(243, 139, 168),
     brightBlue: rgb(137, 180, 250),
     gray: rgb(108, 112, 134),
+    powerline: CATPPUCCIN_POWERLINE,
   },
   monokai: {
     cyan: rgb(102, 217, 239),
@@ -134,6 +218,7 @@ export const THEMES: Record<string, ThemePalette> = {
     red: rgb(249, 38, 114),
     brightBlue: rgb(102, 217, 239),
     gray: rgb(117, 113, 94),
+    powerline: MONOKAI_POWERLINE,
   },
   gruvbox: {
     cyan: rgb(131, 165, 152),
@@ -144,6 +229,7 @@ export const THEMES: Record<string, ThemePalette> = {
     red: rgb(204, 36, 29),
     brightBlue: rgb(69, 133, 136),
     gray: rgb(146, 131, 116),
+    powerline: GRUVBOX_POWERLINE,
   },
   solarized: {
     cyan: rgb(42, 161, 152),
@@ -154,6 +240,7 @@ export const THEMES: Record<string, ThemePalette> = {
     red: rgb(220, 50, 47),
     brightBlue: rgb(38, 139, 210),
     gray: rgb(101, 123, 131),
+    powerline: SOLARIZED_POWERLINE,
   },
 };
 

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -16,19 +16,36 @@ export interface ThemePalette {
   red: string;
   brightBlue: string;
   gray: string;
+  /** Optional per-theme powerline palette; derived from fg colors when absent. */
+  powerline?: PowerlinePalette;
 }
 
-interface RGB { r: number; g: number; b: number; }
+export interface PowerlinePalette {
+  modelBg: RGB;
+  dirBg: RGB;
+  branchCleanBg: RGB;
+  branchDirtyBg: RGB;
+  taskBg: RGB;
+  versionBg: RGB;
+  fg: RGB;
+}
+
+export interface RGB { r: number; g: number; b: number; }
 
 function rgb(r: number, g: number, b: number): string {
   return `\x1b[38;2;${r};${g};${b}m`;
 }
 
-/** Parse a truecolor escape `\x1b[38;2;R;G;Bm` back into RGB components. */
-function parseRgb(escape: string): RGB | null {
-  const m = escape.match(/^\x1b\[38;2;(\d+);(\d+);(\d+)m$/);
+/** Parse a truecolor fg or bg escape (`\x1b[38;2;…m` / `\x1b[48;2;…m`) back into RGB. */
+export function parseRgb(escape: string): RGB | null {
+  const m = escape.match(/^\x1b\[[34]8;2;(\d+);(\d+);(\d+)m$/);
   if (!m) return null;
   return { r: parseInt(m[1], 10), g: parseInt(m[2], 10), b: parseInt(m[3], 10) };
+}
+
+/** Convert RGB to the nearest xterm 256-color index (cube 16..231 + grayscale 232..255). */
+export function rgbTo256Index(r: number, g: number, b: number): number {
+  return rgbTo256(r, g, b);
 }
 
 /**
@@ -143,6 +160,47 @@ export const THEMES: Record<string, ThemePalette> = {
 export function getThemeNames(): string[] {
   return Object.keys(THEMES);
 }
+
+/** Darken an RGB triple toward black by `factor` in [0,1]. */
+function darken(c: RGB, factor: number): RGB {
+  return {
+    r: Math.round(c.r * (1 - factor)),
+    g: Math.round(c.g * (1 - factor)),
+    b: Math.round(c.b * (1 - factor)),
+  };
+}
+
+/**
+ * Build a PowerlinePalette for a theme that doesn't define one explicitly.
+ * We darken the existing fg hues (by ~55%) so the palette reads as "background
+ * tones of the theme" rather than blown-out fg colors that would clash with
+ * white text. The branchDirtyBg uses `red` regardless of theme for signal.
+ */
+export function derivePowerlinePalette(theme: ThemePalette): PowerlinePalette {
+  const get = (escape: string, fallback: RGB): RGB => parseRgb(escape) ?? fallback;
+  const f = 0.55; // darkening factor — tuned so white fg stays legible
+  const fb = { r: 80, g: 80, b: 80 };
+  return {
+    modelBg:        darken(get(theme.cyan, fb), f),
+    dirBg:          darken(get(theme.brightBlue, fb), f),
+    branchCleanBg:  darken(get(theme.magenta, fb), f),
+    branchDirtyBg:  darken(get(theme.red, fb), f),
+    taskBg:         darken(get(theme.yellow, fb), f),
+    versionBg:      darken(get(theme.gray, fb), f),
+    fg:             { r: 255, g: 255, b: 255 },
+  };
+}
+
+/** Fallback powerline palette when no theme is selected (named-ANSI terminals use classic). */
+export const DEFAULT_POWERLINE_PALETTE: PowerlinePalette = {
+  modelBg:       { r: 32,  g: 96,  b: 128 },
+  dirBg:         { r: 48,  g: 72,  b: 128 },
+  branchCleanBg: { r: 96,  g: 48,  b: 112 },
+  branchDirtyBg: { r: 160, g: 40,  b: 40  },
+  taskBg:        { r: 128, g: 96,  b: 24  },
+  versionBg:     { r: 64,  g: 64,  b: 72  },
+  fg:            { r: 255, g: 255, b: 255 },
+};
 
 export function resolveTheme(name: string | undefined, mode: ColorMode): ThemePalette | null {
   if (!name) return null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,6 +161,12 @@ export interface HudConfig {
   preset?: 'full' | 'balanced' | 'minimal';
   theme?: string;
   icons?: 'nerd' | 'emoji' | 'none';
+  /** Visual style for line1 — 'classic' (pipe-separated) or 'powerline' (colored segments). */
+  style?: 'classic' | 'powerline';
+  powerline?: {
+    /** Separator glyph preset. Defaults to 'auto' (nerd font → arrow, else compatible). */
+    style?: 'arrow' | 'flame' | 'slant' | 'round' | 'diamond' | 'compatible' | 'plain' | 'auto';
+  };
 }
 
 export interface DisplayToggles {

--- a/tests/render/powerline.test.ts
+++ b/tests/render/powerline.test.ts
@@ -124,6 +124,16 @@ describe('powerline', () => {
       const rendered = renderPowerline(segments, POWERLINE_STYLES.arrow, 'truecolor', 120);
       expect(powerlineWidth(segments, POWERLINE_STYLES.arrow)).toBe(displayWidth(rendered));
     });
+
+    it('width matches rendered output for all 7 styles', () => {
+      const segments = [seg('hello', RED, 100), seg('world', GREEN, 90)];
+      for (const name of ['arrow', 'flame', 'slant', 'round', 'diamond', 'compatible', 'plain'] as const) {
+        const style = POWERLINE_STYLES[name];
+        const rendered = renderPowerline(segments, style, 'truecolor', 120);
+        expect(powerlineWidth(segments, style), `width mismatch for ${name}`)
+          .toBe(displayWidth(rendered));
+      }
+    });
   });
 
   describe('applyPriorityEviction', () => {
@@ -153,6 +163,38 @@ describe('powerline', () => {
       const original = segments[0].text.length;
       const kept = applyPriorityEviction(segments, POWERLINE_STYLES.arrow, 15);
       expect(kept[0].text.length).toBeLessThan(original);
+      expect(kept[0].text).toContain('…');
+    });
+
+    it('preserves the first segment when priorities tie', () => {
+      // Previously strict `<` + left-to-right scan would drop the model on ties.
+      const segments = [
+        seg('keep-me', RED, 50),
+        seg('drop',    GREEN, 50),
+      ];
+      const kept = applyPriorityEviction(segments, POWERLINE_STYLES.arrow, 20);
+      expect(kept.map(s => s.text)).toContain('keep-me');
+    });
+
+    it('truncation budget respects diamond style geometry', () => {
+      // Diamond uses leftCap+rightCap (2 cols) + padding (2) + content,
+      // vs arrow's leftCap(0) + terminator(1) + padding(2) + content.
+      // Budget calc must differ by 1 to stay within safeCols.
+      const long = 'a'.repeat(50);
+      const segments = [seg(long, RED, 100)];
+      const kept = applyPriorityEviction(segments, POWERLINE_STYLES.diamond, 20);
+      const rendered = renderPowerline(kept, POWERLINE_STYLES.diamond, 'truecolor', 20);
+      const safeCols = 20 - 4;
+      expect(displayWidth(rendered)).toBeLessThanOrEqual(safeCols);
+    });
+
+    it('truncates hyperlink-wrapped text without leaking raw escape bytes', () => {
+      const osc = '\x1b]8;;https://example.com\x1b\\clickable-label-text\x1b]8;;\x1b\\';
+      const segments = [{ text: osc, bg: RED, fg: WHITE, priority: 100 } as PowerlineSegment];
+      const kept = applyPriorityEviction(segments, POWERLINE_STYLES.arrow, 15);
+      // stripAnsi must run before truncField so the result is plain text + ellipsis,
+      // not a cut-in-half OSC 8 sequence.
+      expect(kept[0].text).not.toContain('\x1b');
       expect(kept[0].text).toContain('…');
     });
   });

--- a/tests/render/powerline.test.ts
+++ b/tests/render/powerline.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderPowerline,
+  resolveStyle,
+  powerlineWidth,
+  applyPriorityEviction,
+  POWERLINE_STYLES,
+  type PowerlineSegment,
+} from '../../src/render/powerline.js';
+import { stripAnsi } from '../../src/render/colors.js';
+import { displayWidth } from '../../src/render/text.js';
+import type { RGB } from '../../src/themes.js';
+
+const RED: RGB = { r: 255, g: 0, b: 0 };
+const GREEN: RGB = { r: 0, g: 255, b: 0 };
+const BLUE: RGB = { r: 0, g: 0, b: 255 };
+const WHITE: RGB = { r: 255, g: 255, b: 255 };
+
+function seg(text: string, bg: RGB, priority = 50, icon?: string): PowerlineSegment {
+  return { text, bg, fg: WHITE, priority, icon };
+}
+
+describe('powerline', () => {
+  describe('resolveStyle', () => {
+    it('auto picks arrow when Nerd Font available', () => {
+      expect(resolveStyle('auto', true).sep).toBe(POWERLINE_STYLES.arrow.sep);
+    });
+
+    it('auto picks compatible when Nerd Font unavailable', () => {
+      expect(resolveStyle('auto', false).sep).toBe('▶');
+    });
+
+    it('returns exact style by name', () => {
+      expect(resolveStyle('flame', true).sep).toBe(POWERLINE_STYLES.flame.sep);
+      expect(resolveStyle('diamond', true).gap).toBe(true);
+      expect(resolveStyle('plain', true).sep).toBe(' ');
+    });
+  });
+
+  describe('renderPowerline', () => {
+    it('emits arrow separator between segments in truecolor mode', () => {
+      const out = renderPowerline(
+        [seg('A', RED, 100), seg('B', GREEN, 90)],
+        POWERLINE_STYLES.arrow,
+        'truecolor',
+        120,
+      );
+      expect(out).toContain(POWERLINE_STYLES.arrow.sep!);
+      expect(out).toContain('\x1b[48;2;255;0;0m');  // bg A
+      expect(out).toContain('\x1b[48;2;0;255;0m');  // bg B
+      const clean = stripAnsi(out);
+      expect(clean).toContain('A');
+      expect(clean).toContain('B');
+      // Sep appears twice: once between A/B, once as terminator.
+      const sepCount = clean.split(POWERLINE_STYLES.arrow.sep!).length - 1;
+      expect(sepCount).toBe(2);
+    });
+
+    it('projects to 256-color escapes when mode=256', () => {
+      const out = renderPowerline([seg('A', RED, 100)], POWERLINE_STYLES.arrow, '256', 120);
+      expect(out).toMatch(/\x1b\[48;5;\d+m/);
+      expect(out).not.toContain('\x1b[48;2;');
+    });
+
+    it('diamond mode wraps each segment with caps', () => {
+      const out = renderPowerline(
+        [seg('A', RED, 100), seg('B', GREEN, 90)],
+        POWERLINE_STYLES.diamond,
+        'truecolor',
+        120,
+      );
+      const clean = stripAnsi(out);
+      expect(clean).toContain(POWERLINE_STYLES.diamond.leftCap!);
+      expect(clean).toContain(POWERLINE_STYLES.diamond.rightCap!);
+    });
+
+    it('round mode wraps whole line with outer caps', () => {
+      const out = renderPowerline(
+        [seg('A', RED, 100), seg('B', GREEN, 90)],
+        POWERLINE_STYLES.round,
+        'truecolor',
+        120,
+      );
+      const clean = stripAnsi(out);
+      expect(clean.startsWith(POWERLINE_STYLES.round.leftCap!)).toBe(true);
+      expect(clean.endsWith(POWERLINE_STYLES.round.rightCap!)).toBe(true);
+    });
+
+    it('separator fg = current.bg, bg = next.bg (the blend trick)', () => {
+      // With two distinct bg colors, the separator between them should emit
+      // fg(current.bg) + bg(next.bg) right before the sep glyph.
+      const out = renderPowerline(
+        [seg('A', RED, 100), seg('B', GREEN, 90)],
+        POWERLINE_STYLES.arrow,
+        'truecolor',
+        120,
+      );
+      const sepIdx = out.indexOf(POWERLINE_STYLES.arrow.sep!);
+      const beforeSep = out.slice(0, sepIdx);
+      // The final fg/bg escapes before the sep glyph must set fg=red, bg=green.
+      expect(beforeSep).toMatch(/\x1b\[48;2;0;255;0m\x1b\[38;2;255;0;0m$/);
+    });
+
+    it('returns empty string on empty input', () => {
+      expect(renderPowerline([], POWERLINE_STYLES.arrow, 'truecolor', 120)).toBe('');
+    });
+
+    it('terminates with reset so subsequent output is not painted', () => {
+      const out = renderPowerline([seg('A', RED, 100)], POWERLINE_STYLES.arrow, 'truecolor', 120);
+      expect(out.endsWith('\x1b[0m')).toBe(true);
+    });
+  });
+
+  describe('powerlineWidth', () => {
+    it('accounts for segment padding, separator, and terminator', () => {
+      // Single segment: ' A ' (3) + sep (1) = 4
+      expect(powerlineWidth([seg('A', RED)], POWERLINE_STYLES.arrow)).toBe(4);
+      // Two segments: ' A ' + sep + ' B ' + terminator-sep = 3+1+3+1 = 8
+      expect(powerlineWidth([seg('A', RED), seg('B', GREEN)], POWERLINE_STYLES.arrow)).toBe(8);
+    });
+
+    it('matches the actual rendered display width for arrow', () => {
+      const segments = [seg('hello', RED, 100), seg('world', GREEN, 90)];
+      const rendered = renderPowerline(segments, POWERLINE_STYLES.arrow, 'truecolor', 120);
+      expect(powerlineWidth(segments, POWERLINE_STYLES.arrow)).toBe(displayWidth(rendered));
+    });
+  });
+
+  describe('applyPriorityEviction', () => {
+    it('drops lowest-priority segment first when over budget', () => {
+      const segments = [
+        seg('model', RED, 100),
+        seg('branch', GREEN, 80),
+        seg('dir', BLUE, 60),
+        seg('version', WHITE, 20),
+      ];
+      // Force a tight budget that can only fit two segments.
+      const kept = applyPriorityEviction(segments, POWERLINE_STYLES.arrow, 20);
+      expect(kept.map(s => s.text)).toContain('model');
+      expect(kept.map(s => s.text)).not.toContain('version'); // priority 20 drops first
+    });
+
+    it('always preserves the highest-priority segment', () => {
+      const segments = [seg('keep-me', RED, 100), seg('drop', GREEN, 10)];
+      // Budget too tight for both but large enough to hold "keep-me" untruncated.
+      const kept = applyPriorityEviction(segments, POWERLINE_STYLES.arrow, 20);
+      expect(kept).toHaveLength(1);
+      expect(kept[0].text).toBe('keep-me');
+    });
+
+    it('truncates single remaining segment if still over budget', () => {
+      const segments = [seg('a-very-long-model-name-indeed', RED, 100)];
+      const original = segments[0].text.length;
+      const kept = applyPriorityEviction(segments, POWERLINE_STYLES.arrow, 15);
+      expect(kept[0].text.length).toBeLessThan(original);
+      expect(kept[0].text).toContain('…');
+    });
+  });
+
+  describe('stripAnsi handles powerline output', () => {
+    it('strips all bg and fg escapes from rendered powerline', () => {
+      const out = renderPowerline(
+        [seg('A', RED, 100), seg('B', GREEN, 90)],
+        POWERLINE_STYLES.arrow,
+        'truecolor',
+        120,
+      );
+      const clean = stripAnsi(out);
+      expect(clean).not.toContain('\x1b');
+      expect(clean).toContain('A');
+      expect(clean).toContain('B');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New opt-in powerline renderer for line 1 with **7 separator presets**: arrow, flame, slant, round, diamond, compatible, plain.
- Activation: \`style: \"powerline\"\` in config, \`--powerline\` flag, or \`--powerline-style=<name>\`. \`auto\` picks \`arrow\` (Nerd Font) or \`compatible\` (unicode ▶).
- **Git-dirty bg swap** — branch segment turns red when staged/modified/untracked > 0.
- **Priority-based eviction** — drops \`version\` → \`task\` → \`dir\` first when terminal is narrow; always keeps model.
- Themes can declare \`powerline\` palette explicitly; themes without one get an auto-derived palette (fg hues darkened ~55%).
- Named-ANSI terminals fall back to classic renderer (only 8 base hues can't represent arbitrary RGB bgs).

## Test plan
- [x] 14 new unit tests in \`tests/render/powerline.test.ts\` (styles, separator blend formula, 256-color projection, width calc, priority eviction, text truncation)
- [x] All 408 tests green, typecheck clean, build clean
- [x] Manual: all 7 styles render correctly in truecolor terminal

## Screenshots
Run against this repo with \`--powerline --powerline-style=<name>\` to see each preset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)