### PR TITLE
feat(render): extend powerline renderer to line 2 and line 3

### DIFF
--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -5,6 +5,8 @@ import { renderLine3 } from './line3.js';
 import { renderLine4 } from './line4.js';
 import { renderMinimal } from './minimal.js';
 import { renderPowerlineLine1 } from './powerline-line1.js';
+import { renderPowerlineLine2 } from './powerline-line2.js';
+import { renderPowerlineLine3 } from './powerline-line3.js';
 import { resolveTheme } from '../themes.js';
 import type { RenderContext } from '../types.js';
 
@@ -19,13 +21,13 @@ export function render(ctx: RenderContext): string {
   }
 
   // Powerline mode requires RGB bg escapes; named-ANSI terminals can't
-  // represent arbitrary backgrounds faithfully, so fall back to classic line1.
+  // represent arbitrary backgrounds faithfully, so fall back to classic renderers.
   const wantsPowerline = ctx.config.style === 'powerline' && colorMode !== 'named';
 
   const lines: string[] = [];
   lines.push(wantsPowerline ? renderPowerlineLine1(ctx, colorMode, theme) : renderLine1(ctx, c));
-  lines.push(renderLine2(ctx, c));
-  const l3 = renderLine3(ctx, c);
+  lines.push(wantsPowerline ? renderPowerlineLine2(ctx, colorMode, theme, c) : renderLine2(ctx, c));
+  const l3 = wantsPowerline ? renderPowerlineLine3(ctx, colorMode, theme) : renderLine3(ctx, c);
   if (l3) lines.push(l3);
   if (ctx.config.gsd) { const l4 = renderLine4(ctx, c); if (l4) lines.push(l4); }
   return lines.filter(Boolean).join('\n');

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -19,15 +19,21 @@ import {
 //   modelBg    → context bar segment
 //   taskBg     → cost/tokens segment
 //   versionBg  → duration segment
-// The context bar retains its own green→yellow→red gradient inside the segment text.
+//
+// Context bar policy: cells inherit segment bg (proportion reads from cell
+// length, no need for a colored gradient). The percentage value, warning
+// icon (☠/🔥), and `/compact?` hint keep their alarm colors — these are the
+// urgency channels the user actually needs at a glance. Decision rationale
+// recorded against PR #47.
 
 function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors): PowerlineSegment[] {
   const { input, config: { display }, icons } = ctx;
   const segments: PowerlineSegment[] = [];
 
-  // Context bar — always highest priority, retains its own coloring inside the segment.
+  // Context bar — always highest priority. plain=true so the bar cells inherit
+  // the powerline segment bg; only %/icon/hint emit color escapes.
   if (display.contextBar) {
-    const bar = buildContextBar(input.context.usedPercentage, c, { iconSet: icons });
+    const bar = buildContextBar(input.context.usedPercentage, c, { iconSet: icons, plain: true });
     segments.push({ text: bar, bg: palette.modelBg, fg: palette.fg, priority: 100 });
   }
 

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -1,0 +1,74 @@
+import {
+  renderPowerline,
+  resolveStyle,
+  type PowerlineSegment,
+  type PowerlineStyleName,
+} from './powerline.js';
+import { buildContextBar } from './shared.js';
+import { formatTokens, formatCost, formatDuration } from '../utils/format.js';
+import type { ColorMode, Colors } from './colors.js';
+import type { RenderContext } from '../types.js';
+import {
+  type PowerlinePalette,
+  derivePowerlinePalette,
+  DEFAULT_POWERLINE_PALETTE,
+  type ThemePalette,
+} from '../themes.js';
+
+// Line 2 powerline palette — reuses PowerlinePalette bg slots with semantic remapping:
+//   modelBg    → context bar segment
+//   taskBg     → cost/tokens segment
+//   versionBg  → duration segment
+// The context bar retains its own green→yellow→red gradient inside the segment text.
+
+function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors): PowerlineSegment[] {
+  const { input, config: { display }, icons } = ctx;
+  const segments: PowerlineSegment[] = [];
+
+  // Context bar — always highest priority, retains its own coloring inside the segment.
+  if (display.contextBar) {
+    const bar = buildContextBar(input.context.usedPercentage, c, { iconSet: icons });
+    segments.push({ text: bar, bg: palette.modelBg, fg: palette.fg, priority: 100 });
+  }
+
+  // Context tokens
+  if (display.contextTokens && input.tokens.input > 0 && input.context.usedPercentage > 0) {
+    const used = input.tokens.input;
+    const capacity = Math.round(used / (input.context.usedPercentage / 100));
+    segments.push({ text: `${formatTokens(used)}/${formatTokens(capacity)}`, bg: palette.dirBg, fg: palette.fg, priority: 80 });
+  }
+
+  // Cost
+  if (display.cost && input.cost != null) {
+    segments.push({ text: formatCost(input.cost), bg: palette.taskBg, fg: palette.fg, priority: 60 });
+  }
+
+  // Duration
+  if (display.duration && input.durationMs != null) {
+    segments.push({ text: `${icons.clock} ${formatDuration(input.durationMs)}`, bg: palette.branchCleanBg, fg: palette.fg, priority: 40 });
+  }
+
+  // Rate limits — only show if >=50%
+  if (display.rateLimits && input.rateLimits) {
+    const fh = input.rateLimits.fiveHour;
+    if (fh && fh.usedPercentage >= 50) {
+      const bg = fh.usedPercentage >= 80 ? palette.branchDirtyBg : palette.taskBg;
+      segments.push({ text: `${icons.bolt} ${fh.usedPercentage.toFixed(0)}%(5h)`, bg, fg: palette.fg, priority: 20 });
+    }
+  }
+
+  return segments;
+}
+
+/** Render line2 in powerline style. Caller must ensure mode != 'named'. */
+export function renderPowerlineLine2(ctx: RenderContext, mode: ColorMode, theme: ThemePalette | null, c: Colors): string {
+  const palette = theme
+    ? (theme.powerline ?? derivePowerlinePalette(theme))
+    : DEFAULT_POWERLINE_PALETTE;
+  const styleName = (ctx.config.powerline?.style ?? 'auto') as PowerlineStyleName;
+  const hasNerdFont = (ctx.config.icons ?? 'nerd') === 'nerd';
+  const style = resolveStyle(styleName, hasNerdFont);
+  const segments = buildSegments(ctx, palette, c);
+  if (segments.length === 0) return '';
+  return renderPowerline(segments, style, mode, ctx.cols);
+}

