### PR TITLE
perf(transcript): incremental parsing with byte-offset cache

### DIFF
--- a/src/parsers/transcript.ts
+++ b/src/parsers/transcript.ts
@@ -1,4 +1,4 @@
-import { createReadStream, existsSync } from 'node:fs';
+import { createReadStream, existsSync, openSync, readSync, closeSync } from 'node:fs';
 import { createInterface } from 'node:readline';
 import { resolve } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
@@ -10,7 +10,20 @@ import { debug } from '../utils/debug.js';
 
 const log = debug('transcript');
 
-const transcriptCache = new Map<string, { result: TranscriptData; mtime: MtimeState }>();
+interface TranscriptCacheEntry {
+  result: TranscriptData;
+  mtime: MtimeState;
+  // Incremental parsing state — allows resuming from last byte on next tick.
+  byteOffset: number;
+  partialLine: string;
+  toolMap: Map<string, ToolEntry>;
+  agentMap: Map<string, AgentEntry>;
+  todos: TodoEntry[];
+  taskIdToIndex: Map<string, number>;
+  thinkingEffort: ThinkingEffort;
+}
+
+const transcriptCache = new Map<string, TranscriptCacheEntry>();
 
 const MAX_LINES = 50_000;
 
@@ -40,6 +53,105 @@ export function extractToolTarget(toolName: string, input: Record<string, unknow
   return typeof raw === 'string' ? sanitizeTermString(raw) : raw;
 }
 
