### PR TITLE
fix(powerline): apply post-merge review findings from PR #41

### DIFF
--- a/src/render/powerline-line1.ts
+++ b/src/render/powerline-line1.ts
@@ -53,9 +53,12 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette): Powerline
   if (display.branch && branchName) {
     const dirty = git.staged + git.modified + git.untracked > 0;
     // Signal git state via bg swap — robbed from powerline-go's RepoCleanBg /
-    // RepoDirtyBg distinction. Cleaner than appending status chars post-branch.
+    // RepoDirtyBg distinction. Both badges and the bg swap respect
+    // `display.gitChanges` so toggling it off matches classic renderer
+    // behaviour (no signal of dirty state at all).
+    const showDirty = display.gitChanges && dirty;
     let label = truncField(branchName, 40);
-    if (display.gitChanges && dirty) {
+    if (showDirty) {
       const badges: string[] = [];
       if (git.staged > 0)    badges.push(`+${git.staged}`);
       if (git.modified > 0)  badges.push(`!${git.modified}`);
@@ -65,7 +68,7 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette): Powerline
     segments.push({
       text: label,
       icon: icons.branch,
-      bg: dirty ? palette.branchDirtyBg : palette.branchCleanBg,
+      bg: showDirty ? palette.branchDirtyBg : palette.branchCleanBg,
       fg: palette.fg,
       priority: 80,
     });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -91,6 +91,44 @@ describe('loadConfig', () => {
   it('includes contextTokens in display defaults', () => {
     expect(loadConfig(join(dir, 'nope')).display.contextTokens).toBe(true);
   });
+
+  it('parses style: "powerline"', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"style":"powerline"}');
+    expect(loadConfig(dir).style).toBe('powerline');
+  });
+  it('parses style: "classic"', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"style":"classic"}');
+    expect(loadConfig(dir).style).toBe('classic');
+  });
+  it('ignores invalid style value', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"style":"bogus"}');
+    expect(loadConfig(dir).style).toBeUndefined();
+  });
+  it('parses powerline.style', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"powerline":{"style":"flame"}}');
+    expect(loadConfig(dir).powerline?.style).toBe('flame');
+  });
+  it('ignores invalid powerline.style value', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"powerline":{"style":"bogus"}}');
+    expect(loadConfig(dir).powerline).toBeUndefined();
+  });
+  it('ignores malformed powerline (string instead of object)', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"powerline":"arrow"}');
+    expect(loadConfig(dir).powerline).toBeUndefined();
+  });
+  it('accepts all 8 valid powerline styles', () => {
+    mkdirSync(dir, { recursive: true });
+    for (const s of ['arrow', 'flame', 'slant', 'round', 'diamond', 'compatible', 'plain', 'auto']) {
+      writeFileSync(join(dir, 'config.json'), `{"powerline":{"style":"${s}"}}`);
+      expect(loadConfig(dir).powerline?.style).toBe(s);
+    }
+  });
 });
 
 describe('mergeCliFlags', () => {


### PR DESCRIPTION
## Context
Cleanup PR — applies the two Important findings from the final pre-merge review of PR #41 (powerline line 1) that were submitted *after* #41 was merged into \`develop\` (#41 was merged at \`b6f9097\` on 2026-04-24, this review wave landed today).

## Findings addressed

### 1. \`display.gitChanges = false\` should also gate powerline branch bg swap
Behaviour divergence between classic and powerline renderers: powerline always swapped the branch bg on dirty repos even when \`display.gitChanges = false\`, while classic suppressed all dirty signals under that toggle. The bg swap is the visual primitive in powerline mode, so gating it under the same toggle matches user expectation across both renderers.

**File:** \`src/render/powerline-line1.ts\`

### 2. \`loadConfig\` parsing of \`style\` and \`powerline.style\` had no test coverage
The headline feature for v0.6.0 had zero tests on the config path. Added 7 cases covering valid values, invalid values, malformed input, and all 8 powerline style presets.

**File:** \`tests/config.test.ts\`

## Test plan
- [x] All 419 tests pass (412 → 419, +7 new config tests)
- [x] Typecheck clean
- [x] Lint clean

## Why this is a separate PR
Originally this would have been a follow-up commit on PR #41, but #41 was merged before the final review wave. Splitting these out into a clean PR rather than amending merged history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)