--- a/src/render/powerline-line3.ts
+++ b/src/render/powerline-line3.ts
@@ -1,0 +1,75 @@
+import {
+  renderPowerline,
+  resolveStyle,
+  type PowerlineSegment,
+  type PowerlineStyleName,
+} from './powerline.js';
+import { truncField } from './text.js';
+import type { ColorMode } from './colors.js';
+import type { RenderContext, ToolEntry } from '../types.js';
+import {
+  type PowerlinePalette,
+  derivePowerlinePalette,
+  DEFAULT_POWERLINE_PALETTE,
+  type ThemePalette,
+} from '../themes.js';
+
+const EXCLUDED_TOOLS = new Set(['TodoWrite', 'TaskCreate', 'TaskUpdate']);
+
+function buildSegments(ctx: RenderContext, palette: PowerlinePalette): PowerlineSegment[] {
+  const { transcript: { tools, todos }, config: { display }, icons } = ctx;
+  const segments: PowerlineSegment[] = [];
+
+  // Tools segment — running tools take priority, then completed summary.
+  if (display.tools !== false) {
+    const relevant = tools.filter((t: ToolEntry) => !EXCLUDED_TOOLS.has(t.name));
+    const running = relevant.filter(t => t.status === 'running').slice(-2);
+    const completed = relevant.filter(t => t.status === 'completed');
+
+    if (running.length > 0) {
+      const label = running.map(t => {
+        const target = t.target ? `: ${truncField(t.target, 15)}` : '';
+        return `◐ ${t.name}${target}`;
+      }).join(' ');
+      segments.push({ text: label, bg: palette.taskBg, fg: palette.fg, priority: 100 });
+    } else if (completed.length > 0) {
+      // Group by name, show top 3.
+      const groups = new Map<string, number>();
+      for (const t of completed) groups.set(t.name, (groups.get(t.name) ?? 0) + 1);
+      const label = Array.from(groups.entries())
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 3)
+        .map(([name, count]) => `${icons.checkmark} ${name}${count > 1 ? ` ×${count}` : ''}`)
+        .join(' ');
+      if (label) segments.push({ text: label, bg: palette.versionBg, fg: palette.fg, priority: 100 });
+    }
+  }
+
+  // Todos segment — progress bar + counts.
+  if (display.todos !== false && todos.length > 0) {
+    const total = todos.length;
+    const done = todos.filter(t => t.status === 'completed').length;
+    const inProg = todos.filter(t => t.status === 'in_progress').length;
+    const SEGS = 8;
+    const filled = Math.round((done / total) * SEGS);
+    const bar = icons.barFull.repeat(filled) + icons.barEmpty.repeat(SEGS - filled);
+    let label = `${bar} ${done}/${total}`;
+    if (inProg > 0) label += ` ◐ ${inProg}`;
+    segments.push({ text: label, bg: palette.branchCleanBg, fg: palette.fg, priority: 80 });
+  }
+
+  return segments;
+}
+
+/** Render line3 in powerline style. Caller must ensure mode != 'named'. */
+export function renderPowerlineLine3(ctx: RenderContext, mode: ColorMode, theme: ThemePalette | null): string {
+  const palette = theme
+    ? (theme.powerline ?? derivePowerlinePalette(theme))
+    : DEFAULT_POWERLINE_PALETTE;
+  const styleName = (ctx.config.powerline?.style ?? 'auto') as PowerlineStyleName;
+  const hasNerdFont = (ctx.config.icons ?? 'nerd') === 'nerd';
+  const style = resolveStyle(styleName, hasNerdFont);
+  const segments = buildSegments(ctx, palette);
+  if (segments.length === 0) return '';
+  return renderPowerline(segments, style, mode, ctx.cols);
+}

