### PR TITLE
release: v0.6.2 (themes subcommand) — re-cut

### DIFF
--- a/tests/commands/themes.test.ts
+++ b/tests/commands/themes.test.ts
@@ -1,7 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { parseThemesArgs, runThemesCommand } from '../../src/commands/themes.js';
 import { stripAnsi } from '../../src/render/colors.js';
 import { THEMES } from '../../src/themes.js';
+
+// Force truecolor for tests that assert bg escapes (\x1b[48;…) in powerline
+// output. CI runners don't set COLORTERM, so detectColorMode() returns
+// 'named' and the renderer falls back to classic — no bg escapes emitted.
+const savedColorterm = process.env['COLORTERM'];
+beforeAll(() => { process.env['COLORTERM'] = 'truecolor'; });
+afterAll(() => {
+  if (savedColorterm === undefined) delete process.env['COLORTERM'];
+  else process.env['COLORTERM'] = savedColorterm;
+});
 
 const argv = (...rest: string[]) => ['node', 'lumira', 'themes', ...rest];
 


### PR DESCRIPTION
## Re-cut of v0.6.2

Previous \`release/v0.6.2\` PR (#56) merged but **npm publish failed** in the workflow due to two tests asserting truecolor bg escapes without \`COLORTERM=truecolor\` in the CI env.

The zombie GH release was deleted; this re-cut includes the test fix from PR #57 (\`fix(test): COLORTERM=truecolor for powerline assertions\`).

### Contents (unchanged from previous cut)
- \`lumira themes\` subcommand
- \`POWERLINE_STYLE_NAMES\` single source of truth + drift test
- Prototype-pollution guard, stderr/exit-code split, control-char sanitization

### Plus the fix
- \`tests/commands/themes.test.ts\` sets \`COLORTERM=truecolor\` in \`beforeAll\`, restores in \`afterAll\` — verified locally with \`unset COLORTERM && npm test\` (466/466).

### Risk
Same as before; just adds the missing CI precondition. Three review passes already on the underlying feature work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)