### PR TITLE
release: v0.6.2 (themes subcommand)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-05-01
+
+### Added
+- **`lumira themes` subcommand** — browse and preview the 7 built-in themes from the CLI without touching config. `lumira themes` (or `themes list`) prints names + one-liner descriptions; `lumira themes preview <name>` renders a 3-line sample; `--powerline` and `--style=<arrow|flame|slant|round|diamond|compatible|plain|auto>` toggle the powerline visual; `--all` renders every theme in catalog order (great for screenshots and the upcoming Show & Tell post). `lumira themes help` documents the surface.
+
+### Changed
+- **`POWERLINE_STYLE_NAMES` is now the single source of truth** for the valid powerline style set. `src/config.ts` (JSON validation + `--powerline-style` CLI parser) and `src/render/powerline.ts` (`PowerlineStyleName` type) both derive from it. A new test (`tests/render/powerline.test.ts`) asserts `POWERLINE_STYLES` map keys stay in sync — adding a name to one but not the other now fails CI.
+
+### Fixed
+- **Themes subcommand prototype-pollution guard** — `THEMES['__proto__']` and similar inherited members no longer bypass the unknown-theme check. `Object.prototype.hasOwnProperty.call` is used consistently in `runThemesCommand` and `resolveTheme`.
+- **Themes subcommand error path now writes to stderr** with a non-zero exit code, so `2>/dev/null` and `echo $?` work as users expect.
+- **Control-character sanitization on error banners** — invalid theme names no longer emit raw escape sequences into the user's terminal.
+
 ## [0.6.1] - 2026-04-30
 
 ### Fixed
@@ -200,7 +213,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GSD session IDs sanitized against path traversal
 - `execFile` used instead of `exec` to prevent shell injection (except terminal width detection where shell redirect is required with procfs-sourced paths)
 
-[Unreleased]: https://github.com/cativo23/lumira/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/cativo23/lumira/compare/v0.6.2...HEAD
+[0.6.2]: https://github.com/cativo23/lumira/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/cativo23/lumira/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/cativo23/lumira/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/cativo23/lumira/compare/v0.4.0...v0.5.0

--- a/README.md
+++ b/README.md
@@ -188,6 +188,17 @@ Pick one of the 7 built-in themes via `theme: "<name>"` in config or during `lum
 
 Each theme ships with a hand-curated **powerline palette** (per-segment background colors) that meets WCAG AA contrast for white foreground. Themes apply in truecolor and 256-color terminals; named-ANSI terminals fall back to default colors (8 base hues can't represent arbitrary palettes).
 
+You can browse and preview themes from the CLI without touching your config:
+
+```bash
+lumira themes                                # list all themes with one-line descriptions
+lumira themes preview dracula                # render a sample with the dracula theme
+lumira themes preview nord --powerline       # same in powerline style (default arrow separator)
+lumira themes preview gruvbox --style=flame  # powerline with the flame separator
+lumira themes preview --all                  # render every theme in sequence
+lumira themes preview --all --powerline      # the powerline grid (great for screenshots)
+```
+
 ### Hyperlinks (OSC 8)
 
 The directory on line 1 becomes a clickable `file://` link, and the version tag links to its npm release page on terminals that support [OSC 8](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) (iTerm2, WezTerm, Kitty, Alacritty, VS Code terminal, tmux ≥3.4 with passthrough). Other terminals show plain text. Auto-disabled in `Apple_Terminal` (which leaks markers) and `TERM=dumb`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "lumira — real-time statusline for Claude Code",
   "type": "module",
   "main": "dist/index.js",

