### PR TITLE
fix(wizard): preview shows distinct output per preset

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -116,7 +116,7 @@ const PRESET_DEFS: Record<NonNullable<HudConfig['preset']>, PresetDef> = {
   },
 };
 
-function applyPreset(r: HudConfig, preset: NonNullable<HudConfig['preset']>): void {
+export function applyPreset(r: HudConfig, preset: NonNullable<HudConfig['preset']>): void {
   const def = PRESET_DEFS[preset];
   r.preset = preset;
   r.layout = def.layout;

--- a/src/tui/preview.ts
+++ b/src/tui/preview.ts
@@ -1,6 +1,7 @@
 import { render as defaultRender } from '../render/index.js';
 import { resolveIcons } from '../render/icons.js';
 import { normalize } from '../normalize.js';
+import { applyPreset } from '../config.js';
 import {
   DEFAULT_CONFIG,
   DEFAULT_DISPLAY,
@@ -23,21 +24,19 @@ export interface BuildPreviewDeps {
 }
 
 function buildMockContext(opts: PreviewOpts): RenderContext {
-  // Determine layout from preset (mirrors applyPreset logic without importing it)
-  let layout: HudConfig['layout'] = 'auto';
-  if (opts.preset === 'minimal') layout = 'singleline';
-  else if (opts.preset === 'full') layout = 'multiline';
-  else if (opts.preset === 'balanced') layout = 'auto';
-
+  // Build a fresh HudConfig and run it through `applyPreset` so the wizard
+  // preview matches what users actually get when they pick a preset. The
+  // earlier shortcut only mirrored `layout`, leaving the display toggles
+  // at their defaults — `full` and `balanced` then rendered identically
+  // because both had every segment enabled.
   const config: HudConfig = {
     ...DEFAULT_CONFIG,
-    layout,
-    preset: opts.preset,
     icons: opts.icons,
     theme: opts.theme,
     display: { ...DEFAULT_DISPLAY },
     colors: { mode: opts.colorMode ?? 'truecolor' },
   };
+  applyPreset(config, opts.preset);
 
   // Build a realistic raw Claude Code input that normalize() can consume.
   // Fill every field that renderers access via ctx.input.* or ctx.input.raw.*

--- a/tests/tui/preview.test.ts
+++ b/tests/tui/preview.test.ts
@@ -29,4 +29,19 @@ describe('buildPreview', () => {
     });
     expect(out).toBe('(preview unavailable)');
   });
+
+  it('full preset shows segments that balanced suppresses (regression)', () => {
+    // Pre-fix the wizard preview only mirrored layout, leaving every
+    // display toggle on for both presets. The two outputs were identical
+    // at typical wizard widths. After applyPreset is invoked correctly,
+    // balanced suppresses burnRate, duration, tokenSpeed, linesChanged,
+    // sessionName, version, memory, contextTokens, cacheMetrics — so the
+    // outputs must differ.
+    const full = buildPreview({ preset: 'full', icons: 'nerd' });
+    const balanced = buildPreview({ preset: 'balanced', icons: 'nerd' });
+    expect(full).not.toBe(balanced);
+    // Sanity: full keeps the burn-rate suffix, balanced drops it
+    expect(full).toMatch(/\$\d+\.\d+\/h/);
+    expect(balanced).not.toMatch(/\$\d+\.\d+\/h/);
+  });
 });


### PR DESCRIPTION
## Bug
Reported by @cativo23: \`full\` and \`balanced\` rendered identically in the install wizard preview.

## Root cause
\`buildMockContext\` in \`src/tui/preview.ts\` only mirrored the preset's \`layout\` field. The \`display\` toggles stayed at defaults (everything on), so the visible output for both presets was the same set of segments at typical wizard widths.

## Fix
Export \`applyPreset\` from \`src/config.ts\` and call it directly in the wizard preview. Now the preview goes through the same code path as a real config load — \`balanced\` correctly suppresses \`burnRate\`, \`duration\`, \`tokenSpeed\`, \`linesChanged\`, \`sessionName\`, \`version\`, \`memory\`, \`contextTokens\`, \`cacheMetrics\`, matching what users actually get after install.

## Why this matters
The wizard is the first thing new users see (\`npx lumira install\`). Showing them three options that look identical undermines trust in the picker. The CLI flags (\`--full\` / \`--balanced\` / \`--minimal\`) were never affected — only the wizard preview was visually broken.

## Test plan
- [x] Regression test in \`tests/tui/preview.test.ts\` asserts \`full\` ≠ \`balanced\` and that \`balanced\` drops the burn-rate suffix.
- [x] All 441 tests pass.
- [x] Manual: \`echo … | node dist/index.js --full\` and \`--balanced\` confirmed produce different output (CLI side was already correct).

## Risk
Tiny — three-line diff in \`config.ts\` (one keyword change), preview rewrite drops 5 lines and adds a single \`applyPreset\` call. No public API changes; \`applyPreset\` was already part of the \`mergeCliFlags\` flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)