+/** Process a single parsed JSONL entry into the mutable state maps. */
+function applyEntry(
+  entry: Record<string, unknown>,
+  line: string,
+  result: TranscriptData,
+  toolMap: Map<string, ToolEntry>,
+  agentMap: Map<string, AgentEntry>,
+  todos: TodoEntry[],
+  taskIdToIndex: Map<string, number>,
+  thinkingEffortRef: { value: ThinkingEffort },
+): void {
+  if (!result.sessionStart && entry.timestamp) result.sessionStart = new Date(entry.timestamp as string);
+
+  const effortMatch = line.match(/Set model to .+ with (low|medium|high|max) effort/);
+  if (effortMatch) thinkingEffortRef.value = effortMatch[1] as ThinkingEffort;
+
+  const timestamp = entry.timestamp ? new Date(entry.timestamp as string) : new Date();
+  const content = (entry as { message?: { content?: unknown } }).message?.content;
+  if (!content || !Array.isArray(content)) return;
+
+  for (const block of content) {
+    if (block.type === 'tool_use' && block.id && block.name) {
+      toolMap.set(block.id, { id: block.id, name: sanitizeTermString(block.name), target: extractToolTarget(block.name, block.input), status: 'running', startTime: timestamp });
+
+      if (block.name === 'Task') {
+        const inp = block.input || {};
+        agentMap.set(block.id, {
+          id: block.id,
+          type: sanitizeTermString(inp.subagent_type || 'unknown'),
+          model: typeof inp.model === 'string' ? sanitizeTermString(inp.model) : inp.model,
+          description: typeof inp.description === 'string' ? sanitizeTermString(inp.description) : inp.description,
+          status: 'running',
+          startTime: timestamp,
+        });
+      }
+
+      if (block.name === 'TodoWrite' && block.input?.todos && Array.isArray(block.input.todos)) {
+        const existingById = new Map(todos.map((t: TodoEntry) => [t.id || t.content, t]));
+        todos.splice(0, todos.length, ...block.input.todos.map((t: { id?: string; content?: string; status?: string }) => {
+          const id = t.id || t.content || '';
+          const existing = existingById.get(id);
+          if (existing && (!t.status || t.status === existing.status)) return existing;
+          return { id: t.id || '', content: sanitizeTermString(t.content || ''), status: normalizeTodoStatus(t.status) };
+        }));
+      }
+
+      if (block.name === 'TaskCreate') {
+        const inp = block.input || {};
+        const todoContent = (typeof inp.subject === 'string' ? inp.subject : '') || (typeof inp.description === 'string' ? inp.description : '') || 'Untitled task';
+        todos.push({ id: inp.taskId || block.id, content: sanitizeTermString(todoContent), status: normalizeTodoStatus(inp.status) });
+        if (inp.taskId || block.id) taskIdToIndex.set(String(inp.taskId || block.id), todos.length - 1);
+      }
+
+      if (block.name === 'TaskUpdate') {
+        const inp = block.input || {};
+        let index: number | null = inp.taskId && taskIdToIndex.has(String(inp.taskId)) ? taskIdToIndex.get(String(inp.taskId))! : null;
+        if (index === null && typeof inp.taskId === 'string' && /^\d+$/.test(inp.taskId)) {
+          const n = parseInt(inp.taskId, 10) - 1;
+          if (n >= 0 && n < todos.length) index = n;
+        }
+        if (index !== null && todos[index]) {
+          if (inp.status) todos[index].status = normalizeTodoStatus(inp.status);
+          const subj = typeof inp.subject === 'string' ? inp.subject : '';
+          const desc = typeof inp.description === 'string' ? inp.description : '';
+          if (subj || desc) todos[index].content = sanitizeTermString(subj || desc);
+        }
+      }
+    }
+
+    if (block.type === 'tool_result' && block.tool_use_id) {
+      const tool = toolMap.get(block.tool_use_id);
+      if (tool) { tool.status = block.is_error ? 'error' : 'completed'; tool.endTime = timestamp; }
+      const agent = agentMap.get(block.tool_use_id);
+      if (agent) { agent.status = 'completed'; agent.endTime = timestamp; }
+    }
+  }
+}
+
+/** Read new bytes from `fd` starting at `byteOffset`, returning lines + new offset + leftover partial. */
+function readNewBytes(fd: number, byteOffset: number, partialLine: string): { lines: string[]; newOffset: number; newPartial: string } {
+  const CHUNK = 65536;
+  const buf = Buffer.allocUnsafe(CHUNK);
+  let text = partialLine;
+  let offset = byteOffset;
+
+  let bytesRead: number;
+  do {
+    bytesRead = readSync(fd, buf, 0, CHUNK, offset);
+    if (bytesRead > 0) {
+      text += buf.subarray(0, bytesRead).toString('utf8');
+      offset += bytesRead;
+    }
+  } while (bytesRead === CHUNK);
+
+  const rawLines = text.split('\n');
+  const partial = rawLines.pop() ?? '';
+  return { lines: rawLines, newOffset: offset, newPartial: partial };
+}
+
 export async function parseTranscript(transcriptPath: string): Promise<TranscriptData> {
   const result: TranscriptData = { ...EMPTY_TRANSCRIPT, tools: [], agents: [], todos: [] };
   if (!transcriptPath || !existsSync(transcriptPath)) {
@@ -55,112 +167,79 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
 
   const currentMtime = getMtimeState(transcriptPath);
   const cached = transcriptCache.get(resolved);
+
+  // Full cache hit — mtime + size unchanged.
   if (currentMtime && cached && isMtimeFresh(transcriptPath, cached.mtime)) {
     log('cache hit:', resolved);
     return cached.result;
   }
+
   const parseStart = log.enabled ? Date.now() : 0;
 
-  const toolMap = new Map<string, ToolEntry>();
-  const agentMap = new Map<string, AgentEntry>();
-  let todos: TodoEntry[] = [];
-  const taskIdToIndex = new Map<string, number>();
-  let thinkingEffort: ThinkingEffort = '';
+  // Detect truncation (file shrank) — must full-reparse.
+  const prevOffset = cached?.byteOffset ?? 0;
+  const fileShrunk = currentMtime && prevOffset > currentMtime.size;
 
-  let fileStream: ReturnType<typeof createReadStream> | null = null;
+  const toolMap: Map<string, ToolEntry> = fileShrunk || !cached ? new Map() : new Map(cached.toolMap);
+  const agentMap: Map<string, AgentEntry> = fileShrunk || !cached ? new Map() : new Map(cached.agentMap);
+  const todos: TodoEntry[] = fileShrunk || !cached ? [] : [...cached.todos];
+  const taskIdToIndex: Map<string, number> = fileShrunk || !cached ? new Map() : new Map(cached.taskIdToIndex);
+  const thinkingEffortRef = { value: (fileShrunk || !cached ? '' : cached.thinkingEffort) as ThinkingEffort };
+  const startOffset = fileShrunk || !cached ? 0 : prevOffset;
+  const startPartial = fileShrunk || !cached ? '' : cached.partialLine;
+
+  // Carry over sessionStart from prior parse if available.
+  if (!fileShrunk && cached?.result.sessionStart) result.sessionStart = cached.result.sessionStart;
+
+  let newOffset = startOffset;
+  let newPartial = startPartial;
+  let lineCount = 0;
+
+  let fd: number | null = null;
   try {
-    fileStream = createReadStream(transcriptPath);
-    const rl = createInterface({ input: fileStream, crlfDelay: Infinity });
-    let lineCount = 0;
+    fd = openSync(transcriptPath, 'r');
+    const { lines, newOffset: off, newPartial: partial } = readNewBytes(fd, startOffset, startPartial);
+    newOffset = off;
+    newPartial = partial;
 
-    for await (const line of rl) {
+    for (const line of lines) {
       if (!line.trim()) continue;
       if (++lineCount > MAX_LINES) break;
-
       try {
-        const entry = JSON.parse(line);
-        if (!result.sessionStart && entry.timestamp) result.sessionStart = new Date(entry.timestamp);
-
-        const effortMatch = line.match(/Set model to .+ with (low|medium|high|max) effort/);
-        if (effortMatch) thinkingEffort = effortMatch[1] as ThinkingEffort;
-
-        const timestamp = entry.timestamp ? new Date(entry.timestamp) : new Date();
-        const content = entry.message?.content;
-        if (!content || !Array.isArray(content)) continue;
-
-        for (const block of content) {
-          if (block.type === 'tool_use' && block.id && block.name) {
-            toolMap.set(block.id, { id: block.id, name: sanitizeTermString(block.name), target: extractToolTarget(block.name, block.input), status: 'running', startTime: timestamp });
-
-            if (block.name === 'Task') {
-              const inp = block.input || {};
-              agentMap.set(block.id, {
-                id: block.id,
-                type: sanitizeTermString(inp.subagent_type || 'unknown'),
-                model: typeof inp.model === 'string' ? sanitizeTermString(inp.model) : inp.model,
-                description: typeof inp.description === 'string' ? sanitizeTermString(inp.description) : inp.description,
-                status: 'running',
-                startTime: timestamp,
-              });
-            }
-
-            if (block.name === 'TodoWrite' && block.input?.todos && Array.isArray(block.input.todos)) {
-              const existingById = new Map(todos.map(t => [t.id || t.content, t]));
-              todos = block.input.todos.map((t: { id?: string; content?: string; status?: string }) => {
-                const id = t.id || t.content || '';
-                const existing = existingById.get(id);
-                if (existing && (!t.status || t.status === existing.status)) return existing;
-                return { id: t.id || '', content: sanitizeTermString(t.content || ''), status: normalizeTodoStatus(t.status) };
-              });
-            }
-
-            if (block.name === 'TaskCreate') {
-              const inp = block.input || {};
-              const todoContent = (typeof inp.subject === 'string' ? inp.subject : '') || (typeof inp.description === 'string' ? inp.description : '') || 'Untitled task';
-              todos.push({ id: inp.taskId || block.id, content: sanitizeTermString(todoContent), status: normalizeTodoStatus(inp.status) });
-              if (inp.taskId || block.id) taskIdToIndex.set(String(inp.taskId || block.id), todos.length - 1);
-            }
-
-            if (block.name === 'TaskUpdate') {
-              const inp = block.input || {};
-              let index: number | null = inp.taskId && taskIdToIndex.has(String(inp.taskId)) ? taskIdToIndex.get(String(inp.taskId))! : null;
-              if (index === null && typeof inp.taskId === 'string' && /^\d+$/.test(inp.taskId)) {
-                const n = parseInt(inp.taskId, 10) - 1;
-                if (n >= 0 && n < todos.length) index = n;
-              }
-              if (index !== null && todos[index]) {
-                if (inp.status) todos[index].status = normalizeTodoStatus(inp.status);
-                const subj = typeof inp.subject === 'string' ? inp.subject : '';
-                const desc = typeof inp.description === 'string' ? inp.description : '';
-                if (subj || desc) todos[index].content = sanitizeTermString(subj || desc);
-              }
-            }
-          }
-
-          if (block.type === 'tool_result' && block.tool_use_id) {
-            const tool = toolMap.get(block.tool_use_id);
-            if (tool) { tool.status = block.is_error ? 'error' : 'completed'; tool.endTime = timestamp; }
-            const agent = agentMap.get(block.tool_use_id);
-            if (agent) { agent.status = 'completed'; agent.endTime = timestamp; }
-          }
-        }
+        const entry = JSON.parse(line) as Record<string, unknown>;
+        applyEntry(entry, line, result, toolMap, agentMap, todos, taskIdToIndex, thinkingEffortRef);
       } catch { /* skip malformed */ }
     }
-  } catch { /* partial results */ } finally { fileStream?.destroy(); }
+  } catch { /* partial results */ } finally {
+    if (fd !== null) try { closeSync(fd); } catch {}
+  }
 
   result.tools = Array.from(toolMap.values()).slice(-20);
   result.agents = Array.from(agentMap.values()).slice(-10);
   result.todos = todos;
-  result.thinkingEffort = thinkingEffort;
+  result.thinkingEffort = thinkingEffortRef.value;
+
   if (currentMtime) {
-    transcriptCache.set(resolved, { result, mtime: currentMtime });
+    transcriptCache.set(resolved, {
+      result,
+      mtime: currentMtime,
+      byteOffset: newOffset,
+      partialLine: newPartial,
+      toolMap,
+      agentMap,
+      todos: [...todos],
+      taskIdToIndex,
+      thinkingEffort: thinkingEffortRef.value,
+    });
   }
+
   if (log.enabled) {
     log('parsed', resolved, {
       tools: result.tools.length,
       agents: result.agents.length,
       todos: result.todos.length,
       thinkingEffort: result.thinkingEffort || null,
+      incremental: startOffset > 0 && !fileShrunk,
       durationMs: Date.now() - parseStart,
     });
   }

--- a/tests/parsers/transcript-incremental.test.ts
+++ b/tests/parsers/transcript-incremental.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { writeFileSync, unlinkSync, appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { parseTranscript } from '../../src/parsers/transcript.js';
+
+const TMP = tmpdir();
+
+function tmpFile(name: string): string {
+  return join(TMP, `lumira-test-${name}-${process.pid}.jsonl`);
+}
+
+function toolUseLine(id: string, name: string, filePath: string, ts = '2026-04-08T10:00:00Z'): string {
+  return JSON.stringify({ timestamp: ts, message: { content: [{ type: 'tool_use', id, name, input: { file_path: filePath } }] } });
+}
+
+function toolResultLine(id: string, ts = '2026-04-08T10:00:01Z'): string {
+  return JSON.stringify({ timestamp: ts, message: { content: [{ type: 'tool_result', tool_use_id: id, content: 'ok' }] } });
+}
+
+describe('incremental transcript parsing', () => {
+  const files: string[] = [];
+  afterEach(() => { files.forEach(f => { try { unlinkSync(f); } catch {} }); files.length = 0; });
+
+  it('parses new lines appended since last tick without re-reading from start', async () => {
+    const path = tmpFile('append');
+    files.push(path);
+
+    writeFileSync(path, toolUseLine('t1', 'Read', '/a.ts') + '\n' + toolResultLine('t1') + '\n');
+    const r1 = await parseTranscript(path);
+    expect(r1.tools).toHaveLength(1);
+    expect(r1.tools[0].name).toBe('Read');
+
+    // Append a second tool — incremental parse should pick it up.
+    appendFileSync(path, toolUseLine('t2', 'Edit', '/b.ts', '2026-04-08T10:00:02Z') + '\n');
+    const r2 = await parseTranscript(path);
+    expect(r2.tools).toHaveLength(2);
+    expect(r2.tools[1].name).toBe('Edit');
+  });
+
+  it('resets and full-reparses when file shrinks (truncation)', async () => {
+    const path = tmpFile('shrink');
+    files.push(path);
+
+    writeFileSync(path, toolUseLine('t1', 'Read', '/a.ts') + '\n' + toolResultLine('t1') + '\n');
+    await parseTranscript(path); // prime cache
+
+    // Simulate truncation by overwriting with shorter content.
+    writeFileSync(path, toolUseLine('t2', 'Bash', '/c.ts') + '\n');
+    const r2 = await parseTranscript(path);
+    expect(r2.tools).toHaveLength(1);
+    expect(r2.tools[0].name).toBe('Bash');
+  });
+
+  it('handles partial last line (write cut mid-line) gracefully', async () => {
+    const path = tmpFile('partial');
+    files.push(path);
+
+    const completeLine = toolUseLine('t1', 'Read', '/a.ts') + '\n';
+    const partialLine = '{"timestamp":"2026-04-08T10:00:02Z","message":'; // incomplete JSON
+    writeFileSync(path, completeLine + partialLine);
+
+    const r = await parseTranscript(path);
+    // Should parse the complete line and silently skip the partial one.
+    expect(r.tools).toHaveLength(1);
+    expect(r.tools[0].name).toBe('Read');
+  });
+
+  it('returns cached result when mtime and size are unchanged', async () => {
+    const path = tmpFile('cache');
+    files.push(path);
+
+    writeFileSync(path, toolUseLine('t1', 'Read', '/a.ts') + '\n' + toolResultLine('t1') + '\n');
+    const r1 = await parseTranscript(path);
+    const r2 = await parseTranscript(path);
+    // Same object reference means cache was returned.
+    expect(r2).toBe(r1);
+  });
+});


### PR DESCRIPTION
## Summary
- Extends `TranscriptCacheEntry` with `byteOffset`, `partialLine`, and in-memory state maps (`toolMap`, `agentMap`, `todos`, `taskIdToIndex`)
- On each tick, only reads bytes appended since last parse — O(new lines) instead of O(session length)
- Full reparse on truncation (file shrunk), partial line buffering across ticks
- Switches from `createReadStream` + readline to `openSync`/`readSync` for precise byte-offset control

## Test plan
- [x] 4 new tests in `tests/parsers/transcript-incremental.test.ts`: append, truncation, partial line, cache hit
- [x] All 416 tests green

Closes #43