### PR TITLE
fix(test): COLORTERM=truecolor for powerline assertions in CI

### DIFF
--- a/tests/commands/themes.test.ts
+++ b/tests/commands/themes.test.ts
@@ -1,7 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { parseThemesArgs, runThemesCommand } from '../../src/commands/themes.js';
 import { stripAnsi } from '../../src/render/colors.js';
 import { THEMES } from '../../src/themes.js';
+
+// Force truecolor for tests that assert bg escapes (\x1b[48;…) in powerline
+// output. CI runners don't set COLORTERM, so detectColorMode() returns
+// 'named' and the renderer falls back to classic — no bg escapes emitted.
+const savedColorterm = process.env['COLORTERM'];
+beforeAll(() => { process.env['COLORTERM'] = 'truecolor'; });
+afterAll(() => {
+  if (savedColorterm === undefined) delete process.env['COLORTERM'];
+  else process.env['COLORTERM'] = savedColorterm;
+});
 
 const argv = (...rest: string[]) => ['node', 'lumira', 'themes', ...rest];
 


### PR DESCRIPTION
## Bug
v0.6.2 release pipeline failed at npm publish step. Two tests in \`tests/commands/themes.test.ts\` (lines 130, 135) asserted bg escapes (\`\\x1b[48;\`) in powerline output. CI runners don't set \`COLORTERM\`, so \`detectColorMode()\` returned \`named\` and the renderer correctly fell back to classic — making the assertion fail despite the implementation being correct.

## Fix
\`beforeAll\` sets \`COLORTERM=truecolor\`; \`afterAll\` restores. Two affected tests now have explicit truecolor preconditions matching what they actually test.

## Verified
\`unset COLORTERM && npm test\` → 466/466 green (reproduces CI).

## Aftermath
The v0.6.2 GitHub release was deleted (npm publish never succeeded; nobody could install it). Re-cutting \`release/v0.6.2\` once this lands so npm and GH stay consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)