### PR TITLE
docs(transcript): document why full re-parse is intentional (#43)

### DIFF
--- a/src/parsers/transcript.ts
+++ b/src/parsers/transcript.ts
@@ -10,6 +10,13 @@ import { debug } from '../utils/debug.js';
 
 const log = debug('transcript');
 
+// Full re-parse on cache miss is intentional. Incremental byte-offset parsing
+// was evaluated and rejected (see #43): real transcripts are low-thousands of
+// lines, parse cost stays under the statusline budget, and stateful
+// accumulation breaks under concurrent ticks, file replacement (TOCTOU), and
+// TaskUpdate's numeric-taskId index semantics. Each call uses local maps
+// (toolMap, agentMap, todos below) — that locality is what keeps the parser
+// concurrent-tick safe. Don't refactor it into shared mutable state.
 const transcriptCache = new Map<string, { result: TranscriptData; mtime: MtimeState }>();
 
 const MAX_LINES = 50_000;


### PR DESCRIPTION
Adds a comment above \`transcriptCache\` explaining why incremental byte-offset parsing was rejected (per the analysis in #43). Names the explicit concurrent-safety property of per-call local maps so it doesn't get refactored away by accident.

## Why a code comment, not just an issue thread

Issue threads get forgotten. Code comments survive refactors. The next contributor (or future-me) reading \`transcriptCache\` should immediately see why incremental parsing is not the answer, instead of reproposing it.

## Linked

- Closes nothing (#43 is closed separately with the rationale).
- Related: #69 (LRU cap on transcriptCache), #70 (warn-once on MAX_LINES truncation).