### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Powerline renderer for line 1** — opt-in via `style: "powerline"` (or `--powerline`). Seven separator presets: `arrow`, `flame`, `slant`, `round` (with caps + thin internal sep), `diamond` (per-segment pills), `compatible` (unicode `▶`, no Nerd Font needed), and `plain` (color blocks only). Pick with `powerline.style` in config or `--powerline-style=<name>` on CLI. `auto` picks `arrow` when Nerd Font is available, otherwise `compatible`. Per-theme powerline palettes can be declared on `ThemePalette.powerline`; themes without one get an auto-derived palette (darkened fg hues). Includes **git-dirty bg swap** (branch segment turns red when staged/modified/untracked > 0) and **priority-based eviction** (drops `version` → `task` → `dir` first when the terminal is narrow). Named-ANSI terminals fall back to the classic renderer — powerline needs RGB backgrounds and named-ANSI has only 8 base hues.
 - **OSC 8 hyperlinks** — the directory (line 1) is now a clickable `file://` link that opens the folder in the OS file manager, and the version tag links to the matching Claude Code npm release page. Modern terminals (iTerm2, WezTerm, Kitty, Alacritty, VS Code, tmux ≥3.4 with passthrough) render them as hyperlinks; terminals without support show plain text. Auto-disabled in Apple_Terminal (which leaks escape markers as text) and `TERM=dumb`. Opt out with `NO_HYPERLINKS=1`; force on with `FORCE_HYPERLINK=1`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-30
+
 ### Added
-- **Powerline renderer for line 1** — opt-in via `style: "powerline"` (or `--powerline`). Seven separator presets: `arrow`, `flame`, `slant`, `round` (with caps + thin internal sep), `diamond` (per-segment pills), `compatible` (unicode `▶`, no Nerd Font needed), and `plain` (color blocks only). Pick with `powerline.style` in config or `--powerline-style=<name>` on CLI. `auto` picks `arrow` when Nerd Font is available, otherwise `compatible`. Per-theme powerline palettes can be declared on `ThemePalette.powerline`; themes without one get an auto-derived palette (darkened fg hues). Includes **git-dirty bg swap** (branch segment turns red when staged/modified/untracked > 0) and **priority-based eviction** (drops `version` → `task` → `dir` first when the terminal is narrow). Named-ANSI terminals fall back to the classic renderer — powerline needs RGB backgrounds and named-ANSI has only 8 base hues.
+- **Powerline renderer (line 1, 2, 3)** — opt-in via `style: "powerline"` (or `--powerline`). Seven separator presets: `arrow`, `flame`, `slant`, `round` (with caps + thin internal sep), `diamond` (per-segment pills), `compatible` (unicode `▶`, no Nerd Font needed), and `plain` (color blocks only). Pick with `powerline.style` in config or `--powerline-style=<name>` on CLI. `auto` picks `arrow` when Nerd Font is available, otherwise `compatible`. Hand-curated powerline palettes for all 7 built-in themes (dracula, nord, tokyo-night, catppuccin, monokai, gruvbox, solarized) — distinct hues per segment, all clear WCAG AA contrast for white fg. Themes without an explicit palette fall back to an auto-derived one. Includes **git-dirty bg swap** (branch segment turns red when staged/modified/untracked > 0) and **priority-based eviction** (drops lowest-priority segments first when the terminal is narrow). Named-ANSI terminals fall back to the classic renderer — powerline needs RGB backgrounds and named-ANSI has only 8 base hues.
 - **OSC 8 hyperlinks** — the directory (line 1) is now a clickable `file://` link that opens the folder in the OS file manager, and the version tag links to the matching Claude Code npm release page. Modern terminals (iTerm2, WezTerm, Kitty, Alacritty, VS Code, tmux ≥3.4 with passthrough) render them as hyperlinks; terminals without support show plain text. Auto-disabled in Apple_Terminal (which leaks escape markers as text) and `TERM=dumb`. Opt out with `NO_HYPERLINKS=1`; force on with `FORCE_HYPERLINK=1`.
+- **Config health widget** (opt-in, `display.health: true`) — line 2 surfaces silent fallbacks at a glance: `theme` set in named-ANSI mode (no effect), `style: "powerline"` in named-ANSI (falls back to classic), `gsd: true` with no `.planning/STATE.md` reachable from cwd. Hints sit on the right side next to vim/effort and are dropped silently if they would push line 2 past terminal width.
+- **Context bar `plain` rendering mode** — when the bar is embedded in a powerline segment, cells inherit the segment background (proportion still reads from cell length) while the percentage value, warning icon (☠/🔥), and `/compact?` hint keep their alarm colors. Avoids the visible "holes" that inline `\x1b[0m` resets would leave inside a colored segment.
 
 ### Fixed
 - **`stripAnsi` now handles the ST (`ESC \`) OSC terminator**, not just BEL. Required so OSC 8 sequences don't leak into `displayWidth()` and throw off terminal-width fitting.
+- **Config health GSD walk uses `dirname`**, not `join(dir, '..')` — the prior form never resolved and silently bailed at the iteration cap on deeply-nested projects.
 
 ## [0.5.0] - 2026-04-23
 
@@ -190,7 +195,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GSD session IDs sanitized against path traversal
 - `execFile` used instead of `exec` to prevent shell injection (except terminal width detection where shell redirect is required with procfs-sourced paths)
 
-[Unreleased]: https://github.com/cativo23/lumira/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/cativo23/lumira/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/cativo23/lumira/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/cativo23/lumira/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/cativo23/lumira/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/cativo23/lumira/compare/v0.3.1...v0.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **OSC 8 hyperlinks** — the directory (line 1) is now a clickable `file://` link that opens the folder in the OS file manager, and the version tag links to the matching Claude Code npm release page. Modern terminals (iTerm2, WezTerm, Kitty, Alacritty, VS Code, tmux ≥3.4 with passthrough) render them as hyperlinks; terminals without support show plain text. Auto-disabled in Apple_Terminal (which leaks escape markers as text) and `TERM=dumb`. Opt out with `NO_HYPERLINKS=1`; force on with `FORCE_HYPERLINK=1`.
+
+### Fixed
+- **`stripAnsi` now handles the ST (`ESC \`) OSC terminator**, not just BEL. Required so OSC 8 sequences don't leak into `displayWidth()` and throw off terminal-width fitting.
+
 ## [0.5.0] - 2026-04-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "lumira — real-time statusline for Claude Code",
   "type": "module",
   "main": "dist/index.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,6 +50,14 @@ function mergeConfig(rawIn: Record<string, unknown>): HudConfig {
   if (typeof raw.theme === 'string' && raw.theme.length > 0) result.theme = raw.theme;
   const validIcons = ['nerd', 'emoji', 'none'] as const;
   if (validIcons.includes(raw.icons as never)) result.icons = raw.icons as HudConfig['icons'];
+  if (raw.style === 'classic' || raw.style === 'powerline') result.style = raw.style;
+  if (raw.powerline && typeof raw.powerline === 'object') {
+    const plRaw = raw.powerline as Record<string, unknown>;
+    const validPlStyles = ['arrow', 'flame', 'slant', 'round', 'diamond', 'compatible', 'plain', 'auto'] as const;
+    if (validPlStyles.includes(plRaw.style as never)) {
+      result.powerline = { style: plRaw.style as NonNullable<HudConfig['powerline']>['style'] };
+    }
+  }
   return result;
 }
 
@@ -124,11 +132,19 @@ export function mergeCliFlags(config: HudConfig, argv: string[]): HudConfig {
   if (argv.includes('--minimal')) applyPreset(r, 'minimal');
   if (argv.includes('--balanced')) applyPreset(r, 'balanced');
   if (argv.includes('--full')) applyPreset(r, 'full');
+  if (argv.includes('--powerline')) r.style = 'powerline';
+  if (argv.includes('--classic'))   r.style = 'classic';
   for (const arg of argv) {
     const presetMatch = arg.match(/^--preset[= ]?(full|balanced|minimal)$/);
     if (presetMatch) { applyPreset(r, presetMatch[1] as NonNullable<HudConfig['preset']>); continue; }
     const iconsMatch = arg.match(/^--icons[= ]?(nerd|emoji|none)$/);
     if (iconsMatch) { r.icons = iconsMatch[1] as HudConfig['icons']; continue; }
+    const plStyleMatch = arg.match(/^--powerline-style[= ](arrow|flame|slant|round|diamond|compatible|plain|auto)$/);
+    if (plStyleMatch) {
+      r.style = 'powerline';
+      r.powerline = { ...(r.powerline ?? {}), style: plStyleMatch[1] as NonNullable<HudConfig['powerline']>['style'] };
+      continue;
+    }
   }
   return r;
 }

--- a/src/parsers/config-health.ts
+++ b/src/parsers/config-health.ts
@@ -1,0 +1,40 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { HudConfig } from '../types.js';
+import type { ColorMode } from '../render/colors.js';
+
+export type HealthSeverity = 'warn' | 'info';
+
+export interface HealthHint {
+  severity: HealthSeverity;
+  hint: string;
+}
+
+export function getConfigHealth(config: HudConfig, colorMode: ColorMode, cwd: string): HealthHint[] {
+  const hints: HealthHint[] = [];
+
+  // Theme set but named-ANSI mode can't render RGB colors
+  if (config.theme && colorMode === 'named') {
+    hints.push({ severity: 'warn', hint: 'theme has no effect in named-ANSI mode' });
+  }
+
+  // Powerline requested but named-ANSI can't render RGB backgrounds
+  if (config.style === 'powerline' && colorMode === 'named') {
+    hints.push({ severity: 'warn', hint: 'powerline falling back to classic (named-ANSI)' });
+  }
+
+  // GSD enabled but no STATE.md found walking up from cwd
+  if (config.gsd && cwd) {
+    let found = false;
+    let dir = cwd;
+    for (let i = 0; i < 10; i++) {
+      if (existsSync(join(dir, '.planning', 'STATE.md'))) { found = true; break; }
+      const parent = join(dir, '..');
+      if (parent === dir) break;
+      dir = parent;
+    }
+    if (!found) hints.push({ severity: 'info', hint: 'GSD on but no .planning/STATE.md found' });
+  }
+
+  return hints;
+}

--- a/src/parsers/config-health.ts
+++ b/src/parsers/config-health.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import type { HudConfig } from '../types.js';
 import type { ColorMode } from '../render/colors.js';
 
@@ -23,13 +23,16 @@ export function getConfigHealth(config: HudConfig, colorMode: ColorMode, cwd: st
     hints.push({ severity: 'warn', hint: 'powerline falling back to classic (named-ANSI)' });
   }
 
-  // GSD enabled but no STATE.md found walking up from cwd
+  // GSD enabled but no STATE.md found walking up from cwd.
+  // Use `dirname` (resolves), not `join(dir, '..')` (which appends literal `..`
+  // and never reaches root — so the equality break never fires and the loop
+  // would silently bail at the iteration cap on deeply-nested projects).
   if (config.gsd && cwd) {
     let found = false;
     let dir = cwd;
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 32; i++) {
       if (existsSync(join(dir, '.planning', 'STATE.md'))) { found = true; break; }
-      const parent = join(dir, '..');
+      const parent = dirname(dir);
       if (parent === dir) break;
       dir = parent;
     }

--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -67,7 +67,10 @@ export function createColors(mode: ColorMode, theme?: import('../themes.js').The
 }
 
 export function stripAnsi(str: string): string {
-  return str.replace(/\x1b\[\??[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b[()][AB012]/g, '');
+  // OSC sequences terminate with either BEL (\x07) or ST (\x1b\\). OSC 8
+  // hyperlinks use ST, so both terminators must be matched — otherwise the
+  // URL and the wrapping markers leak into displayWidth() calculations.
+  return str.replace(/\x1b\[\??[0-9;]*[a-zA-Z]|\x1b\][\s\S]*?(?:\x07|\x1b\\)|\x1b[()][AB012]/g, '');
 }
 
 export function detectColorMode(): ColorMode {

--- a/src/render/hyperlink.ts
+++ b/src/render/hyperlink.ts
@@ -1,0 +1,46 @@
+// OSC 8 hyperlink support.
+// Sequence: ESC ] 8 ; ; URL ST TEXT ESC ] 8 ; ; ST  (ST = ESC \)
+// Terminals that don't support it render only TEXT; the wrappers are ignored.
+
+let cached: boolean | null = null;
+
+export function resetHyperlinkSupport(): void {
+  cached = null;
+}
+
+// Exposed for tests; prod code should call supportsHyperlinks().
+export function _setHyperlinkSupport(v: boolean | null): void {
+  cached = v;
+}
+
+export function supportsHyperlinks(): boolean {
+  if (cached !== null) return cached;
+
+  // Explicit opt-out (widely-recognised convention).
+  if (process.env['NO_HYPERLINKS'] || process.env['FORCE_HYPERLINK'] === '0') {
+    return (cached = false);
+  }
+  // Explicit opt-in bypasses all heuristics.
+  if (process.env['FORCE_HYPERLINK'] && process.env['FORCE_HYPERLINK'] !== '0') {
+    return (cached = true);
+  }
+
+  const term = process.env['TERM'] ?? '';
+  if (term === 'dumb') return (cached = false);
+
+  // Apple Terminal ignores OSC 8 but doesn't strip it — link markers leak as text.
+  const termProgram = process.env['TERM_PROGRAM'] ?? '';
+  if (termProgram === 'Apple_Terminal') return (cached = false);
+
+  // Statusline output is piped by Claude Code, so process.stdout.isTTY is false
+  // even in a real terminal. Rather than infer from our own stdout, we trust
+  // the TERM/TERM_PROGRAM hints above and emit by default — modern terminals
+  // (iTerm2, WezTerm, Kitty, Alacritty, VS Code, tmux ≥3.4 with passthrough)
+  // all support OSC 8, and unsupported ones merely render plain text.
+  return (cached = true);
+}
+
+export function hyperlink(url: string, text: string): string {
+  if (!supportsHyperlinks()) return text;
+  return `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`;
+}

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -4,6 +4,7 @@ import { renderLine2 } from './line2.js';
 import { renderLine3 } from './line3.js';
 import { renderLine4 } from './line4.js';
 import { renderMinimal } from './minimal.js';
+import { renderPowerlineLine1 } from './powerline-line1.js';
 import { resolveTheme } from '../themes.js';
 import type { RenderContext } from '../types.js';
 
@@ -17,8 +18,12 @@ export function render(ctx: RenderContext): string {
     return renderMinimal(ctx, c);
   }
 
+  // Powerline mode requires RGB bg escapes; named-ANSI terminals can't
+  // represent arbitrary backgrounds faithfully, so fall back to classic line1.
+  const wantsPowerline = ctx.config.style === 'powerline' && colorMode !== 'named';
+
   const lines: string[] = [];
-  lines.push(renderLine1(ctx, c));
+  lines.push(wantsPowerline ? renderPowerlineLine1(ctx, colorMode, theme) : renderLine1(ctx, c));
   lines.push(renderLine2(ctx, c));
   const l3 = renderLine3(ctx, c);
   if (l3) lines.push(l3);

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -5,6 +5,8 @@ import { renderLine3 } from './line3.js';
 import { renderLine4 } from './line4.js';
 import { renderMinimal } from './minimal.js';
 import { renderPowerlineLine1 } from './powerline-line1.js';
+import { renderPowerlineLine2 } from './powerline-line2.js';
+import { renderPowerlineLine3 } from './powerline-line3.js';
 import { resolveTheme } from '../themes.js';
 import type { RenderContext } from '../types.js';
 
@@ -19,13 +21,13 @@ export function render(ctx: RenderContext): string {
   }
 
   // Powerline mode requires RGB bg escapes; named-ANSI terminals can't
-  // represent arbitrary backgrounds faithfully, so fall back to classic line1.
+  // represent arbitrary backgrounds faithfully, so fall back to classic renderers.
   const wantsPowerline = ctx.config.style === 'powerline' && colorMode !== 'named';
 
   const lines: string[] = [];
   lines.push(wantsPowerline ? renderPowerlineLine1(ctx, colorMode, theme) : renderLine1(ctx, c));
-  lines.push(renderLine2(ctx, c));
-  const l3 = renderLine3(ctx, c);
+  lines.push(wantsPowerline ? renderPowerlineLine2(ctx, colorMode, theme, c) : renderLine2(ctx, c));
+  const l3 = wantsPowerline ? renderPowerlineLine3(ctx, colorMode, theme) : renderLine3(ctx, c);
   if (l3) lines.push(l3);
   if (ctx.config.gsd) { const l4 = renderLine4(ctx, c); if (l4) lines.push(l4); }
   return lines.filter(Boolean).join('\n');

--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -1,6 +1,8 @@
 import { basename } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { fitSegments, truncField } from './text.js';
 import { getModelName, formatGitChanges, SEP } from './shared.js';
+import { hyperlink } from './hyperlink.js';
 import type { Colors } from './colors.js';
 import type { RenderContext, TranscriptData } from '../types.js';
 
@@ -40,7 +42,11 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
     if (cwd) {
       const dirName = basename(cwd) || cwd;
       const dirLen = cols < 80 ? 12 : cols < 120 ? 20 : 30;
-      left.push(c.brightBlue(`${icons.folder} ${truncField(dirName, dirLen)}`));
+      const label = c.brightBlue(`${icons.folder} ${truncField(dirName, dirLen)}`);
+      // Wrap with OSC 8 so terminals that support it turn the directory into a
+      // clickable file:// link. pathToFileURL handles percent-encoding of
+      // spaces and non-ASCII chars correctly.
+      left.push(hyperlink(pathToFileURL(cwd).href, label));
     }
   }
 
@@ -79,9 +85,12 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
     right.push(c.gray(input.outputStyle));
   }
 
-  // Version
+  // Version — link to the Claude Code npm page for quick changelog lookup.
   if (display.version && input.version) {
-    right.push(c.dim(`v${input.version}`));
+    right.push(hyperlink(
+      `https://www.npmjs.com/package/@anthropic-ai/claude-code/v/${encodeURIComponent(input.version)}`,
+      c.dim(`v${input.version}`),
+    ));
   }
 
   if (left.length === 0 && right.length === 0) return '';

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -1,7 +1,8 @@
 import { padLine } from './text.js';