--- a/src/render/shared.ts
+++ b/src/render/shared.ts
@@ -19,17 +19,31 @@ export interface ContextBarOpts {
   iconSet?: IconSet;
   /** When true (default), append an actionable hint like `/compact?` at high fill. */
   showHint?: boolean;
+  /**
+   * When true, the bar cells are emitted without inline color escapes so the
+   * surrounding background (e.g. a powerline segment bg) shows through. The
+   * percentage and warning icon still keep their alarm colors — proportion
+   * reads from cell length, urgency reads from the colored suffix. Set by
+   * the powerline renderer; classic mode leaves it false.
+   */
+  plain?: boolean;
 }
 
 export function buildContextBar(pct: number, c: Colors, opts?: ContextBarOpts): string {
   const segments = opts?.segments ?? 20;
   const showIcons = opts?.showIcons ?? true;
   const showHint = opts?.showHint ?? true;
+  const plain = opts?.plain ?? false;
   const ic = opts?.iconSet ?? NERD_ICONS;
 
   const filled = Math.round((pct / 100) * segments);
   const colorFn = c[getContextColor(pct)];
-  const bar = colorFn(ic.barFull.repeat(filled)) + c.dim(ic.barEmpty.repeat(segments - filled));
+  // In plain mode the bar cells emit no ANSI — terminal default fg over
+  // whatever bg the caller has set. The empty-cell `dim` is also suppressed
+  // because `\x1b[2m...\x1b[0m` would still close out the caller's bg.
+  const bar = plain
+    ? ic.barFull.repeat(filled) + ic.barEmpty.repeat(segments - filled)
+    : colorFn(ic.barFull.repeat(filled)) + c.dim(ic.barEmpty.repeat(segments - filled));
 
   let icon = '';
   if (showIcons) {
@@ -47,7 +61,16 @@ export function buildContextBar(pct: number, c: Colors, opts?: ContextBarOpts): 
 
   const pctStr = colorFn(`${pct < 10 ? pct.toFixed(1) : pct.toFixed(0)}%`);
 
-  return `${bar} ${pctStr}${icon ? ' ' + icon : ''}${hint}`;
+  const out = `${bar} ${pctStr}${icon ? ' ' + icon : ''}${hint}`;
+  if (plain) {
+    // Inside a powerline segment, a literal `\x1b[0m` would clear the
+    // caller-set background and leak the terminal default bg through the
+    // remaining segment text. Replace each full reset with a partial reset
+    // that clears fg + intensity + blink but leaves bg untouched, so the
+    // segment bg flows continuously across the colored % and warning glyph.
+    return out.replace(/\x1b\[0m/g, '\x1b[39;22;25m');
+  }
+  return out;
 }
 
 export function formatGitChanges(git: GitStatus, c: Colors): string[] {

--- a/tests/render/powerline-line2.test.ts
+++ b/tests/render/powerline-line2.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { renderPowerlineLine2 } from '../../src/render/powerline-line2.js';
+import { createColors } from '../../src/render/colors.js';
+import { stripAnsi } from '../../src/render/colors.js';
+import { resolveIcons } from '../../src/render/icons.js';
+import { normalize } from '../../src/normalize.js';
+import { DEFAULT_CONFIG, DEFAULT_DISPLAY, EMPTY_GIT, EMPTY_TRANSCRIPT } from '../../src/types.js';
+import type { RenderContext } from '../../src/types.js';
+
+function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
+  const rawInput = {
+    model: 'Claude Sonnet 4.6',
+    session_id: 'test',
+    context_window: { used_percentage: 42, remaining_percentage: 58, total_input_tokens: 12000, total_output_tokens: 1800 },
+    cost: { total_cost_usd: 0.42, total_duration_ms: 185000 },
+  };
+  return {
+    input: normalize(rawInput),
+    git: { ...EMPTY_GIT },
+    transcript: { ...EMPTY_TRANSCRIPT },
+    tokenSpeed: null,
+    memory: null,
+    gsd: null,
+    mcp: null,
+    cols: 120,
+    config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
+    icons: resolveIcons('nerd'),
+    ...overrides,
+  };
+}
+
+const c = createColors('truecolor', null);
+
+describe('renderPowerlineLine2', () => {
+  it('renders context bar segment in truecolor', () => {
+    const ctx = makeCtx();
+    const out = renderPowerlineLine2(ctx, 'truecolor', null, c);
+    expect(out).toBeTruthy();
+    expect(out).toContain('\x1b[48;2;');
+    expect(out.endsWith('\x1b[0m')).toBe(true);
+  });
+
+  it('renders cost segment when cost is present', () => {
+    const ctx = makeCtx();
+    const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+    expect(out).toContain('$');
+  });
+
+  it('returns empty string when all display toggles are off', () => {
+    const ctx = makeCtx({
+      config: {
+        ...DEFAULT_CONFIG,
+        display: { ...DEFAULT_DISPLAY, contextBar: false, contextTokens: false, cost: false, duration: false, rateLimits: false },
+      },
+    });
+    const out = renderPowerlineLine2(ctx, 'truecolor', null, c);
+    expect(out).toBe('');
+  });
+
+  it('projects to 256-color escapes in 256 mode', () => {
+    const ctx = makeCtx();
+    const out = renderPowerlineLine2(ctx, '256', null, c);
+    expect(out).toMatch(/\x1b\[48;5;\d+m/);
+    expect(out).not.toContain('\x1b[48;2;');
+  });
+});

--- a/tests/render/powerline-line3.test.ts
+++ b/tests/render/powerline-line3.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { renderPowerlineLine3 } from '../../src/render/powerline-line3.js';
+import { stripAnsi } from '../../src/render/colors.js';
+import { resolveIcons } from '../../src/render/icons.js';
+import { normalize } from '../../src/normalize.js';
+import { DEFAULT_CONFIG, DEFAULT_DISPLAY, EMPTY_GIT, EMPTY_TRANSCRIPT } from '../../src/types.js';
+import type { RenderContext } from '../../src/types.js';
+
+function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
+  const rawInput = {
+    model: 'Claude Sonnet 4.6',
+    session_id: 'test',
+    context_window: { used_percentage: 42, remaining_percentage: 58 },
+    cost: { total_cost_usd: 0.42, total_duration_ms: 185000 },
+  };
+  return {
+    input: normalize(rawInput),
+    git: { ...EMPTY_GIT },
+    transcript: { ...EMPTY_TRANSCRIPT },
+    tokenSpeed: null,
+    memory: null,
+    gsd: null,
+    mcp: null,
+    cols: 120,
+    config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
+    icons: resolveIcons('nerd'),
+    ...overrides,
+  };
+}
+
+describe('renderPowerlineLine3', () => {
+  it('returns empty string when no tools or todos', () => {
+    const ctx = makeCtx();
+    expect(renderPowerlineLine3(ctx, 'truecolor', null)).toBe('');
+  });
+
+  it('renders running tool segment', () => {
+    const ctx = makeCtx({
+      transcript: {
+        ...EMPTY_TRANSCRIPT,
+        tools: [{ id: '1', name: 'Read', target: '/src/index.ts', status: 'running', startTime: new Date() }],
+      },
+    });
+    const out = stripAnsi(renderPowerlineLine3(ctx, 'truecolor', null));
+    expect(out).toContain('Read');
+    expect(out).toContain('◐');
+  });
+
+  it('renders todos progress segment', () => {
+    const ctx = makeCtx({
+      transcript: {
+        ...EMPTY_TRANSCRIPT,
+        todos: [
+          { id: '1', content: 'Task A', status: 'completed' },
+          { id: '2', content: 'Task B', status: 'in_progress' },
+          { id: '3', content: 'Task C', status: 'pending' },
+        ],
+      },
+    });
+    const out = stripAnsi(renderPowerlineLine3(ctx, 'truecolor', null));
+    expect(out).toContain('1/3');
+  });
+
+  it('renders both tools and todos segments', () => {
+    const ctx = makeCtx({
+      transcript: {
+        ...EMPTY_TRANSCRIPT,
+        tools: [{ id: '1', name: 'Edit', status: 'completed', startTime: new Date(), endTime: new Date() }],
+        todos: [{ id: '1', content: 'Task', status: 'completed' }],
+      },
+    });
+    const out = renderPowerlineLine3(ctx, 'truecolor', null);
+    expect(out).toBeTruthy();
+    expect(out.endsWith('\x1b[0m')).toBe(true);
+  });
+});

--- a/tests/render/shared.test.ts
+++ b/tests/render/shared.test.ts
@@ -128,6 +128,37 @@ describe('buildContextBar — compact hint', () => {
   });
 });
 
