### PR TITLE
docs: issue templates + CONTRIBUTING + SECURITY

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,92 @@
+name: Bug report
+description: Something rendered wrong, crashed, or behaved unexpectedly.
+title: "[bug]: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: One or two sentences. What did you expect, what did you see instead?
+      placeholder: "Powerline mode renders the directory segment without a background on iTerm2"
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: Screenshot or terminal output
+      description: |
+        A screenshot of the broken statusline is the fastest way to triage. Attach an image, or paste the
+        rendered output (if you can copy it from your terminal scrollback).
+      placeholder: drop image here, or paste raw output
+
+  - type: input
+    id: version
+    attributes:
+      label: lumira version
+      description: Run `npx lumira --version` (or check `~/.config/lumira/config.json` mtime against your last update).
+      placeholder: "0.6.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: CLI host
+      options:
+        - Claude Code (CLI)
+        - Claude Code (VS Code extension)
+        - Qwen Code
+        - Other (specify in description)
+    validations:
+      required: true
+
+  - type: input
+    id: terminal
+    attributes:
+      label: Terminal + OS
+      description: e.g. "iTerm2 3.5 / macOS 14", "WezTerm / Linux", "Windows Terminal / Windows 11"
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: lumira config
+      description: |
+        Paste the contents of `~/.config/lumira/config.json` (or note "default config" if you didn't customize).
+        **Redact API keys / secrets** if you have any in there (you shouldn't — lumira doesn't ask for them).
+      render: json
+      placeholder: |
+        {
+          "preset": "balanced",
+          "theme": "tokyo-night",
+          "style": "powerline"
+        }
+    validations:
+      required: true
+
+  - type: textarea
+    id: debug
+    attributes:
+      label: LUMIRA_DEBUG output (optional but very helpful)
+      description: |
+        Run with `LUMIRA_DEBUG=1` set and paste the stderr output. This shows cache hits, GSD state resolution,
+        transcript parsing decisions, etc. — usually points right at the bug.
+
+        ```bash
+        LUMIRA_DEBUG=1 claude 2> /tmp/lumira.log
+        # then paste the contents of /tmp/lumira.log
+        ```
+      render: text
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce (if you can)
+      description: Optional but helpful for non-obvious cases.
+      placeholder: |
+        1. Set theme to "nord" and style to "powerline"
+        2. Resize terminal to 80 cols
+        3. Statusline wraps onto a 4th line

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📚 Documentation
+    url: https://github.com/cativo23/lumira#readme
+    about: README has setup, configuration, theme, and powerline docs.
+  - name: 🔒 Security issues
+    url: https://github.com/cativo23/lumira/security/advisories/new
+    about: Report security vulnerabilities privately, not as a public issue.
+  - name: 💬 Discussions
+    url: https://github.com/cativo23/lumira/discussions
+    about: Open-ended questions, ideas, "is this a bug?" — start a discussion if unsure.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: Feature request
+description: Suggest a new feature, signal, or visual variant.
+title: "[feat]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: |
+        Lead with the pain. "I want X" is harder to triage than "when I do Y, I can't tell whether Z".
+      placeholder: "I can't tell at a glance which sub-agent is running — the agent name gets truncated past 15 chars"
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What would the fix or new feature look like? A new toggle, a new segment, a config field?
+      placeholder: |
+        Add `display.agentFull` to render the full agent name on its own line, gated to powerline mode.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What else did you try, or what would be the simpler workaround?
+      placeholder: |
+        - Resize terminal wider — works but loses screen space.
+        - Hide other segments via `display.*: false` — works but gives up other signals.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: lumira is a Claude Code statusline. Things that aren't in scope.
+      options:
+        - "✅ Statusline rendering / new signal"
+        - "✅ Theme or visual variant"
+        - "✅ Claude Code integration (transcript / GSD / rate limits)"
+        - "❓ Not sure"
+        - "🚫 Shell prompt features (zsh/fish/etc — out of scope)"
+        - "🚫 Cross-Claude-version testing (out of scope)"
+    validations:
+      required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to lumira
+
+Thanks for the interest. lumira is a statusline plugin for [Claude Code](https://code.claude.com), narrow scope on purpose. Most contributions land best as themes or small renderer tweaks.
+
+## Setup (3 commands)
+
+```bash
+git clone https://github.com/cativo23/lumira.git
+cd lumira && npm install
+npm test                # 440+ tests, should all pass on a fresh clone
+```
+
+Other useful scripts:
+
+```bash
+npm run dev             # tsc --watch
+npm run lint            # tsc --noEmit
+npm run test:watch      # vitest in watch mode
+npm run test:coverage   # vitest with coverage report
+npm run build           # compile to dist/
+```
+
+## Branching (gitflow)
+
+- **`main`** — released versions, tagged. Don't open PRs against main directly.
+- **`develop`** — integration branch. **Open PRs here.**
+- **Feature branches** — `feature/<name>`, `fix/<name>`, `docs/<name>`. Branch off `develop`.
+
+Releases come from `release/vX.Y.Z` branches that get cut from `develop` by maintainers. After a release lands on `main`, it's back-merged to `develop` to keep the lines in sync.
+
+## Commit style
+
+Conventional Commits: `type(scope): subject`.
+
+```
+feat(render): add support for striped powerline separator
+fix(parsers): use dirname for STATE.md walk
+docs(readme): document NO_HYPERLINKS env var
+test(transcript): cover the file-rotation edge case
+chore(deps): bump @types/node to 25.7
+```
+
+Subject in present tense, no trailing period. Wrap the body at 72 cols if you write one.
+
+## Adding a theme
+
+This is the most common contribution path. Five steps:
+
+1. Pick a name and a palette. Real themes only — Dracula, Nord, Catppuccin etc. all have official color specs. Don't invent a "lumira-special" theme without a reference.
+
+2. Open `src/themes.ts`. Each theme exports 8 fg colors (cyan, magenta, yellow, green, orange, red, brightBlue, gray) plus an optional `powerline` palette with 6 backgrounds (modelBg, dirBg, branchCleanBg, branchDirtyBg, taskBg, versionBg).
+
+3. Pick the bg colors so:
+   - White text is legible on every background — **WCAG AA contrast ≥4.5:1**. Use [contrast-ratio.com](https://contrast-ratio.com/) or any contrast checker.
+   - Each segment background is visibly distinct from its neighbours — `modelBg` and `dirBg` shouldn't both be "muted blue", they should be in different hue families.
+
+4. Add the theme name to `tests/themes.test.ts` (the catalog test that asserts every theme has the required fields).
+
+5. Run `npm test` — all 440+ tests should pass.
+
+Then open a PR against `develop` with the diff. PRs that don't add tests for new behavior won't be merged.
+
+## TypeScript / code style
+
+- Strict mode (`tsconfig.json` is the source of truth — don't relax it).
+- ESM only (`type: "module"` in package.json).
+- **Zero runtime dependencies** is a hard rule. devDependencies are fine; runtime deps are a non-starter. The whole point of lumira is that it runs anywhere with Node 18+.
+- TDD: tests for new behavior land in the same PR as the code. Bug fixes land with a regression test that proves the bug.
+
+## Getting code review
+
+PRs run CI on push. When tests + typecheck go green, the PR is **ready for review** but **not auto-merged**. A maintainer (currently just [@cativo23](https://github.com/cativo23)) will pick it up.
+
+**Substantial PRs** (anything beyond a theme or single-line fix) are reviewed by an Opus-class agent before a human review pass. Findings get applied as follow-up commits on the same branch before merge. This is just to keep the bar high while the project has one maintainer; expect ~24h turnaround.
+
+## What's out of scope
+
+- Shell prompt features (zsh/fish/etc.) — lumira is a Claude Code/Qwen Code statusline, not a shell prompt.
+- Cross-Claude-version test matrix — we test against the current Claude Code release, not historical ones.
+- Plugin / custom-segment marketplace — hold off until at least 3 users request it.
+- Auto-update / self-update — npm handles this.
+- Telemetry — never.
+
+## Questions
+
+[Open a discussion](https://github.com/cativo23/lumira/discussions). For security issues, see [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security
+
+## Reporting a vulnerability
+
+**Don't open a public issue for security problems.**
+
+Use GitHub's [private security advisory form](https://github.com/cativo23/lumira/security/advisories/new) instead. The maintainer ([@cativo23](https://github.com/cativo23)) will respond within ~48 hours.
+
+If you can't use the GitHub form, you can email the maintainer directly via the address listed on [their GitHub profile](https://github.com/cativo23).
+
+## What's in scope
+
+lumira reads JSON from stdin (provided by Claude Code or Qwen Code) and writes ANSI text to stdout. The threat surface is small but real:
+
+- **Terminal control-character injection** — fields from stdin like `cwd`, `agent.name`, `worktree.name`, `output_style.name`, `version`, etc. are written into the rendered statusline. lumira sanitizes these via `sanitizeTermString()` (strips C0/C1/DEL control chars) before rendering. A bug that bypasses this guard is in scope.
+- **Path traversal in OSC 8 hyperlinks** — `cwd` is wrapped in a `file://` URL via `pathToFileURL()`, which percent-encodes path components. A way to inject arbitrary URL schemes via crafted stdin is in scope.
+- **Symlink / TOCTOU in transcript or GSD parsing** — lumira reads `transcript_path` and walks up the directory tree looking for `.planning/STATE.md`. A way to make it read files outside the user's home + tmp directories, or trigger writes, is in scope.
+- **Resource exhaustion** — a way to make lumira consume unbounded memory or CPU on a single tick is in scope (statusline blocks the user's prompt while running).
+- **Dependency confusion** — lumira ships with **zero runtime dependencies** by design. A PR or release that introduces a runtime dependency without explicit maintainer review is in scope (and shouldn't happen in practice).
+
+## What's NOT in scope
+
+- **Confidentiality of stdin contents** — lumira processes whatever Claude Code / Qwen Code sends. If your CLI sends secrets in stdin (it shouldn't), that's a host-CLI bug, not a lumira bug.
+- **Theft of npm credentials** — out of scope of the project; reports about npm itself go to npm Inc.
+- **Vulnerabilities in `node` / `npm` / Claude Code itself** — out of scope. Report to those projects directly.
+- **Social engineering, phishing of the maintainer** — out of scope.
+
+## Disclosure timeline
+
+For confirmed vulnerabilities:
+
+1. We acknowledge within 48 hours.
+2. We assess severity and target a fix within 7 days for Critical, 30 days for everything else.
+3. We coordinate disclosure: a private patch lands first (a `release/vX.Y.Z` branch, merged when ready), then a public advisory + CVE if applicable, then a follow-up release note in `CHANGELOG.md` under a `### Security` heading.
+
+You'll be credited in the advisory and changelog unless you ask not to be.


### PR DESCRIPTION
## Summary
Repo-meta needed before npm-downloads bump turns into issue noise. Pure docs/templates, no code.

## What's added

**\`.github/ISSUE_TEMPLATE/\`**
- \`bug_report.yml\` — GH form schema. Required: version, CLI host, terminal+OS, config dump. Optional: screenshot, \`LUMIRA_DEBUG\` log, repro steps. Filters \"no funciona xd\" into actionable triage data.
- \`feature_request.yml\` — leads with problem (not solution), includes scope dropdown that explicitly flags out-of-scope categories (shell prompts, cross-version testing).
- \`config.yml\` — contact links to docs, private security advisories, and discussions.

**\`CONTRIBUTING.md\`** — short. 3-command setup, gitflow basics (PR to develop), conventional commits, and the \"how to add a theme\" walkthrough (most common contribution path). Explicit out-of-scope list — protects narrow focus from feature creep PRs.

**\`SECURITY.md\`** — points to GH private advisory form, scopes threat surface (terminal control-char injection, OSC 8 path traversal, GSD walk traversal, resource exhaustion), sets 48h ack + 7d/30d fix targets.

## Why now
v0.6.0 just shipped. 416 npm downloads/week pre-release. First PRs from external users are likely soon — this is the cheapest way to keep signal high.

## Test plan
- [ ] Verify forms render correctly on a draft issue (\`gh issue create --web\`)
- [ ] All file links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)