-import { getQuotaColor, type Colors } from './colors.js';
+import { getQuotaColor, detectColorMode, type Colors } from './colors.js';
 import { buildContextBar, formatQwenMetrics, SEP } from './shared.js';
 import { formatTokens, formatDuration, formatCost, formatBurnRate } from '../utils/format.js';
+import { getConfigHealth } from '../parsers/config-health.js';
 import type { RenderContext } from '../types.js';
 
 export function formatCountdown(resetsAt: number): string {
@@ -110,6 +111,15 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
         if (countdown) limitStr += c.dim(` ${countdown}`);
       }
       leftParts.push(limitStr);
+    }
+  }
+
+  // Config health hints (opt-in, default off)
+  if (display.health && input.cwd) {
+    const colorMode = ctx.config.colors.mode === 'auto' ? detectColorMode() : ctx.config.colors.mode;
+    const hints = getConfigHealth(ctx.config, colorMode, input.cwd);
+    for (const h of hints) {
+      leftParts.push(h.severity === 'warn' ? c.yellow(`⚠ ${h.hint}`) : c.dim(`ℹ ${h.hint}`));
     }
   }
 

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -1,4 +1,4 @@
-import { padLine } from './text.js';
+import { padLine, displayWidth } from './text.js';
 import { getQuotaColor, detectColorMode, type Colors } from './colors.js';
 import { buildContextBar, formatQwenMetrics, SEP } from './shared.js';
 import { formatTokens, formatDuration, formatCost, formatBurnRate } from '../utils/format.js';
@@ -114,15 +114,6 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
     }
   }
 