--- a/src/commands/themes.ts
+++ b/src/commands/themes.ts
@@ -1,0 +1,126 @@
+import { THEMES, THEME_DESCRIPTIONS } from '../themes.js';
+import { buildPreview, type PreviewOpts } from '../tui/preview.js';
+import { detectColorMode } from '../render/colors.js';
+import type { HudConfig } from '../types.js';
+
+const VALID_POWERLINE_STYLES = [
+  'arrow', 'flame', 'slant', 'round', 'diamond', 'compatible', 'plain', 'auto',
+] as const;
+
+interface ThemesArgs {
+  sub: 'list' | 'preview' | 'help';
+  themeName?: string;
+  powerline: boolean;
+  powerlineStyle?: NonNullable<HudConfig['powerline']>['style'];
+  all: boolean;
+}
+
+export function parseThemesArgs(argv: string[]): ThemesArgs {
+  // argv is the full process.argv; the 'themes' command starts at argv[2],
+  // its sub-subcommand at argv[3], remaining flags from argv[4].
+  const subRaw = argv[3];
+  const sub: ThemesArgs['sub'] =
+    subRaw === 'preview' ? 'preview' :
+    subRaw === 'help' || subRaw === '--help' || subRaw === '-h' ? 'help' :
+    'list';
+
+  let themeName: string | undefined;
+  let powerline = false;
+  let powerlineStyle: ThemesArgs['powerlineStyle'];
+  let all = false;
+
+  for (let i = 4; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--powerline') { powerline = true; continue; }
+    if (arg === '--all') { all = true; continue; }
+    const styleMatch = arg.match(/^--style=(.+)$/);
+    if (styleMatch && VALID_POWERLINE_STYLES.includes(styleMatch[1] as never)) {
+      powerline = true;
+      powerlineStyle = styleMatch[1] as NonNullable<HudConfig['powerline']>['style'];
+      continue;
+    }
+    if (!arg.startsWith('--') && !themeName) {
+      themeName = arg;
+    }
+  }
+
+  return { sub, themeName, powerline, powerlineStyle, all };
+}
+
+function listText(): string {
+  const names = Object.keys(THEMES);
+  const longest = Math.max(...names.map(n => n.length));
+  let out = `Available themes (${names.length}):\n\n`;
+  for (const name of names) {
+    const desc = THEME_DESCRIPTIONS[name] ?? '';
+    out += `  ${name.padEnd(longest + 2)}${desc}\n`;
+  }
+  out += "\nUse 'lumira themes preview <name>' to render a sample.\n";
+  out += 'Add --powerline (optionally --style=<name>) for the powerline style,\n';
+  out += "or --all to preview every theme in one shot (great for screenshots).\n";
+  return out;
+}
+
+function helpText(): string {
+  return [
+    'lumira themes — list, describe, and preview built-in themes',
+    '',
+    'USAGE',
+    '  lumira themes [list]                          List all themes (default)',
+    '  lumira themes preview <name>                  Render a sample with <name>',
+    '  lumira themes preview <name> --powerline      Render with powerline style',
+    '  lumira themes preview <name> --style=<x>      Powerline + specific separator',
+    '  lumira themes preview --all [--powerline]     Render every theme in sequence',
+    '',
+    'THEMES',
+    `  ${Object.keys(THEMES).join(', ')}`,
+    '',
+    'POWERLINE STYLES',
+    `  ${VALID_POWERLINE_STYLES.join(', ')}`,
+    '',
+  ].join('\n');
+}
+
+function previewBlock(name: string, args: ThemesArgs): string {
+  const opts: PreviewOpts = {
+    preset: 'full',
+    theme: name,
+    icons: 'nerd',
+    colorMode: detectColorMode(),
+  };
+  if (args.powerline) {
+    opts.style = 'powerline';
+    opts.powerlineStyle = args.powerlineStyle ?? 'auto';
+  }
+  const banner = `── ${name}${args.powerline ? ` · powerline${args.powerlineStyle ? ` (${args.powerlineStyle})` : ''}` : ''}`;
+  return `${banner}\n${buildPreview(opts)}\n`;
+}
+
+/**
+ * Returns the rendered output for `lumira themes [...]`. Caller is responsible
+ * for writing to stdout. Returns an empty string only on internal failure.
+ */
+export function runThemesCommand(argv: string[]): string {
+  const args = parseThemesArgs(argv);
+
+  if (args.sub === 'help') return helpText();
+  if (args.sub === 'list') return listText();
+
+  // sub === 'preview'
+  if (args.all) {
+    return Object.keys(THEMES).map(n => previewBlock(n, args)).join('\n');
+  }
+
+  if (!args.themeName) {
+    return 'lumira themes preview: missing theme name.\n\n'
+      + "Use 'lumira themes list' to see available themes,\n"
+      + "or 'lumira themes preview --all' to render all of them.\n";
+  }
+
+  if (!THEMES[args.themeName]) {
+    return `lumira themes preview: unknown theme "${args.themeName}".\n\n`
+      + `Available: ${Object.keys(THEMES).join(', ')}\n`;
+  }
+
+  return previewBlock(args.themeName, args);
+}

--- a/src/commands/themes.ts
+++ b/src/commands/themes.ts
@@ -1,18 +1,43 @@
-import { THEMES, THEME_DESCRIPTIONS } from '../themes.js';
+import { THEMES } from '../themes.js';
 import { buildPreview, type PreviewOpts } from '../tui/preview.js';
 import { detectColorMode } from '../render/colors.js';
-import type { HudConfig } from '../types.js';
+import { sanitizeTermString } from '../normalize.js';
+import { POWERLINE_STYLE_NAMES, type HudConfig, type PowerlineStyleName } from '../types.js';
 
