### PR TITLE
chore: migrate to GitHub Flow (single-trunk + tag-triggered releases)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop, feat/*]
+    branches: [main]
   pull_request:
-    branches: [develop, main]
+    branches: [main]
 
 # Defense-in-depth: explicit read-only token. CI doesn't write to the repo,
 # release.yml is the only workflow that needs contents:write / id-token:write.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,9 +108,10 @@ jobs:
       - run: npm ci
 
       - name: Publish to npm
-        run: |
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          echo "Publishing lumira@${PKG_VERSION} (release tag: ${{ needs.release.outputs.tag }})"
-          npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RELEASE_TAG: ${{ needs.release.outputs.tag }}
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "Publishing lumira@${PKG_VERSION} (release tag: ${RELEASE_TAG})"
+          npm publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Auto Release
 
 on:
-  pull_request:
-    types: [closed]
-    branches: [main]
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   contents: write
@@ -15,9 +15,6 @@ concurrency:
 
 jobs:
   release:
-    if: >-
-      github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.version.outputs.tag }}
@@ -27,9 +24,9 @@ jobs:
       - name: Extract and validate version
         id: version
         env:
-          BRANCH: ${{ github.event.pull_request.head.ref }}
+          TAG: ${{ github.ref_name }}
         run: |
-          RAW="${BRANCH#release/}"
+          RAW="$TAG"
           if [[ "$RAW" != v* ]]; then
             RAW="v${RAW}"
           fi
@@ -39,9 +36,9 @@ jobs:
           fi
           echo "tag=$RAW" >> "$GITHUB_OUTPUT"
           echo "number=${RAW#v}" >> "$GITHUB_OUTPUT"
-          MAJOR="${RAW#v}"
-          MAJOR="${MAJOR%%.*}"
-          if [[ "$MAJOR" -eq 0 ]]; then
+          # Pre-release only for tags with a SemVer suffix (e.g. v1.0.0-beta.1, v0.8.0-rc.1).
+          # Stable 0.x.y releases are marked as Latest so users see the actual current version.
+          if [[ "$RAW" =~ - ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
@@ -85,7 +82,6 @@ jobs:
         env:
           TAG: ${{ steps.version.outputs.tag }}
           PRERELEASE: ${{ steps.version.outputs.prerelease }}
-          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PRERELEASE_FLAG=""
@@ -93,7 +89,6 @@ jobs:
           gh release create "$TAG" \
             --title "$TAG" \
             --notes-file /tmp/release-notes.md \
-            --target "$MERGE_SHA" \
             $PRERELEASE_FLAG
 
   npm-publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CI: migrated release workflow from gitflow (release/* → main PR) to GitHub Flow (push to tag `v*`).
+- Docs: updated CONTRIBUTING.md to reflect single-trunk workflow.
+
 ## [0.7.0] - 2026-05-01
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,13 +20,12 @@ npm run test:coverage   # vitest with coverage report
 npm run build           # compile to dist/
 ```
 
-## Branching (gitflow)
+## Branching
 
-- **`main`** — released versions, tagged. Don't open PRs against main directly.
-- **`develop`** — integration branch. **Open PRs here.**
-- **Feature branches** — `feature/<name>`, `fix/<name>`, `docs/<name>`. Branch off `develop`.
+- **`main`** — single trunk. Always releasable. **Open PRs here.**
+- **Feature branches** — `feature/<name>`, `fix/<name>`, `docs/<name>`, `refactor/<name>`. Branch off `main`, target `main`.
 
-Releases come from `release/vX.Y.Z` branches that get cut from `develop` by maintainers. After a release lands on `main`, it's back-merged to `develop` to keep the lines in sync.
+No develop branch, no release branches. Releases are cut by tagging `main` (see [Release process](#release-process-maintainers-only) below).
 
 ## Commit style
 
@@ -65,7 +64,7 @@ This is the most common contribution path. Each theme lives in its own module un
 
 6. **Run the full suite.** `npm test` — the catalog test in `tests/themes.test.ts` verifies your theme exposes every required field. No need to add tests for the theme itself unless it has unusual behavior.
 
-Open a PR against `develop` using the theme template (`?template=theme.md` in the URL, or pick it from the dropdown).
+Open a PR against `main` using the theme template (`?template=theme.md` in the URL, or pick it from the dropdown).
 
 ## TypeScript / code style
 
@@ -87,6 +86,20 @@ PRs run CI on push. When tests + typecheck go green, the PR is **ready for revie
 - Plugin / custom-segment marketplace — hold off until at least 3 users request it.
 - Auto-update / self-update — npm handles this.
 - Telemetry — never.
+
+## Release process (maintainers only)
+
+Releases are tag-triggered. From an up-to-date `main`:
+
+```bash
+npm version X.Y.Z --no-git-tag-version       # bump package.json
+# edit CHANGELOG.md: rename [Unreleased] → [X.Y.Z] - YYYY-MM-DD
+git commit -am "chore(release): vX.Y.Z"
+git tag vX.Y.Z
+git push origin main --tags
+```
+
+Pushing the `vX.Y.Z` tag triggers `.github/workflows/release.yml`, which publishes to npm and creates the GitHub Release with notes parsed from `CHANGELOG.md`. Tags with a SemVer suffix (e.g. `v1.0.0-beta.1`) are flagged as prereleases; stable cuts surface as Latest.
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ LUMIRA_DEBUG=1 claude    # or export LUMIRA_DEBUG=1
 
 ## Contributing
 
-PRs welcome — particularly for new themes (one of the most common contribution paths). See [CONTRIBUTING.md](CONTRIBUTING.md) for the gitflow, theme submission walkthrough, and the contrast-guard CI step that runs on every theme PR.
+PRs welcome — particularly for new themes (one of the most common contribution paths). See [CONTRIBUTING.md](CONTRIBUTING.md) for the branching model, theme submission walkthrough, and the contrast-guard CI step that runs on every theme PR.
 
 ### What's next
 


### PR DESCRIPTION
## Motivation

Gitflow (main + develop + release/* + back-merges) is overkill for a solo-maintainer OSS project. Contributors land on the repo expecting `main` as the PR target; the develop branch creates a confusing two-step for outside contributors and an extra back-merge for me. GitHub Flow (single trunk, tag-triggered releases) is the standard for this size of project.

## What changed

- **`.github/workflows/release.yml`** — trigger flips from `pull_request: closed` on `release/*` branches to `push: tags: [v*]`. Version is now extracted from `github.ref_name` (via `env:` to preserve the command-injection guard). Removed the `--target $MERGE_SHA` flag since the tag itself pins the release commit.
- **`CONTRIBUTING.md`** — Branching section rewritten for GitHub Flow (branch from main, target main, no develop). 'Adding a theme' now points PRs at main. New 'Release process (maintainers only)' section documents `npm version` → tag → push.
- **`README.md`** — drops the 'gitflow' phrasing in the Contributing blurb.
- **`CHANGELOG.md`** — `[Unreleased]` notes the CI + docs migration.

## What's preserved

- **PR #65's prerelease fix** — `[[ "$RAW" =~ - ]]` (SemVer-suffix-based detection) stays; stable 0.x.y still surfaces as Latest, only `v*-rc.*` / `v*-beta.*` get flagged prerelease.
- The 'Check tag does not already exist' safety net.
- The CHANGELOG.md awk parser for release notes.
- npm publish step (still uses NPM_TOKEN, runs `npm ci` first).
- Workflow-level `permissions: { contents: write, id-token: write }` and `concurrency` block.
- The `env:`-based interpolation pattern for any `github.*` value used in `run:` blocks.

## Verification

Local: `npm run build && npm test && npm run lint` all green (472 tests pass, tsc clean).

## Follow-ups (post-merge, manual)

- Delete the `develop` branch on GitHub.
- Delete the 'develop protection' ruleset (id 15845237).
- Update local memory to drop gitflow references.