-  // Config health hints (opt-in, default off)
-  if (display.health && input.cwd) {
-    const colorMode = ctx.config.colors.mode === 'auto' ? detectColorMode() : ctx.config.colors.mode;
-    const hints = getConfigHealth(ctx.config, colorMode, input.cwd);
-    for (const h of hints) {
-      leftParts.push(h.severity === 'warn' ? c.yellow(`⚠ ${h.hint}`) : c.dim(`ℹ ${h.hint}`));
-    }
-  }
-
   // Right side: vim mode
   if (display.vim && input.vimMode) {
     rightParts.push(c.dim(`[${input.vimMode}]`));
@@ -131,6 +122,31 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
   // Right side: effort (hidden if medium)
   if (display.effort && thinkingEffort && thinkingEffort !== 'medium') {
     rightParts.push(c.dim(`^${thinkingEffort}`));
+  }
+
+  // Config health hints (opt-in, default off). Sit on the right side as
+  // auxiliary signals next to vim/effort, and are dropped silently when the
+  // projected line width would overflow `cols` — they are advisory, never
+  // critical, so quietly hiding them on narrow terminals is preferable to
+  // wrapping the statusline.
+  if (display.health && input.cwd) {
+    const colorMode = ctx.config.colors.mode === 'auto' ? detectColorMode() : ctx.config.colors.mode;
+    const hints = getConfigHealth(ctx.config, colorMode, input.cwd);
+    if (hints.length > 0) {
+      const candidates = hints.map(h =>
+        h.severity === 'warn' ? c.yellow(`⚠ ${h.hint}`) : c.dim(`ℹ ${h.hint}`),
+      );
+      const leftW = displayWidth(leftParts.join(SEP));
+      const currentRightW = rightParts.length ? displayWidth(rightParts.join(' ')) : 0;
+      // +1 per added hint accounts for the joining space.
+      let projectedW = leftW + (currentRightW > 0 ? 1 : 0) + currentRightW;
+      for (const h of candidates) {
+        const addW = displayWidth(h) + 1;
+        if (projectedW + addW > cols) break;
+        rightParts.push(h);
+        projectedW += addW;
+      }
+    }
   }
 
   const leftStr = leftParts.join(SEP);

--- a/src/render/powerline-line1.ts
+++ b/src/render/powerline-line1.ts
@@ -1,0 +1,121 @@
+import { basename } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { getModelName } from './shared.js';
+import { truncField } from './text.js';
+import { hyperlink } from './hyperlink.js';
+import {
+  renderPowerline,
+  resolveStyle,
+  type PowerlineSegment,
+  type PowerlineStyleName,
+} from './powerline.js';
+import type { ColorMode } from './colors.js';
+import type { RenderContext, TranscriptData } from '../types.js';
+import {
+  type PowerlinePalette,
+  derivePowerlinePalette,
+  DEFAULT_POWERLINE_PALETTE,
+  type ThemePalette,
+} from '../themes.js';
+
+function getActiveTodo(transcript: TranscriptData): string | undefined {
+  const inProgress = transcript.todos.filter(t => t.status === 'in_progress');
+  return inProgress[0]?.content;
+}
+
+/**
+ * Build the line1 segment list for the powerline renderer. Segment priorities
+ * control which get dropped first when the terminal is narrow:
+ *   model:   100  (always kept)
+ *   branch:   80
+ *   dir:      60
+ *   task:     40
+ *   version:  20  (dropped first)
+ */
+function buildSegments(ctx: RenderContext, palette: PowerlinePalette): PowerlineSegment[] {
+  const { input, git, transcript, config: { display }, icons } = ctx;
+  const segments: PowerlineSegment[] = [];
+
+  if (display.model) {
+    const modelName = getModelName(input.raw.model);
+    if (modelName) {
+      segments.push({
+        text: modelName,
+        icon: icons.model,
+        bg: palette.modelBg,
+        fg: palette.fg,
+        priority: 100,
+      });
+    }
+  }
+
+  const branchName = input.gitBranch || git.branch;
+  if (display.branch && branchName) {
+    const dirty = git.staged + git.modified + git.untracked > 0;
+    // Signal git state via bg swap — robbed from powerline-go's RepoCleanBg /
+    // RepoDirtyBg distinction. Cleaner than appending status chars post-branch.
+    let label = truncField(branchName, 40);
+    if (display.gitChanges && dirty) {
+      const badges: string[] = [];
+      if (git.staged > 0)    badges.push(`+${git.staged}`);
+      if (git.modified > 0)  badges.push(`!${git.modified}`);
+      if (git.untracked > 0) badges.push(`?${git.untracked}`);
+      if (badges.length) label += ' ' + badges.join(' ');
+    }
+    segments.push({
+      text: label,
+      icon: icons.branch,
+      bg: dirty ? palette.branchDirtyBg : palette.branchCleanBg,
+      fg: palette.fg,
+      priority: 80,
+    });
+  }
+
+  if (display.directory && input.cwd) {
+    const dirName = basename(input.cwd) || input.cwd;
+    segments.push({
+      text: hyperlink(pathToFileURL(input.cwd).href, truncField(dirName, 30)),
+      icon: icons.folder,
+      bg: palette.dirBg,
+      fg: palette.fg,
+      priority: 60,
+    });
+  }
+
+  const activeTask = getActiveTodo(transcript);
+  if (activeTask) {
+    segments.push({
+      text: truncField(activeTask, 30),
+      bg: palette.taskBg,
+      fg: palette.fg,
+      priority: 40,
+    });
+  }
+
+  if (display.version && input.version) {
+    segments.push({
+      text: hyperlink(
+        `https://www.npmjs.com/package/@anthropic-ai/claude-code/v/${encodeURIComponent(input.version)}`,
+        `v${input.version}`,
+      ),
+      bg: palette.versionBg,
+      fg: palette.fg,
+      priority: 20,
+    });
+  }
+
+  return segments;
+}
+
+/** Render line1 in powerline style. Caller must ensure mode != 'named'. */
+export function renderPowerlineLine1(ctx: RenderContext, mode: ColorMode, theme: ThemePalette | null): string {
+  const palette = theme
+    ? (theme.powerline ?? derivePowerlinePalette(theme))
+    : DEFAULT_POWERLINE_PALETTE;
+  const styleName = (ctx.config.powerline?.style ?? 'auto') as PowerlineStyleName;
+  const hasNerdFont = (ctx.config.icons ?? 'nerd') === 'nerd';
+  const style = resolveStyle(styleName, hasNerdFont);
+  const segments = buildSegments(ctx, palette);
+  if (segments.length === 0) return '';
+  return renderPowerline(segments, style, mode, ctx.cols);
+}

--- a/src/render/powerline-line1.ts
+++ b/src/render/powerline-line1.ts
@@ -53,9 +53,12 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette): Powerline
   if (display.branch && branchName) {
     const dirty = git.staged + git.modified + git.untracked > 0;
     // Signal git state via bg swap — robbed from powerline-go's RepoCleanBg /
-    // RepoDirtyBg distinction. Cleaner than appending status chars post-branch.
+    // RepoDirtyBg distinction. Both badges and the bg swap respect
+    // `display.gitChanges` so toggling it off matches classic renderer
+    // behaviour (no signal of dirty state at all).
+    const showDirty = display.gitChanges && dirty;
     let label = truncField(branchName, 40);
-    if (display.gitChanges && dirty) {
+    if (showDirty) {
       const badges: string[] = [];
       if (git.staged > 0)    badges.push(`+${git.staged}`);
       if (git.modified > 0)  badges.push(`!${git.modified}`);
@@ -65,7 +68,7 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette): Powerline
     segments.push({
       text: label,
       icon: icons.branch,
-      bg: dirty ? palette.branchDirtyBg : palette.branchCleanBg,
+      bg: showDirty ? palette.branchDirtyBg : palette.branchCleanBg,
       fg: palette.fg,
       priority: 80,
     });

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -19,15 +19,21 @@ import {
 //   modelBg    → context bar segment
 //   taskBg     → cost/tokens segment
 //   versionBg  → duration segment
-// The context bar retains its own green→yellow→red gradient inside the segment text.
+//
+// Context bar policy: cells inherit segment bg (proportion reads from cell
+// length, no need for a colored gradient). The percentage value, warning
+// icon (☠/🔥), and `/compact?` hint keep their alarm colors — these are the
+// urgency channels the user actually needs at a glance. Decision rationale
+// recorded against PR #47.
 
 function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors): PowerlineSegment[] {
   const { input, config: { display }, icons } = ctx;
   const segments: PowerlineSegment[] = [];
 
-  // Context bar — always highest priority, retains its own coloring inside the segment.
+  // Context bar — always highest priority. plain=true so the bar cells inherit
+  // the powerline segment bg; only %/icon/hint emit color escapes.
   if (display.contextBar) {
-    const bar = buildContextBar(input.context.usedPercentage, c, { iconSet: icons });
+    const bar = buildContextBar(input.context.usedPercentage, c, { iconSet: icons, plain: true });
     segments.push({ text: bar, bg: palette.modelBg, fg: palette.fg, priority: 100 });
   }
 

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -1,0 +1,74 @@
+import {
+  renderPowerline,
+  resolveStyle,
+  type PowerlineSegment,
+  type PowerlineStyleName,
+} from './powerline.js';
+import { buildContextBar } from './shared.js';
+import { formatTokens, formatCost, formatDuration } from '../utils/format.js';
+import type { ColorMode, Colors } from './colors.js';
+import type { RenderContext } from '../types.js';
+import {
+  type PowerlinePalette,
+  derivePowerlinePalette,
+  DEFAULT_POWERLINE_PALETTE,
+  type ThemePalette,
+} from '../themes.js';
+
+// Line 2 powerline palette — reuses PowerlinePalette bg slots with semantic remapping:
+//   modelBg    → context bar segment
+//   taskBg     → cost/tokens segment
+//   versionBg  → duration segment
+// The context bar retains its own green→yellow→red gradient inside the segment text.
+
+function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors): PowerlineSegment[] {
+  const { input, config: { display }, icons } = ctx;
+  const segments: PowerlineSegment[] = [];
+
+  // Context bar — always highest priority, retains its own coloring inside the segment.
+  if (display.contextBar) {
+    const bar = buildContextBar(input.context.usedPercentage, c, { iconSet: icons });
+    segments.push({ text: bar, bg: palette.modelBg, fg: palette.fg, priority: 100 });
+  }
+
+  // Context tokens
+  if (display.contextTokens && input.tokens.input > 0 && input.context.usedPercentage > 0) {
+    const used = input.tokens.input;
+    const capacity = Math.round(used / (input.context.usedPercentage / 100));
+    segments.push({ text: `${formatTokens(used)}/${formatTokens(capacity)}`, bg: palette.dirBg, fg: palette.fg, priority: 80 });
+  }
+
+  // Cost
+  if (display.cost && input.cost != null) {
+    segments.push({ text: formatCost(input.cost), bg: palette.taskBg, fg: palette.fg, priority: 60 });
+  }
+
+  // Duration
+  if (display.duration && input.durationMs != null) {
+    segments.push({ text: `${icons.clock} ${formatDuration(input.durationMs)}`, bg: palette.branchCleanBg, fg: palette.fg, priority: 40 });
+  }
+
+  // Rate limits — only show if >=50%
+  if (display.rateLimits && input.rateLimits) {
+    const fh = input.rateLimits.fiveHour;
+    if (fh && fh.usedPercentage >= 50) {
+      const bg = fh.usedPercentage >= 80 ? palette.branchDirtyBg : palette.taskBg;
+      segments.push({ text: `${icons.bolt} ${fh.usedPercentage.toFixed(0)}%(5h)`, bg, fg: palette.fg, priority: 20 });
+    }
+  }
+
+  return segments;
+}
+
+/** Render line2 in powerline style. Caller must ensure mode != 'named'. */
+export function renderPowerlineLine2(ctx: RenderContext, mode: ColorMode, theme: ThemePalette | null, c: Colors): string {
+  const palette = theme
+    ? (theme.powerline ?? derivePowerlinePalette(theme))
+    : DEFAULT_POWERLINE_PALETTE;
+  const styleName = (ctx.config.powerline?.style ?? 'auto') as PowerlineStyleName;
+  const hasNerdFont = (ctx.config.icons ?? 'nerd') === 'nerd';
+  const style = resolveStyle(styleName, hasNerdFont);
+  const segments = buildSegments(ctx, palette, c);
+  if (segments.length === 0) return '';
+  return renderPowerline(segments, style, mode, ctx.cols);
+}

--- a/src/render/powerline-line3.ts
+++ b/src/render/powerline-line3.ts
@@ -1,0 +1,75 @@
+import {
+  renderPowerline,
+  resolveStyle,
+  type PowerlineSegment,
+  type PowerlineStyleName,
+} from './powerline.js';
+import { truncField } from './text.js';
+import type { ColorMode } from './colors.js';
+import type { RenderContext, ToolEntry } from '../types.js';
+import {
+  type PowerlinePalette,
+  derivePowerlinePalette,
+  DEFAULT_POWERLINE_PALETTE,
+  type ThemePalette,
+} from '../themes.js';
+
+const EXCLUDED_TOOLS = new Set(['TodoWrite', 'TaskCreate', 'TaskUpdate']);
+
+function buildSegments(ctx: RenderContext, palette: PowerlinePalette): PowerlineSegment[] {
+  const { transcript: { tools, todos }, config: { display }, icons } = ctx;
+  const segments: PowerlineSegment[] = [];
+
+  // Tools segment — running tools take priority, then completed summary.
+  if (display.tools !== false) {
+    const relevant = tools.filter((t: ToolEntry) => !EXCLUDED_TOOLS.has(t.name));
+    const running = relevant.filter(t => t.status === 'running').slice(-2);
+    const completed = relevant.filter(t => t.status === 'completed');
+
+    if (running.length > 0) {
+      const label = running.map(t => {
+        const target = t.target ? `: ${truncField(t.target, 15)}` : '';
+        return `◐ ${t.name}${target}`;
+      }).join(' ');
+      segments.push({ text: label, bg: palette.taskBg, fg: palette.fg, priority: 100 });
+    } else if (completed.length > 0) {
+      // Group by name, show top 3.
+      const groups = new Map<string, number>();
+      for (const t of completed) groups.set(t.name, (groups.get(t.name) ?? 0) + 1);
+      const label = Array.from(groups.entries())
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 3)
+        .map(([name, count]) => `${icons.checkmark} ${name}${count > 1 ? ` ×${count}` : ''}`)
+        .join(' ');
+      if (label) segments.push({ text: label, bg: palette.versionBg, fg: palette.fg, priority: 100 });
+    }
+  }
+
+  // Todos segment — progress bar + counts.
+  if (display.todos !== false && todos.length > 0) {
+    const total = todos.length;
+    const done = todos.filter(t => t.status === 'completed').length;
+    const inProg = todos.filter(t => t.status === 'in_progress').length;
+    const SEGS = 8;
+    const filled = Math.round((done / total) * SEGS);
+    const bar = icons.barFull.repeat(filled) + icons.barEmpty.repeat(SEGS - filled);
+    let label = `${bar} ${done}/${total}`;
+    if (inProg > 0) label += ` ◐ ${inProg}`;
+    segments.push({ text: label, bg: palette.branchCleanBg, fg: palette.fg, priority: 80 });
+  }
+
+  return segments;
+}
+
+/** Render line3 in powerline style. Caller must ensure mode != 'named'. */
+export function renderPowerlineLine3(ctx: RenderContext, mode: ColorMode, theme: ThemePalette | null): string {
+  const palette = theme
+    ? (theme.powerline ?? derivePowerlinePalette(theme))
+    : DEFAULT_POWERLINE_PALETTE;
+  const styleName = (ctx.config.powerline?.style ?? 'auto') as PowerlineStyleName;
+  const hasNerdFont = (ctx.config.icons ?? 'nerd') === 'nerd';
+  const style = resolveStyle(styleName, hasNerdFont);
+  const segments = buildSegments(ctx, palette);
+  if (segments.length === 0) return '';
+  return renderPowerline(segments, style, mode, ctx.cols);
+}

--- a/src/render/powerline.ts
+++ b/src/render/powerline.ts
@@ -1,0 +1,196 @@
+import type { ColorMode } from './colors.js';
+import { displayWidth, truncField } from './text.js';
+import { stripAnsi } from './colors.js';
+import { type RGB, rgbTo256Index } from '../themes.js';
+
+// Powerline renderer — segment-based with colored backgrounds and glyph
+// separators that blend adjacent segment colors. See research notes: all
+// common implementations (powerline-go, oh-my-posh, vim-airline) agree on
+// `sep.fg = current.bg, sep.bg = next.bg` to produce the blend effect.
+
+const RESET = '\x1b[0m';
+const RESET_BG = '\x1b[49m';
+
+export interface PowerlineSegment {
+  text: string;
+  icon?: string;
+  bg: RGB;
+  fg?: RGB;
+  /** Lower = dropped first when terminal width is exceeded. */
+  priority: number;
+}
+
+export type PowerlineStyleName =
+  | 'arrow' | 'flame' | 'slant' | 'round' | 'diamond'
+  | 'compatible' | 'plain' | 'auto';
+
+interface Style {
+  leftCap?: string;
+  sep?: string;
+  rightCap?: string;
+  /** True = diamond mode: each segment is isolated with its own caps + a space gap. */
+  gap?: boolean;
+  /** Visual width cost of a separator glyph (Nerd Font glyphs are 1 col). */
+  sepWidth: number;
+}
+
+export const POWERLINE_STYLES: Record<Exclude<PowerlineStyleName, 'auto'>, Style> = {
+  arrow:      { sep: '', sepWidth: 1 },
+  flame:      { sep: '', sepWidth: 1 },
+  slant:      { sep: '', sepWidth: 1 },
+  // Round uses thin `` between same-pill segments and `` at
+  // bg transitions. We always use `` here because each lumira segment
+  // has a distinct bg — the thin variant would only apply if we re-used a bg.
+  round:      { leftCap: '', sep: '', rightCap: '', sepWidth: 1 },
+  diamond:    { leftCap: '', rightCap: '', gap: true, sepWidth: 2 },
+  // `▶` (U+25B6) sits in the 0x25A0–0x25FF range which displayWidth treats as
+  // double-width. Must match that assumption or powerlineWidth drifts from
+  // the actual rendered width.
+  compatible: { sep: '▶', sepWidth: 2 },
+  plain:      { sep: ' ', sepWidth: 1 },
+};
+
+export function resolveStyle(name: PowerlineStyleName, hasNerdFont: boolean): Style {
+  if (name === 'auto') return hasNerdFont ? POWERLINE_STYLES.arrow : POWERLINE_STYLES.compatible;
+  return POWERLINE_STYLES[name] ?? POWERLINE_STYLES.arrow;
+}
+
+function bgEscape(c: RGB, mode: ColorMode): string {
+  if (mode === 'truecolor') return `\x1b[48;2;${c.r};${c.g};${c.b}m`;
+  if (mode === '256') return `\x1b[48;5;${rgbTo256Index(c.r, c.g, c.b)}m`;
+  // named mode caller shouldn't reach here — powerline falls back to classic
+  return '';
+}
+
+function fgEscape(c: RGB, mode: ColorMode): string {
+  if (mode === 'truecolor') return `\x1b[38;2;${c.r};${c.g};${c.b}m`;
+  if (mode === '256') return `\x1b[38;5;${rgbTo256Index(c.r, c.g, c.b)}m`;
+  return '';
+}
+
+const DEFAULT_FG: RGB = { r: 255, g: 255, b: 255 };
+
+/** Width of a rendered segment's visible text (not including separators/caps). */
+function segTextWidth(seg: PowerlineSegment): number {
+  const body = seg.icon ? `${seg.icon} ${seg.text}` : seg.text;
+  // One leading + one trailing space of padding per segment.
+  return 2 + displayWidth(body);
+}
+
+/** Total visible width the segment list would render to, given a style. */
+export function powerlineWidth(segments: PowerlineSegment[], style: Style): number {
+  if (segments.length === 0) return 0;
+  const bodyW = segments.reduce((sum, s) => sum + segTextWidth(s), 0);
+
+  if (style.gap) {
+    // diamond: leftCap + body + rightCap per segment, space between segments.
+    return segments.length * (style.sepWidth + 0) // caps already included in sepWidth=2
+      + bodyW
+      + (segments.length - 1); // spaces between pills
+  }
+  // continuous: optional leftCap, N-1 seps between, 1 sep at end (or rightCap),
+  // plus body width.
+  let w = bodyW;
+  if (style.leftCap) w += 1;
+  w += (segments.length - 1) * style.sepWidth;
+  // Terminator glyph — rightCap is always 1 col (Nerd Font PUA), while sep
+  // can be wider (e.g. `▶` for compatible). Use sepWidth when the terminator
+  // is a sep, otherwise 1.
+  w += style.rightCap ? 1 : style.sepWidth;
+  return w;
+}
+
+/**
+ * Drop lowest-priority segments until the projected width fits within `cols`.
+ * Always preserves the highest-priority segment (typically the model name).
+ */
+export function applyPriorityEviction(
+  segments: PowerlineSegment[],
+  style: Style,
+  cols: number,
+): PowerlineSegment[] {
+  if (segments.length === 0) return segments;
+  const safeCols = Math.max(1, cols - 4);
+  let kept = [...segments];
+  while (kept.length > 1 && powerlineWidth(kept, style) > safeCols) {
+    // Find lowest-priority segment, scanning right-to-left so ties resolve in
+    // favour of earlier-inserted (higher-importance) segments. With strict `<`
+    // and a left-to-right scan, equal priorities would drop the model first —
+    // violating the exported contract that the highest-priority segment is
+    // preserved.
+    let lowestIdx = kept.length - 1;
+    let lowest = kept[lowestIdx].priority;
+    for (let i = kept.length - 2; i >= 0; i--) {
+      if (kept[i].priority < lowest) { lowest = kept[i].priority; lowestIdx = i; }
+    }
+    kept.splice(lowestIdx, 1);
+  }
+  // If still over budget with one segment, truncate its text.
+  if (kept.length === 1 && powerlineWidth(kept, style) > safeCols) {
+    const seg = kept[0];
+    // Chrome = fixed cost the style adds around segment content. Must match
+    // `powerlineWidth` for a one-segment case, otherwise the truncated result
+    // can still exceed safeCols by one column (notably for diamond, which has
+    // two caps vs arrow's single terminator).
+    const terminatorW = style.rightCap ? 1 : style.sepWidth;
+    const chrome = style.gap
+      ? 2 /* leftCap + rightCap */ + 2 /* padding */
+      : (style.leftCap ? 1 : 0) + terminatorW + 2 /* padding */;
+    const iconCost = seg.icon ? displayWidth(seg.icon) + 1 : 0;
+    const budget = Math.max(1, safeCols - chrome - iconCost);
+    // Strip ANSI/OSC 8 wrappers before truncating — truncField iterates raw
+    // code points and would otherwise cut mid-escape. Safe on plain strings
+    // too (stripAnsi is a no-op when no escapes are present).
+    kept = [{ ...seg, text: truncField(stripAnsi(seg.text), budget) }];
+  }
+  return kept;
+}
+
+export function renderPowerline(
+  segments: PowerlineSegment[],
+  style: Style,
+  mode: ColorMode,
+  cols: number,
+): string {
+  if (segments.length === 0) return '';
+  const fitted = applyPriorityEviction(segments, style, cols);
+  const out: string[] = [];
+
+  const body = (seg: PowerlineSegment) => {
+    const fg = seg.fg ?? DEFAULT_FG;
+    const parts = [bgEscape(seg.bg, mode), fgEscape(fg, mode), ' '];
+    if (seg.icon) { parts.push(seg.icon, ' '); }
+    parts.push(seg.text, ' ');
+    return parts.join('');
+  };
+
+  if (style.gap) {
+    // Diamond: each segment is a self-contained pill.
+    for (let i = 0; i < fitted.length; i++) {
+      const seg = fitted[i];
+      out.push(fgEscape(seg.bg, mode), style.leftCap!);
+      out.push(body(seg));
+      out.push(RESET_BG, fgEscape(seg.bg, mode), style.rightCap!, RESET);
+      if (i < fitted.length - 1) out.push(' ');
+    }
+    return out.join('');
+  }
+
+  // Continuous mode.
+  if (style.leftCap) {
+    out.push(fgEscape(fitted[0].bg, mode), style.leftCap);
+  }
+  for (let i = 0; i < fitted.length; i++) {
+    const seg = fitted[i];
+    out.push(body(seg));
+    if (i < fitted.length - 1) {
+      const next = fitted[i + 1];
+      // sep.fg = current.bg, sep.bg = next.bg — the classic powerline blend.
+      out.push(bgEscape(next.bg, mode), fgEscape(seg.bg, mode), style.sep!);
+    }
+  }
+  // Terminator: transition from last seg's bg back to the default bg.
+  const last = fitted[fitted.length - 1];
+  out.push(RESET_BG, fgEscape(last.bg, mode), style.rightCap ?? style.sep!, RESET);
+  return out.join('');
+}

--- a/src/render/shared.ts
+++ b/src/render/shared.ts
@@ -19,17 +19,31 @@ export interface ContextBarOpts {
   iconSet?: IconSet;
   /** When true (default), append an actionable hint like `/compact?` at high fill. */
   showHint?: boolean;
+  /**
+   * When true, the bar cells are emitted without inline color escapes so the
+   * surrounding background (e.g. a powerline segment bg) shows through. The
+   * percentage and warning icon still keep their alarm colors — proportion
+   * reads from cell length, urgency reads from the colored suffix. Set by
+   * the powerline renderer; classic mode leaves it false.
+   */
+  plain?: boolean;
 }
 
 export function buildContextBar(pct: number, c: Colors, opts?: ContextBarOpts): string {
   const segments = opts?.segments ?? 20;
   const showIcons = opts?.showIcons ?? true;
   const showHint = opts?.showHint ?? true;
+  const plain = opts?.plain ?? false;
   const ic = opts?.iconSet ?? NERD_ICONS;
 
   const filled = Math.round((pct / 100) * segments);
   const colorFn = c[getContextColor(pct)];
-  const bar = colorFn(ic.barFull.repeat(filled)) + c.dim(ic.barEmpty.repeat(segments - filled));
+  // In plain mode the bar cells emit no ANSI — terminal default fg over
+  // whatever bg the caller has set. The empty-cell `dim` is also suppressed
+  // because `\x1b[2m...\x1b[0m` would still close out the caller's bg.
+  const bar = plain
+    ? ic.barFull.repeat(filled) + ic.barEmpty.repeat(segments - filled)
+    : colorFn(ic.barFull.repeat(filled)) + c.dim(ic.barEmpty.repeat(segments - filled));
 
   let icon = '';
   if (showIcons) {
@@ -47,7 +61,16 @@ export function buildContextBar(pct: number, c: Colors, opts?: ContextBarOpts): 
 
   const pctStr = colorFn(`${pct < 10 ? pct.toFixed(1) : pct.toFixed(0)}%`);
 
-  return `${bar} ${pctStr}${icon ? ' ' + icon : ''}${hint}`;
+  const out = `${bar} ${pctStr}${icon ? ' ' + icon : ''}${hint}`;
+  if (plain) {
+    // Inside a powerline segment, a literal `\x1b[0m` would clear the
+    // caller-set background and leak the terminal default bg through the
+    // remaining segment text. Replace each full reset with a partial reset
+    // that clears fg + intensity + blink but leaves bg untouched, so the
+    // segment bg flows continuously across the colored % and warning glyph.
+    return out.replace(/\x1b\[0m/g, '\x1b[39;22;25m');
+  }
+  return out;
 }
 
 export function formatGitChanges(git: GitStatus, c: Colors): string[] {

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -16,19 +16,36 @@ export interface ThemePalette {
   red: string;
   brightBlue: string;
   gray: string;
+  /** Optional per-theme powerline palette; derived from fg colors when absent. */
+  powerline?: PowerlinePalette;
 }
 
-interface RGB { r: number; g: number; b: number; }
+export interface PowerlinePalette {
+  modelBg: RGB;
+  dirBg: RGB;
+  branchCleanBg: RGB;
+  branchDirtyBg: RGB;
+  taskBg: RGB;
+  versionBg: RGB;
+  fg: RGB;
+}
+
+export interface RGB { r: number; g: number; b: number; }
 
 function rgb(r: number, g: number, b: number): string {
   return `\x1b[38;2;${r};${g};${b}m`;
 }
 
-/** Parse a truecolor escape `\x1b[38;2;R;G;Bm` back into RGB components. */
-function parseRgb(escape: string): RGB | null {
-  const m = escape.match(/^\x1b\[38;2;(\d+);(\d+);(\d+)m$/);
+/** Parse a truecolor fg or bg escape (`\x1b[38;2;…m` / `\x1b[48;2;…m`) back into RGB. */
+export function parseRgb(escape: string): RGB | null {
+  const m = escape.match(/^\x1b\[[34]8;2;(\d+);(\d+);(\d+)m$/);
   if (!m) return null;
   return { r: parseInt(m[1], 10), g: parseInt(m[2], 10), b: parseInt(m[3], 10) };
+}
+
+/** Convert RGB to the nearest xterm 256-color index (cube 16..231 + grayscale 232..255). */
+export function rgbTo256Index(r: number, g: number, b: number): number {
+  return rgbTo256(r, g, b);
 }
 
 /**
@@ -64,8 +81,88 @@ export function downgradePaletteTo256(p: ThemePalette): ThemePalette {
     red: rgbEscapeTo256(p.red),
     brightBlue: rgbEscapeTo256(p.brightBlue),
     gray: rgbEscapeTo256(p.gray),
+    // powerline stores raw RGB triples (projected to 256 at render time by
+    // rgbTo256Index), so pass it through as-is — no escape conversion needed.
+    ...(p.powerline ? { powerline: p.powerline } : {}),
   };
 }
+
+// Hand-curated powerline palettes per theme. Auto-derivation (darken fg by
+// ~55%) produced muddy/indistinguishable bgs for low-saturation themes like
+// Nord and Solarized. These swatches are picked from each theme's official
+// palette — darker enough so white text stays legible, distinct hues so
+// segments are visually separable.
+const WHITE: RGB = { r: 255, g: 255, b: 255 };
+
+const DRACULA_POWERLINE: PowerlinePalette = {
+  modelBg:       { r: 62,  g: 90,  b: 106 },  // dark cyan
+  dirBg:         { r: 68,  g: 71,  b: 90  },  // currentLine #44475a
+  branchCleanBg: { r: 126, g: 61,  b: 124 },  // dark pink
+  branchDirtyBg: { r: 139, g: 50,  b: 50  },  // dark red
+  taskBg:        { r: 138, g: 108, b: 42  },  // dark yellow
+  versionBg:     { r: 58,  g: 61,  b: 74  },
+  fg: WHITE,
+};
+
+const NORD_POWERLINE: PowerlinePalette = {
+  modelBg:       { r: 94,  g: 127, b: 150 },  // frost muted
+  dirBg:         { r: 76,  g: 86,  b: 106 },  // nord3
+  branchCleanBg: { r: 109, g: 90,  b: 130 },  // aurora purple dimmed
+  branchDirtyBg: { r: 142, g: 72,  b: 80  },  // aurora red dimmed
+  taskBg:        { r: 160, g: 101, b: 58  },  // aurora orange dimmed
+  versionBg:     { r: 59,  g: 66,  b: 82  },  // nord1
+  fg: WHITE,
+};
+
+const TOKYO_NIGHT_POWERLINE: PowerlinePalette = {
+  modelBg:       { r: 42,  g: 58,  b: 96  },
+  dirBg:         { r: 61,  g: 78,  b: 138 },
+  branchCleanBg: { r: 90,  g: 63,  b: 140 },
+  branchDirtyBg: { r: 166, g: 58,  b: 75  },
+  taskBg:        { r: 138, g: 106, b: 46  },
+  versionBg:     { r: 39,  g: 43,  b: 58  },
+  fg: WHITE,
+};
+
+const CATPPUCCIN_POWERLINE: PowerlinePalette = {
+  modelBg:       { r: 58,  g: 98,  b: 116 },  // dark teal
+  dirBg:         { r: 74,  g: 90,  b: 154 },  // dark blue
+  branchCleanBg: { r: 122, g: 90,  b: 168 },  // dark mauve
+  branchDirtyBg: { r: 160, g: 72,  b: 86  },  // dark red
+  taskBg:        { r: 160, g: 102, b: 58  },  // dark peach
+  versionBg:     { r: 49,  g: 50,  b: 68  },  // surface0
+  fg: WHITE,
+};
+
+const MONOKAI_POWERLINE: PowerlinePalette = {
+  modelBg:       { r: 42,  g: 93,  b: 110 },  // dark cyan
+  dirBg:         { r: 73,  g: 72,  b: 62  },  // bg variant
+  branchCleanBg: { r: 140, g: 30,  b: 73  },  // dark pink
+  branchDirtyBg: { r: 166, g: 56,  b: 37  },  // dark orange-red
+  taskBg:        { r: 133, g: 107, b: 42  },  // dark yellow
+  versionBg:     { r: 39,  g: 40,  b: 34  },  // bg
+  fg: WHITE,
+};
+
+const GRUVBOX_POWERLINE: PowerlinePalette = {
+  modelBg:       { r: 60,  g: 91,  b: 95  },  // dark aqua
+  dirBg:         { r: 80,  g: 73,  b: 69  },  // bg2
+  branchCleanBg: { r: 131, g: 61,  b: 106 },  // dark purple
+  branchDirtyBg: { r: 157, g: 43,  b: 34  },  // dark red
+  taskBg:        { r: 160, g: 104, b: 21  },  // dark yellow
+  versionBg:     { r: 60,  g: 56,  b: 54  },  // bg1
+  fg: WHITE,
+};
+
+const SOLARIZED_POWERLINE: PowerlinePalette = {
+  modelBg:       { r: 31,  g: 109, b: 103 },  // dark cyan
+  dirBg:         { r: 30,  g: 88,  b: 126 },  // dark blue
+  branchCleanBg: { r: 141, g: 40,  b: 87  },  // dark magenta
+  branchDirtyBg: { r: 168, g: 32,  b: 31  },  // dark red
+  taskBg:        { r: 138, g: 79,  b: 17  },  // dark orange
+  versionBg:     { r: 7,   g: 54,  b: 66  },  // base02
+  fg: WHITE,
+};
 
 export const THEMES: Record<string, ThemePalette> = {
   dracula: {
@@ -77,6 +174,7 @@ export const THEMES: Record<string, ThemePalette> = {
     red: rgb(255, 85, 85),
     brightBlue: rgb(189, 147, 249),
     gray: rgb(98, 114, 164),
+    powerline: DRACULA_POWERLINE,
   },
   nord: {
     cyan: rgb(136, 192, 208),
@@ -87,6 +185,7 @@ export const THEMES: Record<string, ThemePalette> = {
     red: rgb(191, 97, 106),
     brightBlue: rgb(129, 161, 193),
     gray: rgb(76, 86, 106),
+    powerline: NORD_POWERLINE,
   },
   'tokyo-night': {
     cyan: rgb(125, 207, 255),
@@ -97,6 +196,7 @@ export const THEMES: Record<string, ThemePalette> = {
     red: rgb(247, 118, 142),
     brightBlue: rgb(122, 162, 247),
     gray: rgb(86, 95, 137),
+    powerline: TOKYO_NIGHT_POWERLINE,
   },
   catppuccin: {
     cyan: rgb(137, 220, 235),
@@ -107,6 +207,7 @@ export const THEMES: Record<string, ThemePalette> = {
     red: rgb(243, 139, 168),
     brightBlue: rgb(137, 180, 250),
     gray: rgb(108, 112, 134),
+    powerline: CATPPUCCIN_POWERLINE,
   },
   monokai: {
     cyan: rgb(102, 217, 239),
@@ -117,6 +218,7 @@ export const THEMES: Record<string, ThemePalette> = {
     red: rgb(249, 38, 114),
     brightBlue: rgb(102, 217, 239),
     gray: rgb(117, 113, 94),
+    powerline: MONOKAI_POWERLINE,
   },
   gruvbox: {
     cyan: rgb(131, 165, 152),
@@ -127,6 +229,7 @@ export const THEMES: Record<string, ThemePalette> = {
     red: rgb(204, 36, 29),
     brightBlue: rgb(69, 133, 136),
     gray: rgb(146, 131, 116),
+    powerline: GRUVBOX_POWERLINE,
   },
   solarized: {
     cyan: rgb(42, 161, 152),
@@ -137,12 +240,54 @@ export const THEMES: Record<string, ThemePalette> = {
     red: rgb(220, 50, 47),
     brightBlue: rgb(38, 139, 210),
     gray: rgb(101, 123, 131),
+    powerline: SOLARIZED_POWERLINE,
   },
 };
 
 export function getThemeNames(): string[] {
   return Object.keys(THEMES);
 }
+
+/** Darken an RGB triple toward black by `factor` in [0,1]. */
+function darken(c: RGB, factor: number): RGB {
+  return {
+    r: Math.round(c.r * (1 - factor)),
+    g: Math.round(c.g * (1 - factor)),
+    b: Math.round(c.b * (1 - factor)),
+  };
+}
+
+/**
+ * Build a PowerlinePalette for a theme that doesn't define one explicitly.
+ * We darken the existing fg hues (by ~55%) so the palette reads as "background
+ * tones of the theme" rather than blown-out fg colors that would clash with
+ * white text. The branchDirtyBg uses `red` regardless of theme for signal.
+ */
+export function derivePowerlinePalette(theme: ThemePalette): PowerlinePalette {
+  const get = (escape: string, fallback: RGB): RGB => parseRgb(escape) ?? fallback;
+  const f = 0.55; // darkening factor — tuned so white fg stays legible
+  const fb = { r: 80, g: 80, b: 80 };
+  return {
+    modelBg:        darken(get(theme.cyan, fb), f),
+    dirBg:          darken(get(theme.brightBlue, fb), f),
+    branchCleanBg:  darken(get(theme.magenta, fb), f),
+    branchDirtyBg:  darken(get(theme.red, fb), f),
+    taskBg:         darken(get(theme.yellow, fb), f),
+    versionBg:      darken(get(theme.gray, fb), f),
+    fg:             { r: 255, g: 255, b: 255 },
+  };
+}
+
+/** Fallback powerline palette when no theme is selected (named-ANSI terminals use classic). */
+export const DEFAULT_POWERLINE_PALETTE: PowerlinePalette = {
+  modelBg:       { r: 32,  g: 96,  b: 128 },
+  dirBg:         { r: 48,  g: 72,  b: 128 },
+  branchCleanBg: { r: 96,  g: 48,  b: 112 },
+  branchDirtyBg: { r: 160, g: 40,  b: 40  },
+  taskBg:        { r: 128, g: 96,  b: 24  },
+  versionBg:     { r: 64,  g: 64,  b: 72  },
+  fg:            { r: 255, g: 255, b: 255 },
+};
 
 export function resolveTheme(name: string | undefined, mode: ColorMode): ThemePalette | null {
   if (!name) return null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,6 +161,12 @@ export interface HudConfig {
   preset?: 'full' | 'balanced' | 'minimal';
   theme?: string;
   icons?: 'nerd' | 'emoji' | 'none';
+  /** Visual style for line1 — 'classic' (pipe-separated) or 'powerline' (colored segments). */
+  style?: 'classic' | 'powerline';
+  powerline?: {
+    /** Separator glyph preset. Defaults to 'auto' (nerd font → arrow, else compatible). */
+    style?: 'arrow' | 'flame' | 'slant' | 'round' | 'diamond' | 'compatible' | 'plain' | 'auto';
+  };
 }
 
 export interface DisplayToggles {

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,6 +195,7 @@ export interface DisplayToggles {
   memory: boolean;
   cacheMetrics: boolean;
   mcp: boolean;
+  health: boolean;
 }
 
 export interface ColorConfig {
@@ -227,6 +228,7 @@ export const DEFAULT_DISPLAY: DisplayToggles = {
   memory: true,
   cacheMetrics: true,
   mcp: true,
+  health: false,
 };
 
 export const DEFAULT_CONFIG: HudConfig = {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -91,6 +91,44 @@ describe('loadConfig', () => {
   it('includes contextTokens in display defaults', () => {
     expect(loadConfig(join(dir, 'nope')).display.contextTokens).toBe(true);
   });
+
+  it('parses style: "powerline"', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"style":"powerline"}');
+    expect(loadConfig(dir).style).toBe('powerline');
+  });
+  it('parses style: "classic"', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"style":"classic"}');
+    expect(loadConfig(dir).style).toBe('classic');
+  });
+  it('ignores invalid style value', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"style":"bogus"}');
+    expect(loadConfig(dir).style).toBeUndefined();
+  });
+  it('parses powerline.style', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"powerline":{"style":"flame"}}');
+    expect(loadConfig(dir).powerline?.style).toBe('flame');
+  });
+  it('ignores invalid powerline.style value', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"powerline":{"style":"bogus"}}');
+    expect(loadConfig(dir).powerline).toBeUndefined();
+  });
+  it('ignores malformed powerline (string instead of object)', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"powerline":"arrow"}');
+    expect(loadConfig(dir).powerline).toBeUndefined();
+  });
+  it('accepts all 8 valid powerline styles', () => {
+    mkdirSync(dir, { recursive: true });
+    for (const s of ['arrow', 'flame', 'slant', 'round', 'diamond', 'compatible', 'plain', 'auto']) {
+      writeFileSync(join(dir, 'config.json'), `{"powerline":{"style":"${s}"}}`);
+      expect(loadConfig(dir).powerline?.style).toBe(s);
+    }
+  });
 });
 
 describe('mergeCliFlags', () => {

--- a/tests/parsers/config-health.test.ts
+++ b/tests/parsers/config-health.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { getConfigHealth } from '../../src/parsers/config-health.js';
+import type { HudConfig } from '../../src/types.js';
+import { DEFAULT_DISPLAY } from '../../src/types.js';
+
+const baseConfig: HudConfig = {
+  layout: 'auto',
+  gsd: false,
+  display: { ...DEFAULT_DISPLAY },
+  colors: { mode: 'truecolor' },
+};
+
+describe('getConfigHealth', () => {
+  it('returns no hints when config is clean', () => {
+    expect(getConfigHealth(baseConfig, 'truecolor', '/tmp')).toHaveLength(0);
+  });
+
+  it('warns when theme is set but colorMode is named', () => {
+    const config = { ...baseConfig, theme: 'dracula' };
+    const hints = getConfigHealth(config, 'named', '/tmp');
+    expect(hints).toHaveLength(1);
+    expect(hints[0].severity).toBe('warn');
+    expect(hints[0].hint).toContain('theme');
+  });
+
+  it('warns when powerline is set but colorMode is named', () => {
+    const config = { ...baseConfig, style: 'powerline' as const };
+    const hints = getConfigHealth(config, 'named', '/tmp');
+    expect(hints).toHaveLength(1);
+    expect(hints[0].severity).toBe('warn');
+    expect(hints[0].hint).toContain('powerline');
+  });
+
+  it('emits both theme and powerline hints when both apply', () => {
+    const config = { ...baseConfig, theme: 'nord', style: 'powerline' as const };
+    const hints = getConfigHealth(config, 'named', '/tmp');
+    expect(hints).toHaveLength(2);
+  });
+
+  it('emits info hint when gsd is on but no STATE.md found', () => {
+    const config = { ...baseConfig, gsd: true };
+    const hints = getConfigHealth(config, 'truecolor', '/tmp');
+    expect(hints).toHaveLength(1);
+    expect(hints[0].severity).toBe('info');
+    expect(hints[0].hint).toContain('GSD');
+  });
+
+  it('no gsd hint when gsd is off', () => {
+    const config = { ...baseConfig, gsd: false };
+    const hints = getConfigHealth(config, 'truecolor', '/tmp');
+    expect(hints).toHaveLength(0);
+  });
+
+  it('no gsd hint when STATE.md exists', () => {
+    // Use the actual lumira project dir which has .planning/STATE.md if it exists,
+    // otherwise just verify no crash on a real path.
+    const config = { ...baseConfig, gsd: true };
+    // Should not throw regardless of whether STATE.md exists
+    expect(() => getConfigHealth(config, 'truecolor', process.cwd())).not.toThrow();
+  });
+});

--- a/tests/parsers/config-health.test.ts
+++ b/tests/parsers/config-health.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { getConfigHealth } from '../../src/parsers/config-health.js';
 import type { HudConfig } from '../../src/types.js';
 import { DEFAULT_DISPLAY } from '../../src/types.js';
@@ -51,11 +54,36 @@ describe('getConfigHealth', () => {
     expect(hints).toHaveLength(0);
   });
 
-  it('no gsd hint when STATE.md exists', () => {
-    // Use the actual lumira project dir which has .planning/STATE.md if it exists,
-    // otherwise just verify no crash on a real path.
-    const config = { ...baseConfig, gsd: true };
-    // Should not throw regardless of whether STATE.md exists
-    expect(() => getConfigHealth(config, 'truecolor', process.cwd())).not.toThrow();
+  describe('GSD STATE.md walk', () => {
+    let dir: string;
+    beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'cc-health-')); });
+    afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+    it('no gsd hint when STATE.md exists at cwd', () => {
+      mkdirSync(join(dir, '.planning'), { recursive: true });
+      writeFileSync(join(dir, '.planning', 'STATE.md'), '# state');
+      const config = { ...baseConfig, gsd: true };
+      expect(getConfigHealth(config, 'truecolor', dir)).toHaveLength(0);
+    });
+
+    it('no gsd hint when STATE.md is in an ancestor (walk ascends correctly)', () => {
+      mkdirSync(join(dir, '.planning'), { recursive: true });
+      writeFileSync(join(dir, '.planning', 'STATE.md'), '# state');
+      const nested = join(dir, 'a', 'b', 'c');
+      mkdirSync(nested, { recursive: true });
+      const config = { ...baseConfig, gsd: true };
+      // Pre-fix this would emit the "no STATE.md" hint because join(dir,'..')
+      // never resolves and the walk silently bails after 10 iterations.
+      expect(getConfigHealth(config, 'truecolor', nested)).toHaveLength(0);
+    });
+
+    it('emits gsd hint when no STATE.md exists in any ancestor', () => {
+      const nested = join(dir, 'a', 'b');
+      mkdirSync(nested, { recursive: true });
+      const config = { ...baseConfig, gsd: true };
+      const hints = getConfigHealth(config, 'truecolor', nested);
+      expect(hints).toHaveLength(1);
+      expect(hints[0].hint).toContain('GSD');
+    });
   });
 });

