### PR TITLE
release: v0.6.1 (wizard preview hotfix)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,92 @@
+name: Bug report
+description: Something rendered wrong, crashed, or behaved unexpectedly.
+title: "[bug]: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: One or two sentences. What did you expect, what did you see instead?
+      placeholder: "Powerline mode renders the directory segment without a background on iTerm2"
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: Screenshot or terminal output
+      description: |
+        A screenshot of the broken statusline is the fastest way to triage. Attach an image, or paste the
+        rendered output (if you can copy it from your terminal scrollback).
+      placeholder: drop image here, or paste raw output
+
+  - type: input
+    id: version
+    attributes:
+      label: lumira version
+      description: Run `npx lumira --version` (or check `~/.config/lumira/config.json` mtime against your last update).
+      placeholder: "0.6.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: CLI host
+      options:
+        - Claude Code (CLI)
+        - Claude Code (VS Code extension)
+        - Qwen Code
+        - Other (specify in description)
+    validations:
+      required: true
+
+  - type: input
+    id: terminal
+    attributes:
+      label: Terminal + OS
+      description: e.g. "iTerm2 3.5 / macOS 14", "WezTerm / Linux", "Windows Terminal / Windows 11"
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: lumira config
+      description: |
+        Paste the contents of `~/.config/lumira/config.json` (or note "default config" if you didn't customize).
+        **Redact API keys / secrets** if you have any in there (you shouldn't — lumira doesn't ask for them).
+      render: json
+      placeholder: |
+        {
+          "preset": "balanced",
+          "theme": "tokyo-night",
+          "style": "powerline"
+        }
+    validations:
+      required: true
+
+  - type: textarea
+    id: debug
+    attributes:
+      label: LUMIRA_DEBUG output (optional but very helpful)
+      description: |
+        Run with `LUMIRA_DEBUG=1` set and paste the stderr output. This shows cache hits, GSD state resolution,
+        transcript parsing decisions, etc. — usually points right at the bug.
+
+        ```bash
+        LUMIRA_DEBUG=1 claude 2> /tmp/lumira.log
+        # then paste the contents of /tmp/lumira.log
+        ```
+      render: text
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce (if you can)
+      description: Optional but helpful for non-obvious cases.
+      placeholder: |
+        1. Set theme to "nord" and style to "powerline"
+        2. Resize terminal to 80 cols
+        3. Statusline wraps onto a 4th line

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📚 Documentation
+    url: https://github.com/cativo23/lumira#readme
+    about: README has setup, configuration, theme, and powerline docs.
+  - name: 🔒 Security issues
+    url: https://github.com/cativo23/lumira/security/advisories/new
+    about: Report security vulnerabilities privately, not as a public issue.
+  - name: 💬 Discussions
+    url: https://github.com/cativo23/lumira/discussions
+    about: Open-ended questions, ideas, "is this a bug?" — start a discussion if unsure.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: Feature request
+description: Suggest a new feature, signal, or visual variant.
+title: "[feat]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: |
+        Lead with the pain. "I want X" is harder to triage than "when I do Y, I can't tell whether Z".
+      placeholder: "I can't tell at a glance which sub-agent is running — the agent name gets truncated past 15 chars"
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What would the fix or new feature look like? A new toggle, a new segment, a config field?
+      placeholder: |
+        Add `display.agentFull` to render the full agent name on its own line, gated to powerline mode.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What else did you try, or what would be the simpler workaround?
+      placeholder: |
+        - Resize terminal wider — works but loses screen space.
+        - Hide other segments via `display.*: false` — works but gives up other signals.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: lumira is a Claude Code statusline. Things that aren't in scope.
+      options:
+        - "✅ Statusline rendering / new signal"
+        - "✅ Theme or visual variant"
+        - "✅ Claude Code integration (transcript / GSD / rate limits)"
+        - "❓ Not sure"
+        - "🚫 Shell prompt features (zsh/fish/etc — out of scope)"
+        - "🚫 Cross-Claude-version testing (out of scope)"
+    validations:
+      required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,23 @@ jobs:
         with:
           node-version: 22
       - run: npm ci
-      - run: npm test
+      # Coverage thresholds enforced via vitest.config.ts. A drop below
+      # the configured floors (lines 87, statements 85, branches 75,
+      # functions 80) fails this step.
+      - run: npm run test:coverage
+      - run: npm run lint
       - run: npm run build
+      # Bundle size guard: dist/ ships to npm. Currently ~280 KB; the
+      # ceiling is set to 350 KB so meaningful growth is a deliberate
+      # decision rather than accidental. Raise alongside the corresponding
+      # PR if a feature genuinely needs the headroom.
+      - name: Bundle size guard
+        env:
+          CEILING: '358400'
+        run: |
+          SIZE=$(du -sb dist/ | cut -f1)
+          echo "dist/ size: $SIZE bytes (ceiling: $CEILING)"
+          if [ "$SIZE" -gt "$CEILING" ]; then
+            echo "::error::dist/ exceeded ceiling — raise it in ci.yml if intentional"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-04-30
+
+### Fixed
+- **Install wizard now shows distinct previews per preset.** `full` and `balanced` rendered identically because `buildMockContext` only mirrored the preset's layout while leaving every display toggle at its default. The wizard now goes through the same `applyPreset` code path as `loadConfig` / `mergeCliFlags`, so each preset shows the actual segment set users will see after install. CLI flags (`--full` / `--balanced` / `--minimal`) were never affected.
+
 ## [0.6.0] - 2026-04-30
 
 ### Added
@@ -195,7 +200,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GSD session IDs sanitized against path traversal
 - `execFile` used instead of `exec` to prevent shell injection (except terminal width detection where shell redirect is required with procfs-sourced paths)
 
-[Unreleased]: https://github.com/cativo23/lumira/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/cativo23/lumira/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/cativo23/lumira/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/cativo23/lumira/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/cativo23/lumira/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/cativo23/lumira/compare/v0.3.2...v0.4.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to lumira
+
+Thanks for the interest. lumira is a statusline plugin for [Claude Code](https://code.claude.com), narrow scope on purpose. Most contributions land best as themes or small renderer tweaks.
+
+## Setup (3 commands)
+
+```bash
+git clone https://github.com/cativo23/lumira.git
+cd lumira && npm install
+npm test                # 440+ tests, should all pass on a fresh clone
+```
+
+Other useful scripts:
+
+```bash
+npm run dev             # tsc --watch
+npm run lint            # tsc --noEmit
+npm run test:watch      # vitest in watch mode
+npm run test:coverage   # vitest with coverage report
+npm run build           # compile to dist/
+```
+
+## Branching (gitflow)
+
+- **`main`** — released versions, tagged. Don't open PRs against main directly.
+- **`develop`** — integration branch. **Open PRs here.**
+- **Feature branches** — `feature/<name>`, `fix/<name>`, `docs/<name>`. Branch off `develop`.
+
+Releases come from `release/vX.Y.Z` branches that get cut from `develop` by maintainers. After a release lands on `main`, it's back-merged to `develop` to keep the lines in sync.
+
+## Commit style
+
+Conventional Commits: `type(scope): subject`.
+
+```
+feat(render): add support for striped powerline separator
+fix(parsers): use dirname for STATE.md walk
+docs(readme): document NO_HYPERLINKS env var
+test(transcript): cover the file-rotation edge case
+chore(deps): bump @types/node to 25.7
+```
+
+Subject in present tense, no trailing period. Wrap the body at 72 cols if you write one.
+
+## Adding a theme
+
+This is the most common contribution path. Five steps:
+
+1. Pick a name and a palette. Real themes only — Dracula, Nord, Catppuccin etc. all have official color specs. Don't invent a "lumira-special" theme without a reference.
+
+2. Open `src/themes.ts`. Each theme exports 8 fg colors (cyan, magenta, yellow, green, orange, red, brightBlue, gray) plus an optional `powerline` palette with 6 backgrounds (modelBg, dirBg, branchCleanBg, branchDirtyBg, taskBg, versionBg).
+
+3. Pick the bg colors so:
+   - White text is legible on every background — **WCAG AA contrast ≥4.5:1**. Use [contrast-ratio.com](https://contrast-ratio.com/) or any contrast checker.
+   - Each segment background is visibly distinct from its neighbours — `modelBg` and `dirBg` shouldn't both be "muted blue", they should be in different hue families.
+
+4. Add the theme name to `tests/themes.test.ts` (the catalog test that asserts every theme has the required fields).
+
+5. Run `npm test` — all 440+ tests should pass.
+
+Then open a PR against `develop` with the diff. PRs that don't add tests for new behavior won't be merged.
+
+## TypeScript / code style
+
+- Strict mode (`tsconfig.json` is the source of truth — don't relax it).
+- ESM only (`type: "module"` in package.json).
+- **Zero runtime dependencies** is a hard rule. devDependencies are fine; runtime deps are a non-starter. The whole point of lumira is that it runs anywhere with Node 18+.
+- TDD: tests for new behavior land in the same PR as the code. Bug fixes land with a regression test that proves the bug.
+
+## Getting code review
+
+PRs run CI on push. When tests + typecheck go green, the PR is **ready for review** but **not auto-merged**. A maintainer (currently just [@cativo23](https://github.com/cativo23)) will pick it up.
+
+**Substantial PRs** (anything beyond a theme or single-line fix) are reviewed by an Opus-class agent before a human review pass. Findings get applied as follow-up commits on the same branch before merge. This is just to keep the bar high while the project has one maintainer; expect ~24h turnaround.
+
+## What's out of scope
+
+- Shell prompt features (zsh/fish/etc.) — lumira is a Claude Code/Qwen Code statusline, not a shell prompt.
+- Cross-Claude-version test matrix — we test against the current Claude Code release, not historical ones.
+- Plugin / custom-segment marketplace — hold off until at least 3 users request it.
+- Auto-update / self-update — npm handles this.
+- Telemetry — never.
+
+## Questions
+
+[Open a discussion](https://github.com/cativo23/lumira/discussions). For security issues, see [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -11,12 +11,16 @@ Real-time statusline plugin for [Claude Code](https://code.claude.com) and Qwen 
 ## Features
 
 - **3-line custom mode** + **1-line minimal mode** (auto-switches at <70 columns)
-- **Context bar** with color thresholds (green → yellow → orange → blinking red)
-- **Git status** with branch, staged/modified/untracked counts (5s TTL cache)
+- **Powerline mode** — opt-in colored segments with 7 separator presets (`arrow`, `flame`, `slant`, `round`, `diamond`, `compatible`, `plain`) across all 3 lines
+- **OSC 8 hyperlinks** — clickable directory (file://) and version (npm) on supported terminals (iTerm2, WezTerm, Kitty, VS Code, Alacritty)
+- **7 built-in themes** — `dracula`, `nord`, `tokyo-night`, `catppuccin`, `monokai`, `gruvbox`, `solarized` with hand-curated powerline palettes
+- **Context bar** with color thresholds (green → yellow → orange → blinking red) and actionable `/compact?` hint at high fill
+- **Git status** with branch, staged/modified/untracked counts (5s TTL cache); branch turns red on dirty repos in powerline mode
 - **Token metrics** — input/output counts, speed (tok/s), cost + burn rate ($/h)
 - **Rate limits** — 5h/7d usage with color warnings and reset countdown
 - **Transcript parsing** — active tools, agents, and todo progress
 - **GSD integration** — current task and update notifications
+- **Config health widget** (opt-in) — surfaces silent fallbacks (theme/powerline in named-ANSI, missing GSD STATE.md)
 - **Memory usage** display
 - **Nerd Font icons** throughout
 - **3-tier color system** — named ANSI, 256-color, truecolor (auto-detected)
@@ -91,21 +95,38 @@ If installed from source:
 my-project |  main | Opus 4.6 | ████░░░░░░░░░░░░░░░░ 21% | 131k↑ 25k↓ | $1.31
 ```
 
+### Powerline Mode (opt-in via `style: "powerline"`)
+
+```
+  Opus 4.6   main    my-project   Fix the bug   v2.1.92
+ ████░░░░░░░░░░░░░░░░ 21%   131k↑ 25k↓   $1.31    35m06s
+ ✓ Read ×3   ✓ Edit ×2    ████████░░ 8/10
+```
+
+Each segment renders with a distinct background colour drawn from the active theme; segments are separated by a Nerd Font glyph (default ``). On dirty git repos the branch segment turns red. Falls back to classic mode silently in named-ANSI terminals (powerline needs RGB backgrounds). See [Powerline](#powerline) below for the 7 separator styles.
+
 ## Configuration
 
 Create `~/.config/lumira/config.json`:
 
 ```json
 {
-  "layout": "auto",
+  "preset": "balanced",
+  "theme": "tokyo-night",
+  "icons": "nerd",
+  "style": "classic",
+  "powerline": { "style": "auto" },
   "gsd": false,
+  "colors": { "mode": "auto" },
   "display": {
     "model": true,
     "branch": true,
     "gitChanges": true,
     "directory": true,
     "contextBar": true,
+    "contextTokens": true,
     "tokens": true,
+    "cacheMetrics": true,
     "cost": true,
     "burnRate": true,
     "duration": true,
@@ -113,6 +134,7 @@ Create `~/.config/lumira/config.json`:
     "rateLimits": true,
     "tools": true,
     "todos": true,
+    "mcp": true,
     "vim": true,
     "effort": true,
     "worktree": true,
@@ -121,23 +143,58 @@ Create `~/.config/lumira/config.json`:
     "style": true,
     "version": true,
     "linesChanged": true,
-    "memory": true
-  },
-  "colors": {
-    "mode": "auto"
+    "memory": true,
+    "health": false
   }
 }
 ```
 
-All fields are optional — defaults are shown above.
+All fields are optional — defaults are shown above. `display.health` defaults to `false` (opt-in widget).
 
 ### CLI Flags
 
 ```bash
-lumira --minimal    # Force single-line mode
-lumira --balanced   # Force balanced preset
-lumira --full       # Force full multi-line preset
-lumira --gsd        # Enable GSD integration
+lumira --minimal                    # Force single-line mode
+lumira --balanced                   # Force balanced preset
+lumira --full                       # Force full multi-line preset
+lumira --gsd                        # Enable GSD integration
+lumira --powerline                  # Enable powerline visual style
+lumira --classic                    # Force classic (pipe-separated) line 1
+lumira --powerline-style=arrow      # Pick separator: arrow|flame|slant|round|diamond|compatible|plain|auto
+lumira --icons=nerd|emoji|none      # Override icon set
+lumira --preset=full|balanced|minimal
+```
+
+## Powerline
+
+`style: "powerline"` (or `--powerline`) renders the statusline with colored segment backgrounds and glyph separators inspired by powerline-go / oh-my-posh. Available separator presets via `powerline.style` (or `--powerline-style=<name>`):
+
+| Style | Look |
+|---|---|
+| `arrow` | classic right-pointing triangle separator (default) |
+| `flame` | wavy flame-shaped separator |
+| `slant` | forward-slanting separator |
+| `round` | rounded caps at line ends + thin internal separators |
+| `diamond` | each segment isolated as its own pill with rounded caps |
+| `compatible` | unicode `▶` separator (no Nerd Font required) |
+| `plain` | no separator glyphs — just colored blocks |
+| `auto` | picks `arrow` if Nerd Font icons are configured, else `compatible` |
+
+### Themes
+
+Pick one of the 7 built-in themes via `theme: "<name>"` in config or during `lumira install`:
+
+`dracula` · `nord` · `tokyo-night` · `catppuccin` · `monokai` · `gruvbox` · `solarized`
+
+Each theme ships with a hand-curated **powerline palette** (per-segment background colors) that meets WCAG AA contrast for white foreground. Themes apply in truecolor and 256-color terminals; named-ANSI terminals fall back to default colors (8 base hues can't represent arbitrary palettes).
+
+### Hyperlinks (OSC 8)
+
+The directory on line 1 becomes a clickable `file://` link, and the version tag links to its npm release page on terminals that support [OSC 8](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) (iTerm2, WezTerm, Kitty, Alacritty, VS Code terminal, tmux ≥3.4 with passthrough). Other terminals show plain text. Auto-disabled in `Apple_Terminal` (which leaks markers) and `TERM=dumb`.
+
+```bash
+NO_HYPERLINKS=1 claude    # disable
+FORCE_HYPERLINK=1 claude  # force-enable (overrides denylist)
 ```
 
 ### Qwen Code

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security
+
+## Reporting a vulnerability
+
+**Don't open a public issue for security problems.**
+
+Use GitHub's [private security advisory form](https://github.com/cativo23/lumira/security/advisories/new) instead. The maintainer ([@cativo23](https://github.com/cativo23)) will respond within ~48 hours.
+
+If you can't use the GitHub form, you can email the maintainer directly via the address listed on [their GitHub profile](https://github.com/cativo23).
+
+## What's in scope
+
+lumira reads JSON from stdin (provided by Claude Code or Qwen Code) and writes ANSI text to stdout. The threat surface is small but real:
+
+- **Terminal control-character injection** — fields from stdin like `cwd`, `agent.name`, `worktree.name`, `output_style.name`, `version`, etc. are written into the rendered statusline. lumira sanitizes these via `sanitizeTermString()` (strips C0/C1/DEL control chars) before rendering. A bug that bypasses this guard is in scope.
+- **Path traversal in OSC 8 hyperlinks** — `cwd` is wrapped in a `file://` URL via `pathToFileURL()`, which percent-encodes path components. A way to inject arbitrary URL schemes via crafted stdin is in scope.
+- **Symlink / TOCTOU in transcript or GSD parsing** — lumira reads `transcript_path` and walks up the directory tree looking for `.planning/STATE.md`. A way to make it read files outside the user's home + tmp directories, or trigger writes, is in scope.
+- **Resource exhaustion** — a way to make lumira consume unbounded memory or CPU on a single tick is in scope (statusline blocks the user's prompt while running).
+- **Dependency confusion** — lumira ships with **zero runtime dependencies** by design. A PR or release that introduces a runtime dependency without explicit maintainer review is in scope (and shouldn't happen in practice).
+
+## What's NOT in scope
+
+- **Confidentiality of stdin contents** — lumira processes whatever Claude Code / Qwen Code sends. If your CLI sends secrets in stdin (it shouldn't), that's a host-CLI bug, not a lumira bug.
+- **Theft of npm credentials** — out of scope of the project; reports about npm itself go to npm Inc.
+- **Vulnerabilities in `node` / `npm` / Claude Code itself** — out of scope. Report to those projects directly.
+- **Social engineering, phishing of the maintainer** — out of scope.
+
+## Disclosure timeline
+
+For confirmed vulnerabilities:
+
+1. We acknowledge within 48 hours.
+2. We assess severity and target a fix within 7 days for Critical, 30 days for everything else.
+3. We coordinate disclosure: a private patch lands first (a `release/vX.Y.Z` branch, merged when ready), then a public advisory + CVE if applicable, then a follow-up release note in `CHANGELOG.md` under a `### Security` heading.
+
+You'll be credited in the advisory and changelog unless you ask not to be.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "lumira — real-time statusline for Claude Code",
   "type": "module",
   "main": "dist/index.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -116,7 +116,7 @@ const PRESET_DEFS: Record<NonNullable<HudConfig['preset']>, PresetDef> = {
   },
 };
 
-function applyPreset(r: HudConfig, preset: NonNullable<HudConfig['preset']>): void {
+export function applyPreset(r: HudConfig, preset: NonNullable<HudConfig['preset']>): void {
   const def = PRESET_DEFS[preset];
   r.preset = preset;
   r.layout = def.layout;

--- a/src/tui/preview.ts
+++ b/src/tui/preview.ts
@@ -1,6 +1,7 @@
 import { render as defaultRender } from '../render/index.js';
 import { resolveIcons } from '../render/icons.js';
 import { normalize } from '../normalize.js';
+import { applyPreset } from '../config.js';
 import {
   DEFAULT_CONFIG,
   DEFAULT_DISPLAY,
@@ -23,21 +24,19 @@ export interface BuildPreviewDeps {
 }
 
 function buildMockContext(opts: PreviewOpts): RenderContext {
-  // Determine layout from preset (mirrors applyPreset logic without importing it)
-  let layout: HudConfig['layout'] = 'auto';
-  if (opts.preset === 'minimal') layout = 'singleline';
-  else if (opts.preset === 'full') layout = 'multiline';
-  else if (opts.preset === 'balanced') layout = 'auto';
-
+  // Build a fresh HudConfig and run it through `applyPreset` so the wizard
+  // preview matches what users actually get when they pick a preset. The
+  // earlier shortcut only mirrored `layout`, leaving the display toggles
+  // at their defaults — `full` and `balanced` then rendered identically
+  // because both had every segment enabled.
   const config: HudConfig = {
     ...DEFAULT_CONFIG,
-    layout,
-    preset: opts.preset,
     icons: opts.icons,
     theme: opts.theme,
     display: { ...DEFAULT_DISPLAY },
     colors: { mode: opts.colorMode ?? 'truecolor' },
   };
+  applyPreset(config, opts.preset);
 
   // Build a realistic raw Claude Code input that normalize() can consume.
   // Fill every field that renderers access via ctx.input.* or ctx.input.raw.*

--- a/tests/tui/preview.test.ts
+++ b/tests/tui/preview.test.ts
@@ -29,4 +29,19 @@ describe('buildPreview', () => {
     });
     expect(out).toBe('(preview unavailable)');
   });
+
+  it('full preset shows segments that balanced suppresses (regression)', () => {
+    // Pre-fix the wizard preview only mirrored layout, leaving every
+    // display toggle on for both presets. The two outputs were identical
+    // at typical wizard widths. After applyPreset is invoked correctly,
+    // balanced suppresses burnRate, duration, tokenSpeed, linesChanged,
+    // sessionName, version, memory, contextTokens, cacheMetrics — so the
+    // outputs must differ.
+    const full = buildPreview({ preset: 'full', icons: 'nerd' });
+    const balanced = buildPreview({ preset: 'balanced', icons: 'nerd' });
+    expect(full).not.toBe(balanced);
+    // Sanity: full keeps the burn-rate suffix, balanced drops it
+    expect(full).toMatch(/\$\d+\.\d+\/h/);
+    expect(balanced).not.toMatch(/\$\d+\.\d+\/h/);
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,16 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],
+      // Floors set ~3% below current values (lines 90.08, statements 88.76,
+      // branches 79.10) so normal churn doesn't fail CI but a meaningful drop
+      // does. Raise these as coverage improves; never lower without a PR
+      // that justifies it in the description.
+      thresholds: {
+        lines: 87,
+        statements: 85,
+        branches: 75,
+        functions: 80,
+      },
     },
   },
 });


### PR DESCRIPTION
## v0.6.1 — wizard preview hotfix

Patch release fixing the install wizard showing identical previews for \`full\` and \`balanced\` presets. CLI flags were never affected; only the wizard's visual feedback was broken.

### Fixed
- **\`buildMockContext\` now calls \`applyPreset\`** (PR #53) so the wizard preview goes through the same code path as a real config load. Each preset now shows the actual segments users will see after install.

### Risk
- ~20-line diff
- Test coverage: regression test asserts \`full ≠ balanced\` and that \`balanced\` drops the burn-rate suffix
- 441 tests pass; lint clean

### Why hotfix vs roll into v0.7
- Bug visible to every new user running \`npx lumira install\` since v0.5.0
- Fix is tiny + tested — no reason to wait
- v0.6.0 was published 1 hour ago — minimum-friction patch

### Post-merge
- Auto npm publish on merge to main (release.yml workflow)
- Back-merge main → develop after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)