-const VALID_POWERLINE_STYLES = [
-  'arrow', 'flame', 'slant', 'round', 'diamond', 'compatible', 'plain', 'auto',
-] as const;
+/**
+ * One-line descriptions for `lumira themes list`. Lives next to the only
+ * consumer rather than in `themes.ts` so the renderer's module graph
+ * doesn't pull these strings.
+ */
+const THEME_DESCRIPTIONS: Record<string, string> = {
+  dracula: 'vampire dark — purple/pink accents',
+  nord: 'arctic muted polar palette',
+  'tokyo-night': 'Tokyo at night — purple/blue, high contrast',
+  catppuccin: 'pastel mocha — warm soft colors',
+  monokai: 'classic high-saturation dark',
+  gruvbox: 'retro warm earth tones',
+  solarized: 'accessibility-focused, high readability',
+};
 
 interface ThemesArgs {
   sub: 'list' | 'preview' | 'help';
   themeName?: string;
   powerline: boolean;
-  powerlineStyle?: NonNullable<HudConfig['powerline']>['style'];
+  powerlineStyle?: PowerlineStyleName;
   all: boolean;
+}
+
+/**
+ * Result of invoking the themes subcommand. Caller (typically `index.ts`)
+ * is responsible for writing each stream to the right fd and exiting with
+ * the indicated code. Splitting this out (vs returning a plain string)
+ * lets pipe / redirection workflows (`2>/dev/null`, `| grep`) work as
+ * users expect, and lets shell scripts detect failure via `$?`.
+ */
+export interface ThemesCommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
 }
 
 export function parseThemesArgs(argv: string[]): ThemesArgs {
@@ -26,7 +51,7 @@ export function parseThemesArgs(argv: string[]): ThemesArgs {
 
   let themeName: string | undefined;
   let powerline = false;
-  let powerlineStyle: ThemesArgs['powerlineStyle'];
+  let powerlineStyle: PowerlineStyleName | undefined;
   let all = false;
 
   for (let i = 4; i < argv.length; i++) {
@@ -34,11 +59,14 @@ export function parseThemesArgs(argv: string[]): ThemesArgs {
     if (arg === '--powerline') { powerline = true; continue; }
     if (arg === '--all') { all = true; continue; }
     const styleMatch = arg.match(/^--style=(.+)$/);
-    if (styleMatch && VALID_POWERLINE_STYLES.includes(styleMatch[1] as never)) {
+    if (styleMatch && POWERLINE_STYLE_NAMES.includes(styleMatch[1] as never)) {
       powerline = true;
-      powerlineStyle = styleMatch[1] as NonNullable<HudConfig['powerline']>['style'];
+      powerlineStyle = styleMatch[1] as PowerlineStyleName;
       continue;
     }
+    // Unknown --flag is silently ignored to stay forward-compatible if a
+    // future minor adds a new flag and an old binary sees it. Positional
+    // tokens become themeName (first non-flag wins).
     if (!arg.startsWith('--') && !themeName) {
       themeName = arg;
     }
@@ -76,17 +104,18 @@ function helpText(): string {
     `  ${Object.keys(THEMES).join(', ')}`,
     '',
     'POWERLINE STYLES',
-    `  ${VALID_POWERLINE_STYLES.join(', ')}`,
+    `  ${POWERLINE_STYLE_NAMES.join(', ')}`,
     '',
   ].join('\n');
 }
 
-function previewBlock(name: string, args: ThemesArgs): string {
+function previewBlock(name: string, args: ThemesArgs, cols: number): string {
   const opts: PreviewOpts = {
     preset: 'full',
     theme: name,
     icons: 'nerd',
     colorMode: detectColorMode(),
+    cols,
   };
   if (args.powerline) {
     opts.style = 'powerline';
@@ -96,31 +125,62 @@ function previewBlock(name: string, args: ThemesArgs): string {
   return `${banner}\n${buildPreview(opts)}\n`;
 }
 
-/**
- * Returns the rendered output for `lumira themes [...]`. Caller is responsible
- * for writing to stdout. Returns an empty string only on internal failure.
- */
-export function runThemesCommand(argv: string[]): string {
-  const args = parseThemesArgs(argv);
+/** Reject themes lookups that would otherwise bypass the unknown-theme guard
+ * via prototype chain (`__proto__`, `constructor`, etc). */
+function isKnownTheme(name: string): boolean {
+  return Object.prototype.hasOwnProperty.call(THEMES, name);
+}
 
-  if (args.sub === 'help') return helpText();
-  if (args.sub === 'list') return listText();
+function ok(stdout: string): ThemesCommandResult {
+  return { stdout, stderr: '', exitCode: 0 };
+}
+
+function err(stderr: string): ThemesCommandResult {
+  return { stdout: '', stderr, exitCode: 1 };
+}
+
+/**
+ * Returns the rendered output for `lumira themes [...]` along with a
+ * separate stderr buffer and an exit code. The caller wires these to the
+ * right streams and exits the process accordingly.
+ *
+ * The optional `cols` argument is the terminal width to render previews at;
+ * defaults to 120 when stdout has no detectable column count (e.g. piped).
+ */
+export function runThemesCommand(argv: string[], cols?: number): ThemesCommandResult {
+  const args = parseThemesArgs(argv);
+  const previewCols = cols ?? 120;
+
+  if (args.sub === 'help') return ok(helpText());
+  if (args.sub === 'list') return ok(listText());
 
   // sub === 'preview'
   if (args.all) {
-    return Object.keys(THEMES).map(n => previewBlock(n, args)).join('\n');
+    return ok(Object.keys(THEMES).map(n => previewBlock(n, args, previewCols)).join('\n'));
   }
 
   if (!args.themeName) {
-    return 'lumira themes preview: missing theme name.\n\n'
+    return err(
+      'lumira themes preview: missing theme name.\n\n'
       + "Use 'lumira themes list' to see available themes,\n"
-      + "or 'lumira themes preview --all' to render all of them.\n";
+      + "or 'lumira themes preview --all' to render all of them.\n",
+    );
   }
 
-  if (!THEMES[args.themeName]) {
-    return `lumira themes preview: unknown theme "${args.themeName}".\n\n`
-      + `Available: ${Object.keys(THEMES).join(', ')}\n`;
+  // Sanitize for the error banner: a malicious shell alias could pass an
+  // argv containing terminal control sequences which would render directly
+  // into the user's terminal otherwise.
+  const safeName = sanitizeTermString(args.themeName);
+
+  if (!isKnownTheme(args.themeName)) {
+    return err(
+      `lumira themes preview: unknown theme "${safeName}".\n\n`
+      + `Available: ${Object.keys(THEMES).join(', ')}\n`,
+    );
   }
 
-  return previewBlock(args.themeName, args);
+  return ok(previewBlock(args.themeName, args, previewCols));
 }
+
+// Re-export PowerlineStyleName so callers don't have to import it from types.
+export type { PowerlineStyleName, HudConfig };

--- a/src/commands/themes.ts
+++ b/src/commands/themes.ts
@@ -149,7 +149,11 @@ function err(stderr: string): ThemesCommandResult {
  */
 export function runThemesCommand(argv: string[], cols?: number): ThemesCommandResult {
   const args = parseThemesArgs(argv);
-  const previewCols = cols ?? 120;
+  // Floor the preview width at 40 cols so a pathological `tput cols` of 1
+  // (or a piped output that erroneously passes 0) doesn't produce empty
+  // line truncations. 40 is the narrowest width any built-in renderer
+  // claims to support cleanly.
+  const previewCols = Math.max(40, cols ?? 120);
 
   if (args.sub === 'help') return ok(helpText());
   if (args.sub === 'list') return ok(listText());

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import { readFileSync, existsSync, writeFileSync, renameSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
-import { DEFAULT_CONFIG, DEFAULT_DISPLAY, type HudConfig, type DisplayToggles, type ColorConfig } from './types.js';
+import { DEFAULT_CONFIG, DEFAULT_DISPLAY, POWERLINE_STYLE_NAMES, type HudConfig, type DisplayToggles, type ColorConfig } from './types.js';
 
 // Module-level flag: fires the qwen→minimal deprecation warning once per
 // Node process. Process-scoped by design — tests must run in forked workers
@@ -53,8 +53,7 @@ function mergeConfig(rawIn: Record<string, unknown>): HudConfig {
   if (raw.style === 'classic' || raw.style === 'powerline') result.style = raw.style;
   if (raw.powerline && typeof raw.powerline === 'object') {
     const plRaw = raw.powerline as Record<string, unknown>;
-    const validPlStyles = ['arrow', 'flame', 'slant', 'round', 'diamond', 'compatible', 'plain', 'auto'] as const;
-    if (validPlStyles.includes(plRaw.style as never)) {
+    if (POWERLINE_STYLE_NAMES.includes(plRaw.style as never)) {
       result.powerline = { style: plRaw.style as NonNullable<HudConfig['powerline']>['style'] };
     }
   }
@@ -139,7 +138,9 @@ export function mergeCliFlags(config: HudConfig, argv: string[]): HudConfig {
     if (presetMatch) { applyPreset(r, presetMatch[1] as NonNullable<HudConfig['preset']>); continue; }
     const iconsMatch = arg.match(/^--icons[= ]?(nerd|emoji|none)$/);
     if (iconsMatch) { r.icons = iconsMatch[1] as HudConfig['icons']; continue; }
-    const plStyleMatch = arg.match(/^--powerline-style[= ](arrow|flame|slant|round|diamond|compatible|plain|auto)$/);
+    // Build the alternation from POWERLINE_STYLE_NAMES so this regex stays
+    // in sync when a new style is added — single source of truth in types.ts.
+    const plStyleMatch = arg.match(new RegExp(`^--powerline-style[= ](${POWERLINE_STYLE_NAMES.join('|')})$`));
     if (plStyleMatch) {
       r.style = 'powerline';
       r.powerline = { ...(r.powerline ?? {}), style: plStyleMatch[1] as NonNullable<HudConfig['powerline']>['style'] };

--- a/src/config.ts
+++ b/src/config.ts
@@ -140,7 +140,10 @@ export function mergeCliFlags(config: HudConfig, argv: string[]): HudConfig {
     if (iconsMatch) { r.icons = iconsMatch[1] as HudConfig['icons']; continue; }
     // Build the alternation from POWERLINE_STYLE_NAMES so this regex stays
     // in sync when a new style is added — single source of truth in types.ts.
-    const plStyleMatch = arg.match(new RegExp(`^--powerline-style[= ](${POWERLINE_STYLE_NAMES.join('|')})$`));
+    // Escape regex metacharacters defensively in case a future style name
+    // ever contains one (today they're all `[a-z]+`, but the safety is free).
+    const escaped = POWERLINE_STYLE_NAMES.map(n => n.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    const plStyleMatch = arg.match(new RegExp(`^--powerline-style[= ](${escaped.join('|')})$`));
     if (plStyleMatch) {
       r.style = 'powerline';
       r.powerline = { ...(r.powerline ?? {}), style: plStyleMatch[1] as NonNullable<HudConfig['powerline']>['style'] };

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { loadConfig, mergeCliFlags } from './config.js';
 import { render } from './render/index.js';
 import { resolveIcons } from './render/icons.js';
 import { install, uninstall } from './installer.js';
+import { runThemesCommand } from './commands/themes.js';
 import type { Dependencies } from './types.js';
 import { EMPTY_TRANSCRIPT } from './types.js';
 import { normalize } from './normalize.js';
@@ -76,6 +77,8 @@ if (isDirectRun()) {
   } else if (cmd === 'uninstall') {
     const o = uninstall();
     process.stdout.write(o);
+  } else if (cmd === 'themes') {
+    process.stdout.write(runThemesCommand(process.argv));
   } else {
     main().then(o => process.stdout.write(o)).catch(e => { if (!(e instanceof SyntaxError)) process.stderr.write(`Statusline error: ${e.message}\n`); });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,10 @@ if (isDirectRun()) {
     const o = uninstall();
     process.stdout.write(o);
   } else if (cmd === 'themes') {
-    process.stdout.write(runThemesCommand(process.argv));
+    const r = runThemesCommand(process.argv, process.stdout.columns);
+    if (r.stdout) process.stdout.write(r.stdout);
+    if (r.stderr) process.stderr.write(r.stderr);
+    if (r.exitCode !== 0) process.exit(r.exitCode);
   } else {
     main().then(o => process.stdout.write(o)).catch(e => { if (!(e instanceof SyntaxError)) process.stderr.write(`Statusline error: ${e.message}\n`); });
   }

--- a/src/render/powerline.ts
+++ b/src/render/powerline.ts
@@ -2,6 +2,10 @@ import type { ColorMode } from './colors.js';
 import { displayWidth, truncField } from './text.js';
 import { stripAnsi } from './colors.js';
 import { type RGB, rgbTo256Index } from '../themes.js';
+// Re-export the canonical name list type so this module stays the runtime
+// home of POWERLINE_STYLES while types.ts is the single source of truth
+// for the name set. A test asserts the map keys match the const.
+import type { PowerlineStyleName as CanonicalName } from '../types.js';
 
 // Powerline renderer — segment-based with colored backgrounds and glyph
 // separators that blend adjacent segment colors. See research notes: all
@@ -20,9 +24,8 @@ export interface PowerlineSegment {
   priority: number;
 }
 
-export type PowerlineStyleName =
-  | 'arrow' | 'flame' | 'slant' | 'round' | 'diamond'
-  | 'compatible' | 'plain' | 'auto';
+/** Aliased from types.ts so types.ts is the single source of truth. */
+export type PowerlineStyleName = CanonicalName;
 
 interface Style {
   leftCap?: string;

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -248,20 +248,6 @@ export function getThemeNames(): string[] {
   return Object.keys(THEMES);
 }
 
-/**
- * One-line descriptions for the `lumira themes list` subcommand. Kept
- * separate from THEMES so the renderer doesn't pull strings into the hot
- * path; only the themes subcommand reads this map.
- */
-export const THEME_DESCRIPTIONS: Record<string, string> = {
-  dracula: 'vampire dark — purple/pink accents',
-  nord: 'arctic muted polar palette',
-  'tokyo-night': 'Tokyo at night — purple/blue, high contrast',
-  catppuccin: 'pastel mocha — warm soft colors',
-  monokai: 'classic high-saturation dark',
-  gruvbox: 'retro warm earth tones',
-  solarized: 'accessibility-focused, high readability',
-};
 
 /** Darken an RGB triple toward black by `factor` in [0,1]. */
 function darken(c: RGB, factor: number): RGB {
@@ -306,8 +292,13 @@ export const DEFAULT_POWERLINE_PALETTE: PowerlinePalette = {
 
 export function resolveTheme(name: string | undefined, mode: ColorMode): ThemePalette | null {
   if (!name) return null;
-  const base = THEMES[name.toLowerCase()];
-  if (!base) return null;
+  const key = name.toLowerCase();
+  // hasOwn guard: a name like `__proto__` or `constructor` would otherwise
+  // resolve to `Object.prototype` (truthy), bypass the `!base` check, then
+  // crash later when render code reads `.cyan` etc. Reject anything not
+  // explicitly in the THEMES map.
+  if (!Object.prototype.hasOwnProperty.call(THEMES, key)) return null;
+  const base = THEMES[key];
   // Truecolor terminals get the exact palette; 256-color terminals get a
   // nearest-index projection. Named-ANSI terminals cannot represent arbitrary
   // palettes — fall back to built-in defaults rather than lying with mismatched

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -248,6 +248,21 @@ export function getThemeNames(): string[] {
   return Object.keys(THEMES);
 }
 
+/**
+ * One-line descriptions for the `lumira themes list` subcommand. Kept
+ * separate from THEMES so the renderer doesn't pull strings into the hot
+ * path; only the themes subcommand reads this map.
+ */
+export const THEME_DESCRIPTIONS: Record<string, string> = {
+  dracula: 'vampire dark — purple/pink accents',
+  nord: 'arctic muted polar palette',
+  'tokyo-night': 'Tokyo at night — purple/blue, high contrast',
+  catppuccin: 'pastel mocha — warm soft colors',
+  monokai: 'classic high-saturation dark',
+  gruvbox: 'retro warm earth tones',
+  solarized: 'accessibility-focused, high readability',
+};
+
 /** Darken an RGB triple toward black by `factor` in [0,1]. */
 function darken(c: RGB, factor: number): RGB {
   return {

--- a/src/tui/preview.ts
+++ b/src/tui/preview.ts
@@ -17,6 +17,12 @@ export interface PreviewOpts {
   theme?: string;
   icons: 'nerd' | 'emoji' | 'none';
   colorMode?: ColorMode;
+  /** When set to 'powerline', render with the powerline-style line 1/2/3. */
+  style?: HudConfig['style'];
+  /** Powerline separator style; only consulted when style === 'powerline'. */
+  powerlineStyle?: NonNullable<HudConfig['powerline']>['style'];
+  /** Width to render at; defaults to 120 (the wizard's typical width). */
+  cols?: number;
 }
 
 export interface BuildPreviewDeps {
@@ -37,6 +43,8 @@ function buildMockContext(opts: PreviewOpts): RenderContext {
     colors: { mode: opts.colorMode ?? 'truecolor' },
   };
   applyPreset(config, opts.preset);
+  if (opts.style) config.style = opts.style;
+  if (opts.powerlineStyle) config.powerline = { style: opts.powerlineStyle };
 
   // Build a realistic raw Claude Code input that normalize() can consume.
   // Fill every field that renderers access via ctx.input.* or ctx.input.raw.*
@@ -73,6 +81,8 @@ function buildMockContext(opts: PreviewOpts): RenderContext {
     },
     exceeds_200k_tokens: false,
   };
+
+  const cols = opts.cols ?? 120;
 
   const input = normalize(rawInput);
 
@@ -120,7 +130,7 @@ function buildMockContext(opts: PreviewOpts): RenderContext {
     memory: { usedBytes: 512 * 1024 * 1024, totalBytes: 16 * 1024 * 1024 * 1024, percentage: 3 },
     gsd: null,
     mcp: null,
-    cols: 120,
+    cols,
     config,
     icons: resolveIcons(opts.icons),
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,9 +165,21 @@ export interface HudConfig {
   style?: 'classic' | 'powerline';
   powerline?: {
     /** Separator glyph preset. Defaults to 'auto' (nerd font → arrow, else compatible). */
-    style?: 'arrow' | 'flame' | 'slant' | 'round' | 'diamond' | 'compatible' | 'plain' | 'auto';
+    style?: PowerlineStyleName;
   };
 }
+
+/**
+ * Single source of truth for valid powerline style names. Imported by
+ * `src/config.ts` (validates JSON config + CLI flags) and
+ * `src/commands/themes.ts` (validates `--style=<name>`). Keep in sync with
+ * `POWERLINE_STYLES` in `src/render/powerline.ts` — that map's keys
+ * MUST match this list.
+ */
+export const POWERLINE_STYLE_NAMES = [
+  'arrow', 'flame', 'slant', 'round', 'diamond', 'compatible', 'plain', 'auto',
+] as const;
+export type PowerlineStyleName = typeof POWERLINE_STYLE_NAMES[number];
 
 export interface DisplayToggles {
   model: boolean;

--- a/tests/commands/themes.test.ts
+++ b/tests/commands/themes.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { parseThemesArgs, runThemesCommand } from '../../src/commands/themes.js';
+import { stripAnsi } from '../../src/render/colors.js';
+import { THEMES } from '../../src/themes.js';
+
+const argv = (...rest: string[]) => ['node', 'lumira', 'themes', ...rest];
+
+describe('parseThemesArgs', () => {
+  it('defaults to list when no sub-subcommand given', () => {
+    expect(parseThemesArgs(argv()).sub).toBe('list');
+  });
+
+  it('recognises preview subcommand', () => {
+    expect(parseThemesArgs(argv('preview', 'dracula')).sub).toBe('preview');
+    expect(parseThemesArgs(argv('preview', 'dracula')).themeName).toBe('dracula');
+  });
+
+  it('recognises help variants', () => {
+    expect(parseThemesArgs(argv('help')).sub).toBe('help');
+    expect(parseThemesArgs(argv('--help')).sub).toBe('help');
+    expect(parseThemesArgs(argv('-h')).sub).toBe('help');
+  });
+
+  it('parses --powerline flag', () => {
+    expect(parseThemesArgs(argv('preview', 'nord', '--powerline')).powerline).toBe(true);
+  });
+
+  it('parses --all flag', () => {
+    expect(parseThemesArgs(argv('preview', '--all')).all).toBe(true);
+  });
+
+  it('parses --style=<name> and implies --powerline', () => {
+    const args = parseThemesArgs(argv('preview', 'nord', '--style=flame'));
+    expect(args.powerlineStyle).toBe('flame');
+    expect(args.powerline).toBe(true);
+  });
+
+  it('ignores invalid --style values', () => {
+    const args = parseThemesArgs(argv('preview', 'nord', '--style=bogus'));
+    expect(args.powerlineStyle).toBeUndefined();
+  });
+
+  it('only takes the first positional as theme name', () => {
+    const args = parseThemesArgs(argv('preview', 'dracula', 'nord'));
+    expect(args.themeName).toBe('dracula');
+  });
+});
+
+describe('runThemesCommand — list', () => {
+  it('lists all 7 built-in themes by default', () => {
+    const out = stripAnsi(runThemesCommand(argv()));
+    for (const name of Object.keys(THEMES)) {
+      expect(out).toContain(name);
+    }
+  });
+
+  it("includes a hint about 'preview <name>'", () => {
+    expect(runThemesCommand(argv('list'))).toContain('preview');
+  });
+});
+
+describe('runThemesCommand — help', () => {
+  it('lists subcommands and theme names', () => {
+    const out = runThemesCommand(argv('help'));
+    expect(out).toContain('USAGE');
+    expect(out).toContain('preview');
+    expect(out).toContain('--powerline');
+  });
+});
+
+describe('runThemesCommand — preview', () => {
+  it('returns rendered output for a known theme', () => {
+    const out = runThemesCommand(argv('preview', 'dracula'));
+    // Banner mentions the theme name
+    expect(out).toContain('dracula');
+    // The preview includes mock content like the project name
+    expect(stripAnsi(out)).toContain('lumira');
+  });
+
+  it('handles unknown theme with a helpful error', () => {
+    const out = runThemesCommand(argv('preview', 'bogus-theme-xyz'));
+    expect(out).toContain('unknown theme');
+    expect(out).toContain('Available:');
+  });
+
+  it('handles missing theme name with a helpful error', () => {
+    const out = runThemesCommand(argv('preview'));
+    expect(out).toContain('missing theme name');
+  });
+
+  it('renders all themes when --all is given', () => {
+    const out = runThemesCommand(argv('preview', '--all'));
+    for (const name of Object.keys(THEMES)) {
+      expect(out).toContain(name);
+    }
+  });
+
+  it('--powerline produces different output than classic', () => {
+    const classic = runThemesCommand(argv('preview', 'dracula'));
+    const powerline = runThemesCommand(argv('preview', 'dracula', '--powerline'));
+    expect(classic).not.toBe(powerline);
+    // Powerline output should contain a bg escape (\x1b[48;…)
+    expect(powerline).toMatch(/\x1b\[48;/);
+  });
+
+  it('--style=flame implies powerline mode', () => {
+    const out = runThemesCommand(argv('preview', 'dracula', '--style=flame'));
+    expect(out).toMatch(/\x1b\[48;/);
+    expect(out).toContain('flame');
+  });
+});

--- a/tests/commands/themes.test.ts
+++ b/tests/commands/themes.test.ts
@@ -35,77 +35,132 @@ describe('parseThemesArgs', () => {
     expect(args.powerline).toBe(true);
   });
 
-  it('ignores invalid --style values', () => {
+  it('--style=bogus drops both the style and the implicit powerline flag', () => {
     const args = parseThemesArgs(argv('preview', 'nord', '--style=bogus'));
     expect(args.powerlineStyle).toBeUndefined();
+    // The implicit-powerline-from-style only fires for valid styles. With
+    // a bogus value, neither side of the implicit toggle fires.
+    expect(args.powerline).toBe(false);
   });
 
   it('only takes the first positional as theme name', () => {
     const args = parseThemesArgs(argv('preview', 'dracula', 'nord'));
     expect(args.themeName).toBe('dracula');
   });
+
+  it('flag-before-name still finds the theme name', () => {
+    const args = parseThemesArgs(argv('preview', '--powerline', 'dracula'));
+    expect(args.themeName).toBe('dracula');
+    expect(args.powerline).toBe(true);
+  });
+
+  it('unknown --flag is silently ignored (forward-compatible)', () => {
+    const args = parseThemesArgs(argv('preview', '--unknown', 'dracula'));
+    expect(args.themeName).toBe('dracula');
+  });
 });
 
 describe('runThemesCommand — list', () => {
   it('lists all 7 built-in themes by default', () => {
-    const out = stripAnsi(runThemesCommand(argv()));
+    const r = runThemesCommand(argv());
+    expect(r.exitCode).toBe(0);
     for (const name of Object.keys(THEMES)) {
-      expect(out).toContain(name);
+      expect(r.stdout).toContain(name);
     }
+    expect(r.stderr).toBe('');
   });
 
   it("includes a hint about 'preview <name>'", () => {
-    expect(runThemesCommand(argv('list'))).toContain('preview');
+    expect(runThemesCommand(argv('list')).stdout).toContain('preview');
   });
 });
 
 describe('runThemesCommand — help', () => {
   it('lists subcommands and theme names', () => {
-    const out = runThemesCommand(argv('help'));
-    expect(out).toContain('USAGE');
-    expect(out).toContain('preview');
-    expect(out).toContain('--powerline');
+    const r = runThemesCommand(argv('help'));
+    expect(r.stdout).toContain('USAGE');
+    expect(r.stdout).toContain('preview');
+    expect(r.stdout).toContain('--powerline');
+    expect(r.exitCode).toBe(0);
   });
 });
 
 describe('runThemesCommand — preview', () => {
   it('returns rendered output for a known theme', () => {
-    const out = runThemesCommand(argv('preview', 'dracula'));
-    // Banner mentions the theme name
-    expect(out).toContain('dracula');
-    // The preview includes mock content like the project name
-    expect(stripAnsi(out)).toContain('lumira');
+    const r = runThemesCommand(argv('preview', 'dracula'));
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('dracula');
+    expect(stripAnsi(r.stdout)).toContain('lumira');
+    expect(r.stderr).toBe('');
   });
 
-  it('handles unknown theme with a helpful error', () => {
-    const out = runThemesCommand(argv('preview', 'bogus-theme-xyz'));
-    expect(out).toContain('unknown theme');
-    expect(out).toContain('Available:');
+  it('handles unknown theme with stderr + nonzero exit', () => {
+    const r = runThemesCommand(argv('preview', 'bogus-theme-xyz'));
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toBe('');
+    expect(r.stderr).toContain('unknown theme');
+    expect(r.stderr).toContain('Available:');
   });
 
-  it('handles missing theme name with a helpful error', () => {
-    const out = runThemesCommand(argv('preview'));
-    expect(out).toContain('missing theme name');
+  it('handles missing theme name with stderr + nonzero exit', () => {
+    const r = runThemesCommand(argv('preview'));
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toBe('');
+    expect(r.stderr).toContain('missing theme name');
   });
 
-  it('renders all themes when --all is given', () => {
-    const out = runThemesCommand(argv('preview', '--all'));
-    for (const name of Object.keys(THEMES)) {
-      expect(out).toContain(name);
+  it('renders all themes when --all is given, in catalog order', () => {
+    const r = runThemesCommand(argv('preview', '--all'));
+    expect(r.exitCode).toBe(0);
+    const names = Object.keys(THEMES);
+    let lastIdx = -1;
+    for (const name of names) {
+      const idx = r.stdout.indexOf(`── ${name}`);
+      expect(idx, `theme ${name} missing from --all output`).toBeGreaterThan(-1);
+      expect(idx, `theme ${name} appeared out of catalog order`).toBeGreaterThan(lastIdx);
+      lastIdx = idx;
     }
   });
 
   it('--powerline produces different output than classic', () => {
     const classic = runThemesCommand(argv('preview', 'dracula'));
     const powerline = runThemesCommand(argv('preview', 'dracula', '--powerline'));
-    expect(classic).not.toBe(powerline);
+    expect(classic.stdout).not.toBe(powerline.stdout);
     // Powerline output should contain a bg escape (\x1b[48;…)
-    expect(powerline).toMatch(/\x1b\[48;/);
+    expect(powerline.stdout).toMatch(/\x1b\[48;/);
   });
 
   it('--style=flame implies powerline mode', () => {
-    const out = runThemesCommand(argv('preview', 'dracula', '--style=flame'));
-    expect(out).toMatch(/\x1b\[48;/);
-    expect(out).toContain('flame');
+    const r = runThemesCommand(argv('preview', 'dracula', '--style=flame'));
+    expect(r.stdout).toMatch(/\x1b\[48;/);
+    expect(r.stdout).toContain('flame');
+  });
+
+  it('rejects __proto__ as theme name (prototype-pollution guard)', () => {
+    const r = runThemesCommand(argv('preview', '__proto__'));
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('unknown theme');
+  });
+
+  it('rejects constructor as theme name', () => {
+    const r = runThemesCommand(argv('preview', 'constructor'));
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('unknown theme');
+  });
+
+  it('strips terminal control chars from invalid theme name in error banner', () => {
+    const evil = '\x1b[2J\x1b[H';
+    const r = runThemesCommand(argv('preview', evil));
+    expect(r.exitCode).toBe(1);
+    // Sanitized output should not contain raw escape bytes.
+    expect(r.stderr).not.toContain('\x1b');
+  });
+
+  it('--all wins over a positional theme name', () => {
+    const r = runThemesCommand(argv('preview', '--all', 'dracula'));
+    expect(r.exitCode).toBe(0);
+    // All themes rendered, not just dracula. Look for nord which would be
+    // absent if --all were dropped in favour of the name.
+    expect(r.stdout).toContain('── nord');
   });
 });

--- a/tests/commands/themes.test.ts
+++ b/tests/commands/themes.test.ts
@@ -148,6 +148,14 @@ describe('runThemesCommand — preview', () => {
     expect(r.stderr).toContain('unknown theme');
   });
 
+  it('rejects toString as theme name (full prototype guard)', () => {
+    // The hasOwn guard is exhaustive across the prototype chain — verify
+    // one more inherited member to lock the behavior.
+    const r = runThemesCommand(argv('preview', 'toString'));
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('unknown theme');
+  });
+
   it('strips terminal control chars from invalid theme name in error banner', () => {
     const evil = '\x1b[2J\x1b[H';
     const r = runThemesCommand(argv('preview', evil));

--- a/tests/render/powerline.test.ts
+++ b/tests/render/powerline.test.ts
@@ -10,6 +10,7 @@ import {
 import { stripAnsi } from '../../src/render/colors.js';
 import { displayWidth } from '../../src/render/text.js';
 import type { RGB } from '../../src/themes.js';
+import { POWERLINE_STYLE_NAMES } from '../../src/types.js';
 
 const RED: RGB = { r: 255, g: 0, b: 0 };
 const GREEN: RGB = { r: 0, g: 255, b: 0 };
@@ -21,6 +22,17 @@ function seg(text: string, bg: RGB, priority = 50, icon?: string): PowerlineSegm
 }
 
 describe('powerline', () => {
+  describe('POWERLINE_STYLES drift detection', () => {
+    it('map keys match POWERLINE_STYLE_NAMES (excluding "auto" which resolves)', () => {
+      // Adding a name to types.ts without adding the corresponding entry to
+      // POWERLINE_STYLES (or vice versa) silently breaks `resolveStyle`,
+      // which falls back to arrow. This test catches the drift before users do.
+      const mapKeys = Object.keys(POWERLINE_STYLES).sort();
+      const expected = POWERLINE_STYLE_NAMES.filter(n => n !== 'auto').sort();
+      expect(mapKeys).toEqual([...expected]);
+    });
+  });
+
   describe('resolveStyle', () => {
     it('auto picks arrow when Nerd Font available', () => {
       expect(resolveStyle('auto', true).sep).toBe(POWERLINE_STYLES.arrow.sep);


### PR DESCRIPTION
## v0.6.2 — themes subcommand

### Added
- \`lumira themes\` — list, describe, preview the 7 built-in themes from the CLI. Includes \`--powerline\`, \`--style=<name>\`, and \`--all\` for screenshot grids.

### Changed
- \`POWERLINE_STYLE_NAMES\` extracted to \`types.ts\` as single source of truth. \`config.ts\` and \`render/powerline.ts\` now derive from it. Drift detection test catches future skew.

### Fixed
- Prototype-pollution guard on theme name lookups (\`__proto__\`, \`constructor\`, \`toString\` etc).
- Themes subcommand errors → stderr with non-zero exit code.
- Control-char sanitization on error banners.

### Risk
- Three review passes by Opus, 466 tests, lint + bundle-size guards green.
- Code path is opt-in (new subcommand); zero impact on existing statusline render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)