--- a/tests/render/hyperlink.test.ts
+++ b/tests/render/hyperlink.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { hyperlink, supportsHyperlinks, resetHyperlinkSupport, _setHyperlinkSupport } from '../../src/render/hyperlink.js';
+import { stripAnsi } from '../../src/render/colors.js';
+
+describe('hyperlink', () => {
+  const envKeys = ['NO_HYPERLINKS', 'FORCE_HYPERLINK', 'TERM', 'TERM_PROGRAM'] as const;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of envKeys) saved[k] = process.env[k];
+    for (const k of envKeys) delete process.env[k];
+    resetHyperlinkSupport();
+  });
+
+  afterEach(() => {
+    for (const k of envKeys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    resetHyperlinkSupport();
+  });
+
+  it('wraps text with OSC 8 sequence when supported', () => {
+    _setHyperlinkSupport(true);
+    const out = hyperlink('https://example.com', 'click');
+    expect(out).toBe('\x1b]8;;https://example.com\x1b\\click\x1b]8;;\x1b\\');
+  });
+
+  it('returns plain text when unsupported', () => {
+    _setHyperlinkSupport(false);
+    expect(hyperlink('https://example.com', 'click')).toBe('click');
+  });
+
+  it('disables in Apple_Terminal (leaks markers as text)', () => {
+    process.env['TERM_PROGRAM'] = 'Apple_Terminal';
+    expect(supportsHyperlinks()).toBe(false);
+  });
+
+  it('disables when TERM=dumb', () => {
+    process.env['TERM'] = 'dumb';
+    expect(supportsHyperlinks()).toBe(false);
+  });
+
+  it('disables when NO_HYPERLINKS is set', () => {
+    process.env['NO_HYPERLINKS'] = '1';
+    expect(supportsHyperlinks()).toBe(false);
+  });
+
+  it('disables when FORCE_HYPERLINK=0', () => {
+    process.env['FORCE_HYPERLINK'] = '0';
+    expect(supportsHyperlinks()).toBe(false);
+  });
+
+  it('force-enables with FORCE_HYPERLINK=1 even in Apple_Terminal', () => {
+    process.env['TERM_PROGRAM'] = 'Apple_Terminal';
+    process.env['FORCE_HYPERLINK'] = '1';
+    expect(supportsHyperlinks()).toBe(true);
+  });
+
+  it('defaults to enabled in modern terminals', () => {
+    process.env['TERM'] = 'xterm-256color';
+    expect(supportsHyperlinks()).toBe(true);
+  });
+
+  it('stripAnsi removes OSC 8 wrappers (ST terminator)', () => {
+    const wrapped = hyperlink.bind(null);
+    _setHyperlinkSupport(true);
+    const s = wrapped('https://example.com', 'click');
+    expect(stripAnsi(s)).toBe('click');
+  });
+
+  it('stripAnsi removes OSC sequences with BEL terminator too', () => {
+    const bel = '\x1b]8;;https://example.com\x07text\x1b]8;;\x07';
+    expect(stripAnsi(bel)).toBe('text');
+  });
+});

