### PR TITLE
fix(ci): mark 0.x.y releases as Latest, not Pre-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,9 @@ jobs:
           fi
           echo "tag=$RAW" >> "$GITHUB_OUTPUT"
           echo "number=${RAW#v}" >> "$GITHUB_OUTPUT"
-          MAJOR="${RAW#v}"
-          MAJOR="${MAJOR%%.*}"
-          if [[ "$MAJOR" -eq 0 ]]; then
+          # Pre-release only for tags with a SemVer suffix (e.g. v1.0.0-beta.1, v0.8.0-rc.1).
+          # Stable 0.x.y releases are marked as Latest so users see the actual current version.
+          if [[ "$RAW" =~ - ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

`release.yml` auto-flagged any `0.x` cut as `prerelease=true`. As a result, GitHub kept showing **v0.2.1** (Apr 11) as the "Latest" release even though we shipped v0.3 → v0.7.0 since then. New visitors to the repo landing page were seeing a version that's months out of date.

## Fix

Mark prerelease only when the tag has a SemVer suffix (`v1.0.0-beta.1`, `v0.8.0-rc.1`). Stable `0.x.y` cuts publish as Latest.

```diff
-          MAJOR="${RAW#v}"
-          MAJOR="${MAJOR%%.*}"
-          if [[ "$MAJOR" -eq 0 ]]; then
+          if [[ "$RAW" =~ - ]]; then
             echo "prerelease=true" >> "\$GITHUB_OUTPUT"
```

## Follow-up (manual, after merge)

Re-mark the existing 14 releases as non-prerelease via `gh release edit` so v0.7.0 surfaces as Latest immediately. CI-only change, no version bump needed.