### PR TITLE
ci: lock coverage floor + bundle size ceiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,23 @@ jobs:
         with:
           node-version: 22
       - run: npm ci
-      - run: npm test
+      # Coverage thresholds enforced via vitest.config.ts. A drop below
+      # the configured floors (lines 87, statements 85, branches 75,
+      # functions 80) fails this step.
+      - run: npm run test:coverage
+      - run: npm run lint
       - run: npm run build
+      # Bundle size guard: dist/ ships to npm. Currently ~280 KB; the
+      # ceiling is set to 350 KB so meaningful growth is a deliberate
+      # decision rather than accidental. Raise alongside the corresponding
+      # PR if a feature genuinely needs the headroom.
+      - name: Bundle size guard
+        env:
+          CEILING: '358400'
+        run: |
+          SIZE=$(du -sb dist/ | cut -f1)
+          echo "dist/ size: $SIZE bytes (ceiling: $CEILING)"
+          if [ "$SIZE" -gt "$CEILING" ]; then
+            echo "::error::dist/ exceeded ceiling — raise it in ci.yml if intentional"
+            exit 1
+          fi

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,16 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],
+      // Floors set ~3% below current values (lines 90.08, statements 88.76,
+      // branches 79.10) so normal churn doesn't fail CI but a meaningful drop
+      // does. Raise these as coverage improves; never lower without a PR
+      // that justifies it in the description.
+      thresholds: {
+        lines: 87,
+        statements: 85,
+        branches: 75,
+        functions: 80,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
Two CI guards before the post-v0.6.0 contribution flow opens up.

## Coverage thresholds (vitest.config.ts)
Set ~3% below current actuals so normal churn doesn't trip CI but a meaningful drop does. Raise as coverage improves.

| Metric | Floor | Current |
|---|---|---|
| Lines | 87 | 90.08 |
| Statements | 85 | 88.76 |
| Functions | 80 | 85.02 |
| Branches | 75 | 79.10 |

## Bundle size guard (ci.yml)
\`dist/\` ships to npm. Currently ~280 KB. Ceiling 350 KB. CI fails if \`du -sb dist/\` exceeds it. Raise alongside the corresponding PR if a feature genuinely needs the headroom.

## Other
CI also runs \`npm run lint\` (typecheck) explicitly — was missing, only ran implicitly via build. Switched \`npm test\` → \`npm run test:coverage\` so thresholds fire on every PR.

## Test plan
- [x] \`npm run test:coverage\` passes locally with thresholds enforced
- [x] \`du -sb dist/\` returns ~286 KB (well under ceiling)
- [ ] CI run on this PR validates the full pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)