--- a/tests/render/powerline-line2.test.ts
+++ b/tests/render/powerline-line2.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { renderPowerlineLine2 } from '../../src/render/powerline-line2.js';
+import { createColors } from '../../src/render/colors.js';
+import { stripAnsi } from '../../src/render/colors.js';
+import { resolveIcons } from '../../src/render/icons.js';
+import { normalize } from '../../src/normalize.js';
+import { DEFAULT_CONFIG, DEFAULT_DISPLAY, EMPTY_GIT, EMPTY_TRANSCRIPT } from '../../src/types.js';
+import type { RenderContext } from '../../src/types.js';
+
+function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
+  const rawInput = {
+    model: 'Claude Sonnet 4.6',
+    session_id: 'test',
+    context_window: { used_percentage: 42, remaining_percentage: 58, total_input_tokens: 12000, total_output_tokens: 1800 },
+    cost: { total_cost_usd: 0.42, total_duration_ms: 185000 },
+  };
+  return {
+    input: normalize(rawInput),
+    git: { ...EMPTY_GIT },
+    transcript: { ...EMPTY_TRANSCRIPT },
+    tokenSpeed: null,
+    memory: null,
+    gsd: null,
+    mcp: null,
+    cols: 120,
+    config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
+    icons: resolveIcons('nerd'),
+    ...overrides,
+  };
+}
+
+const c = createColors('truecolor', null);
+
+describe('renderPowerlineLine2', () => {
+  it('renders context bar segment in truecolor', () => {
+    const ctx = makeCtx();
+    const out = renderPowerlineLine2(ctx, 'truecolor', null, c);
+    expect(out).toBeTruthy();
+    expect(out).toContain('\x1b[48;2;');
+    expect(out.endsWith('\x1b[0m')).toBe(true);
+  });
+
+  it('renders cost segment when cost is present', () => {
+    const ctx = makeCtx();
+    const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+    expect(out).toContain('$');
+  });
+
+  it('returns empty string when all display toggles are off', () => {
+    const ctx = makeCtx({
+      config: {
+        ...DEFAULT_CONFIG,
+        display: { ...DEFAULT_DISPLAY, contextBar: false, contextTokens: false, cost: false, duration: false, rateLimits: false },
+      },
+    });
+    const out = renderPowerlineLine2(ctx, 'truecolor', null, c);
+    expect(out).toBe('');
+  });
+
+  it('projects to 256-color escapes in 256 mode', () => {
+    const ctx = makeCtx();
+    const out = renderPowerlineLine2(ctx, '256', null, c);
+    expect(out).toMatch(/\x1b\[48;5;\d+m/);
+    expect(out).not.toContain('\x1b[48;2;');
+  });
+});

--- a/tests/render/powerline-line3.test.ts
+++ b/tests/render/powerline-line3.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { renderPowerlineLine3 } from '../../src/render/powerline-line3.js';
+import { stripAnsi } from '../../src/render/colors.js';
+import { resolveIcons } from '../../src/render/icons.js';
+import { normalize } from '../../src/normalize.js';
+import { DEFAULT_CONFIG, DEFAULT_DISPLAY, EMPTY_GIT, EMPTY_TRANSCRIPT } from '../../src/types.js';
+import type { RenderContext } from '../../src/types.js';
+
+function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
+  const rawInput = {
+    model: 'Claude Sonnet 4.6',
+    session_id: 'test',
+    context_window: { used_percentage: 42, remaining_percentage: 58 },
+    cost: { total_cost_usd: 0.42, total_duration_ms: 185000 },
+  };
+  return {
+    input: normalize(rawInput),
+    git: { ...EMPTY_GIT },
+    transcript: { ...EMPTY_TRANSCRIPT },
+    tokenSpeed: null,
+    memory: null,
+    gsd: null,
+    mcp: null,
+    cols: 120,
+    config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
+    icons: resolveIcons('nerd'),
+    ...overrides,
+  };
+}
+
+describe('renderPowerlineLine3', () => {
+  it('returns empty string when no tools or todos', () => {
+    const ctx = makeCtx();
+    expect(renderPowerlineLine3(ctx, 'truecolor', null)).toBe('');
+  });
+
+  it('renders running tool segment', () => {
+    const ctx = makeCtx({
+      transcript: {
+        ...EMPTY_TRANSCRIPT,
+        tools: [{ id: '1', name: 'Read', target: '/src/index.ts', status: 'running', startTime: new Date() }],
+      },
+    });
+    const out = stripAnsi(renderPowerlineLine3(ctx, 'truecolor', null));
+    expect(out).toContain('Read');
+    expect(out).toContain('◐');
+  });
+
+  it('renders todos progress segment', () => {
+    const ctx = makeCtx({
+      transcript: {
+        ...EMPTY_TRANSCRIPT,
+        todos: [
+          { id: '1', content: 'Task A', status: 'completed' },
+          { id: '2', content: 'Task B', status: 'in_progress' },
+          { id: '3', content: 'Task C', status: 'pending' },
+        ],
+      },
+    });
+    const out = stripAnsi(renderPowerlineLine3(ctx, 'truecolor', null));
+    expect(out).toContain('1/3');
+  });
+
+  it('renders both tools and todos segments', () => {
+    const ctx = makeCtx({
+      transcript: {
+        ...EMPTY_TRANSCRIPT,
+        tools: [{ id: '1', name: 'Edit', status: 'completed', startTime: new Date(), endTime: new Date() }],
+        todos: [{ id: '1', content: 'Task', status: 'completed' }],
+      },
+    });
+    const out = renderPowerlineLine3(ctx, 'truecolor', null);
+    expect(out).toBeTruthy();
+    expect(out.endsWith('\x1b[0m')).toBe(true);
+  });
+});