+describe('buildContextBar — plain mode (powerline)', () => {
+  it('emits no inline color codes for the bar cells when plain=true', () => {
+    const out = buildContextBar(50, c, { plain: true, showHint: false, showIcons: false });
+    // First 20 chars (the bar itself) should be raw glyphs, no escape sequences.
+    // Find the first space (separates bar from %); bar substring is everything before.
+    const spaceIdx = out.indexOf(' ');
+    const barSlice = out.slice(0, spaceIdx);
+    expect(barSlice).not.toMatch(/\x1b\[/);
+  });
+
+  it('replaces full resets with bg-preserving partial reset', () => {
+    // The colored % still wraps with the named-ANSI reset (\x1b[0m). In plain
+    // mode that gets rewritten to \x1b[39;22;25m so the caller's bg flows
+    // through. Verify no full \x1b[0m survives.
+    const out = buildContextBar(85, c, { plain: true });
+    expect(out).not.toContain('\x1b[0m');
+    expect(out).toContain('\x1b[39;22;25m');
+  });
+
+  it('keeps the percentage value colored', () => {
+    // 70% triggers `orange` (`\x1b[38;5;208m`); 85% would trigger blinkRed.
+    const out = buildContextBar(70, c, { plain: true });
+    expect(out).toContain('\x1b[38;5;208m');
+  });
+
+  it('classic mode (plain=false) is unchanged — still uses \\x1b[0m', () => {
+    const out = buildContextBar(50, c, { plain: false });
+    expect(out).toContain('\x1b[0m');
+  });
+});
+
 describe('SEP constants', () => {
   it('SEP uses Unicode pipe', () => {
     expect(SEP).toContain('\u2502');


### PR DESCRIPTION
## Summary
- New `src/render/powerline-line2.ts` — context bar, tokens, cost, duration, rate-limits as powerline segments with priority-based eviction
- New `src/render/powerline-line3.ts` — running/completed tools and todos progress as two segments
- `src/render/index.ts` updated to route all 3 lines through powerline renderers when `style: "powerline"` is set
- Named-ANSI terminals fall back to classic renderers (same guard as line 1)

## Test plan
- [x] 4 new tests in `tests/render/powerline-line2.test.ts`
- [x] 4 new tests in `tests/render/powerline-line3.test.ts`
- [x] All 420 tests green

Closes #44