--- a/tests/render/powerline.test.ts
+++ b/tests/render/powerline.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderPowerline,
+  resolveStyle,
+  powerlineWidth,
+  applyPriorityEviction,
+  POWERLINE_STYLES,
+  type PowerlineSegment,
+} from '../../src/render/powerline.js';
+import { stripAnsi } from '../../src/render/colors.js';
+import { displayWidth } from '../../src/render/text.js';
+import type { RGB } from '../../src/themes.js';
+
+const RED: RGB = { r: 255, g: 0, b: 0 };
+const GREEN: RGB = { r: 0, g: 255, b: 0 };
+const BLUE: RGB = { r: 0, g: 0, b: 255 };
+const WHITE: RGB = { r: 255, g: 255, b: 255 };
+
+function seg(text: string, bg: RGB, priority = 50, icon?: string): PowerlineSegment {
+  return { text, bg, fg: WHITE, priority, icon };
+}
+
+describe('powerline', () => {
+  describe('resolveStyle', () => {
+    it('auto picks arrow when Nerd Font available', () => {
+      expect(resolveStyle('auto', true).sep).toBe(POWERLINE_STYLES.arrow.sep);
+    });
+
+    it('auto picks compatible when Nerd Font unavailable', () => {
+      expect(resolveStyle('auto', false).sep).toBe('▶');
+    });
+
+    it('returns exact style by name', () => {
+      expect(resolveStyle('flame', true).sep).toBe(POWERLINE_STYLES.flame.sep);
+      expect(resolveStyle('diamond', true).gap).toBe(true);
+      expect(resolveStyle('plain', true).sep).toBe(' ');
+    });
+  });
+
+  describe('renderPowerline', () => {
+    it('emits arrow separator between segments in truecolor mode', () => {
+      const out = renderPowerline(
+        [seg('A', RED, 100), seg('B', GREEN, 90)],
+        POWERLINE_STYLES.arrow,
+        'truecolor',
+        120,
+      );
+      expect(out).toContain(POWERLINE_STYLES.arrow.sep!);
+      expect(out).toContain('\x1b[48;2;255;0;0m');  // bg A
+      expect(out).toContain('\x1b[48;2;0;255;0m');  // bg B
+      const clean = stripAnsi(out);
+      expect(clean).toContain('A');
+      expect(clean).toContain('B');
+      // Sep appears twice: once between A/B, once as terminator.
+      const sepCount = clean.split(POWERLINE_STYLES.arrow.sep!).length - 1;
+      expect(sepCount).toBe(2);
+    });
+
+    it('projects to 256-color escapes when mode=256', () => {
+      const out = renderPowerline([seg('A', RED, 100)], POWERLINE_STYLES.arrow, '256', 120);
+      expect(out).toMatch(/\x1b\[48;5;\d+m/);
+      expect(out).not.toContain('\x1b[48;2;');
+    });
+
+    it('diamond mode wraps each segment with caps', () => {
+      const out = renderPowerline(
+        [seg('A', RED, 100), seg('B', GREEN, 90)],
+        POWERLINE_STYLES.diamond,
+        'truecolor',
+        120,
+      );
+      const clean = stripAnsi(out);
+      expect(clean).toContain(POWERLINE_STYLES.diamond.leftCap!);
+      expect(clean).toContain(POWERLINE_STYLES.diamond.rightCap!);
+    });
+
+    it('round mode wraps whole line with outer caps', () => {
+      const out = renderPowerline(
+        [seg('A', RED, 100), seg('B', GREEN, 90)],
+        POWERLINE_STYLES.round,
+        'truecolor',
+        120,
+      );
+      const clean = stripAnsi(out);
+      expect(clean.startsWith(POWERLINE_STYLES.round.leftCap!)).toBe(true);
+      expect(clean.endsWith(POWERLINE_STYLES.round.rightCap!)).toBe(true);
+    });
+
+    it('separator fg = current.bg, bg = next.bg (the blend trick)', () => {
+      // With two distinct bg colors, the separator between them should emit
+      // fg(current.bg) + bg(next.bg) right before the sep glyph.
+      const out = renderPowerline(
+        [seg('A', RED, 100), seg('B', GREEN, 90)],
+        POWERLINE_STYLES.arrow,
+        'truecolor',
+        120,
+      );
+      const sepIdx = out.indexOf(POWERLINE_STYLES.arrow.sep!);
+      const beforeSep = out.slice(0, sepIdx);
+      // The final fg/bg escapes before the sep glyph must set fg=red, bg=green.
+      expect(beforeSep).toMatch(/\x1b\[48;2;0;255;0m\x1b\[38;2;255;0;0m$/);
+    });
+
+    it('returns empty string on empty input', () => {
+      expect(renderPowerline([], POWERLINE_STYLES.arrow, 'truecolor', 120)).toBe('');
+    });
+
+    it('terminates with reset so subsequent output is not painted', () => {
+      const out = renderPowerline([seg('A', RED, 100)], POWERLINE_STYLES.arrow, 'truecolor', 120);
+      expect(out.endsWith('\x1b[0m')).toBe(true);
+    });
+  });
+
+  describe('powerlineWidth', () => {
+    it('accounts for segment padding, separator, and terminator', () => {
+      // Single segment: ' A ' (3) + sep (1) = 4
+      expect(powerlineWidth([seg('A', RED)], POWERLINE_STYLES.arrow)).toBe(4);
+      // Two segments: ' A ' + sep + ' B ' + terminator-sep = 3+1+3+1 = 8
+      expect(powerlineWidth([seg('A', RED), seg('B', GREEN)], POWERLINE_STYLES.arrow)).toBe(8);
+    });
+
+    it('matches the actual rendered display width for arrow', () => {
+      const segments = [seg('hello', RED, 100), seg('world', GREEN, 90)];
+      const rendered = renderPowerline(segments, POWERLINE_STYLES.arrow, 'truecolor', 120);
+      expect(powerlineWidth(segments, POWERLINE_STYLES.arrow)).toBe(displayWidth(rendered));
+    });
+
+    it('width matches rendered output for all 7 styles', () => {
+      const segments = [seg('hello', RED, 100), seg('world', GREEN, 90)];
+      for (const name of ['arrow', 'flame', 'slant', 'round', 'diamond', 'compatible', 'plain'] as const) {
+        const style = POWERLINE_STYLES[name];
+        const rendered = renderPowerline(segments, style, 'truecolor', 120);
+        expect(powerlineWidth(segments, style), `width mismatch for ${name}`)
+          .toBe(displayWidth(rendered));
+      }
+    });
+  });
+
+  describe('applyPriorityEviction', () => {
+    it('drops lowest-priority segment first when over budget', () => {
+      const segments = [
+        seg('model', RED, 100),
+        seg('branch', GREEN, 80),
+        seg('dir', BLUE, 60),
+        seg('version', WHITE, 20),
+      ];
+      // Force a tight budget that can only fit two segments.
+      const kept = applyPriorityEviction(segments, POWERLINE_STYLES.arrow, 20);
+      expect(kept.map(s => s.text)).toContain('model');
+      expect(kept.map(s => s.text)).not.toContain('version'); // priority 20 drops first
+    });
+
+    it('always preserves the highest-priority segment', () => {
+      const segments = [seg('keep-me', RED, 100), seg('drop', GREEN, 10)];
+      // Budget too tight for both but large enough to hold "keep-me" untruncated.
+      const kept = applyPriorityEviction(segments, POWERLINE_STYLES.arrow, 20);
+      expect(kept).toHaveLength(1);
+      expect(kept[0].text).toBe('keep-me');
+    });
+
+    it('truncates single remaining segment if still over budget', () => {
+      const segments = [seg('a-very-long-model-name-indeed', RED, 100)];
+      const original = segments[0].text.length;
+      const kept = applyPriorityEviction(segments, POWERLINE_STYLES.arrow, 15);
+      expect(kept[0].text.length).toBeLessThan(original);
+      expect(kept[0].text).toContain('…');
+    });
+
+    it('preserves the first segment when priorities tie', () => {
+      // Previously strict `<` + left-to-right scan would drop the model on ties.
+      const segments = [
+        seg('keep-me', RED, 50),
+        seg('drop',    GREEN, 50),
+      ];
+      const kept = applyPriorityEviction(segments, POWERLINE_STYLES.arrow, 20);
+      expect(kept.map(s => s.text)).toContain('keep-me');
+    });
+
+    it('truncation budget respects diamond style geometry', () => {
+      // Diamond uses leftCap+rightCap (2 cols) + padding (2) + content,
+      // vs arrow's leftCap(0) + terminator(1) + padding(2) + content.
+      // Budget calc must differ by 1 to stay within safeCols.
+      const long = 'a'.repeat(50);
+      const segments = [seg(long, RED, 100)];
+      const kept = applyPriorityEviction(segments, POWERLINE_STYLES.diamond, 20);
+      const rendered = renderPowerline(kept, POWERLINE_STYLES.diamond, 'truecolor', 20);
+      const safeCols = 20 - 4;
+      expect(displayWidth(rendered)).toBeLessThanOrEqual(safeCols);
+    });
+
+    it('truncates hyperlink-wrapped text without leaking raw escape bytes', () => {
+      const osc = '\x1b]8;;https://example.com\x1b\\clickable-label-text\x1b]8;;\x1b\\';
+      const segments = [{ text: osc, bg: RED, fg: WHITE, priority: 100 } as PowerlineSegment];
+      const kept = applyPriorityEviction(segments, POWERLINE_STYLES.arrow, 15);
+      // stripAnsi must run before truncField so the result is plain text + ellipsis,
+      // not a cut-in-half OSC 8 sequence.
+      expect(kept[0].text).not.toContain('\x1b');
+      expect(kept[0].text).toContain('…');
+    });
+  });
+
+  describe('stripAnsi handles powerline output', () => {
+    it('strips all bg and fg escapes from rendered powerline', () => {
+      const out = renderPowerline(
+        [seg('A', RED, 100), seg('B', GREEN, 90)],
+        POWERLINE_STYLES.arrow,
+        'truecolor',
+        120,
+      );
+      const clean = stripAnsi(out);
+      expect(clean).not.toContain('\x1b');
+      expect(clean).toContain('A');
+      expect(clean).toContain('B');
+    });
+  });
+});

--- a/tests/render/shared.test.ts
+++ b/tests/render/shared.test.ts
@@ -128,6 +128,37 @@ describe('buildContextBar — compact hint', () => {
   });
 });
 
+describe('buildContextBar — plain mode (powerline)', () => {
+  it('emits no inline color codes for the bar cells when plain=true', () => {
+    const out = buildContextBar(50, c, { plain: true, showHint: false, showIcons: false });
+    // First 20 chars (the bar itself) should be raw glyphs, no escape sequences.
+    // Find the first space (separates bar from %); bar substring is everything before.
+    const spaceIdx = out.indexOf(' ');
+    const barSlice = out.slice(0, spaceIdx);
+    expect(barSlice).not.toMatch(/\x1b\[/);
+  });
+
+  it('replaces full resets with bg-preserving partial reset', () => {
+    // The colored % still wraps with the named-ANSI reset (\x1b[0m). In plain
+    // mode that gets rewritten to \x1b[39;22;25m so the caller's bg flows
+    // through. Verify no full \x1b[0m survives.
+    const out = buildContextBar(85, c, { plain: true });
+    expect(out).not.toContain('\x1b[0m');
+    expect(out).toContain('\x1b[39;22;25m');
+  });
+
+  it('keeps the percentage value colored', () => {
+    // 70% triggers `orange` (`\x1b[38;5;208m`); 85% would trigger blinkRed.
+    const out = buildContextBar(70, c, { plain: true });
+    expect(out).toContain('\x1b[38;5;208m');
+  });
+
+  it('classic mode (plain=false) is unchanged — still uses \\x1b[0m', () => {
+    const out = buildContextBar(50, c, { plain: false });
+    expect(out).toContain('\x1b[0m');
+  });
+});
+
 describe('SEP constants', () => {
   it('SEP uses Unicode pipe', () => {
     expect(SEP).toContain('\u2502');


### PR DESCRIPTION
## v0.6.0 release

Three new features + visual polish — biggest visual release since v0.4.0.

### Headline features

**Powerline renderer** (`style: "powerline"`, `--powerline`)
- 7 separator presets: arrow, flame, slant, round, diamond, compatible, plain
- Hand-curated palettes for all 7 themes (dracula, nord, tokyo-night, catppuccin, monokai, gruvbox, solarized) — all WCAG AA contrast for white fg
- Git-dirty bg swap (branch turns red on dirty repos)
- Priority-based eviction on narrow terminals
- Now applies to line 1, 2 AND 3 (line 1 first since v0.6.0)
- Falls back to classic on named-ANSI terminals

**OSC 8 hyperlinks**
- Directory becomes a clickable \`file://\` link
- Version tag links to the npm release page
- Auto-disabled in Apple_Terminal / TERM=dumb; opt out with NO_HYPERLINKS=1

**Config health widget** (\`display.health: true\`)
- Surfaces silent fallbacks: theme in named-ANSI, powerline in named-ANSI, missing GSD STATE.md
- Right-side placement, dropped silently on narrow terminals

### Behind the scenes

- All 4 PRs (#41, #45, #47, plus follow-up #48) reviewed pre-merge by Opus
- 440 tests, 36 test files, all green
- Two reviewer-flagged Critical bugs fixed before merge: \`dirname\` walk, context-bar bg destruction
- One PR (#46 incremental transcript parsing) deferred to v0.7+ per pre-merge review (3 Critical findings, needs rework)

### Test plan
- [x] 440/440 tests passing
- [x] \`npm run lint\` clean
- [x] CHANGELOG.md \`[0.6.0]\` section + compare links
- [x] package.json bumped to 0.6.0
- [ ] Release workflow auto-tags + publishes to npm on merge to main
- [ ] Back-merge main → develop after release lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)