### PR TITLE
fix(cache): read cache_read from nested current_usage path + cap overflow

### DIFF
--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -144,7 +144,9 @@ export function normalize(input: RawInput): NormalizedInput {
       const total = fresh + read + create;
       if (total > 0) cacheTurnDenominator = total;
     }
-    // Legacy fallback: top-level totals (pre-2.1.x payloads)
+    // Legacy fallback: top-level totals (pre-2.1.x payloads, or current_usage
+    // without cache fields). The Math.min(100, ...) cap below protects against
+    // overflow when cache_read accumulates past total_input in long sessions.
     if (cacheTurnDenominator == null && inputTokens > 0) {
       cacheTurnDenominator = inputTokens;
     }

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -123,7 +123,31 @@ export function normalize(input: RawInput): NormalizedInput {
       thoughts = first.tokens?.thoughts;
     }
   } else if (claude) {
-    cached = claude.context_window?.cache_read_input_tokens;
+    // Modern Claude Code (≥ 2.1.x) nests cache fields under current_usage.
+    // Fall back to the legacy top-level path for older payloads.
+    const cu = claude.context_window?.current_usage;
+    const nested = typeof cu === 'object' ? cu?.cache_read_input_tokens : undefined;
+    cached = nested ?? claude.context_window?.cache_read_input_tokens;
+  }
+
+  // Per-turn cache denominator (Claude only): fresh input + cache_read + cache_creation
+  // for the current turn. Used to compute a meaningful cache hit rate, since
+  // `cached` is per-turn while `total_input_tokens` is cumulative across the session.
+  // Falls back to total_input_tokens for legacy payloads without current_usage.
+  let cacheTurnDenominator: number | undefined;
+  if (claude) {
+    const cu = claude.context_window?.current_usage;
+    if (typeof cu === 'object' && cu) {
+      const fresh = cu.input_tokens ?? 0;
+      const read = cu.cache_read_input_tokens ?? 0;
+      const create = cu.cache_creation_input_tokens ?? 0;
+      const total = fresh + read + create;
+      if (total > 0) cacheTurnDenominator = total;
+    }
+    // Legacy fallback: top-level totals (pre-2.1.x payloads)
+    if (cacheTurnDenominator == null && inputTokens > 0) {
+      cacheTurnDenominator = inputTokens;
+    }
   }
 
   // Performance (Qwen only)
@@ -160,9 +184,10 @@ export function normalize(input: RawInput): NormalizedInput {
     };
   }
 
-  // Cache hit rate (Claude only)
-  const cacheHitRate = (cached != null && inputTokens > 0 && platform === 'claude-code')
-    ? Math.round((cached / inputTokens) * 100)
+  // Cache hit rate (Claude only) — denominator is the current turn's total input
+  // (fresh + cache_read + cache_creation), not the cumulative session total.
+  const cacheHitRate = (cached != null && cached > 0 && cacheTurnDenominator && platform === 'claude-code')
+    ? Math.min(100, Math.round((cached / cacheTurnDenominator) * 100))
     : undefined;
 
   return {

--- a/src/parsers/token-speed.ts
+++ b/src/parsers/token-speed.ts
@@ -3,7 +3,9 @@ import { tmpdir } from 'node:os';
 
 const SPEED_CACHE_TTL = 2000;
 interface SpeedCache { outputTokens: number; timestamp: number; }
-// current_usage: Claude sends {output_tokens: number}, Qwen sends plain number (20369)
+// current_usage shape: Claude Code 2.1.x sends an object with input/output/cache fields,
+// older Claude versions sent {output_tokens: number}, Qwen sends a plain number (20369).
+// We only need output_tokens here for token speed; ignore the rest.
 interface ContextWindow { used_percentage: number; remaining_percentage: number; current_usage?: number | { output_tokens?: number }; }
 
 export function getTokenSpeed(contextWindow: ContextWindow, cacheDir: string = tmpdir()): number | null {

--- a/src/parsers/token-speed.ts
+++ b/src/parsers/token-speed.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 const SPEED_CACHE_TTL = 2000;
 interface SpeedCache { outputTokens: number; timestamp: number; }
 // current_usage: Claude sends {output_tokens: number}, Qwen sends plain number (20369)
-interface ContextWindow { used_percentage: number; remaining_percentage: number; current_usage?: number | { output_tokens: number }; }
+interface ContextWindow { used_percentage: number; remaining_percentage: number; current_usage?: number | { output_tokens?: number }; }
 
 export function getTokenSpeed(contextWindow: ContextWindow, cacheDir: string = tmpdir()): number | null {
   const cu = contextWindow?.current_usage;

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -47,13 +47,8 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
   }
 
   // Cache metrics (hit rate)
-  if (display.cacheMetrics) {
-    const cacheRead = input.tokens.cached;
-    const totalIn = input.tokens.input;
-    if (cacheRead != null && cacheRead > 0 && totalIn > 0) {
-      const hitRate = Math.min(100, Math.round((cacheRead / totalIn) * 100));
-      leftParts.push(c.dim(`cache ${hitRate}%`));
-    }
+  if (display.cacheMetrics && input.cacheHitRate != null) {
+    leftParts.push(c.dim(`cache ${input.cacheHitRate}%`));
   }
 
   // Cost + burn rate (Claude only — Qwen doesn't send cost data)

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -50,8 +50,8 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
   if (display.cacheMetrics) {
     const cacheRead = input.tokens.cached;
     const totalIn = input.tokens.input;
-    if (cacheRead != null && totalIn > 0) {
-      const hitRate = Math.round((cacheRead / totalIn) * 100);
+    if (cacheRead != null && cacheRead > 0 && totalIn > 0) {
+      const hitRate = Math.min(100, Math.round((cacheRead / totalIn) * 100));
       leftParts.push(c.dim(`cache ${hitRate}%`));
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,9 +10,15 @@ export interface ClaudeCodeInput {
     context_window_size?: number;
     used_percentage: number;
     remaining_percentage: number;
-    current_usage?: number | { output_tokens: number };
+    current_usage?: number | {
+      input_tokens?: number;
+      output_tokens?: number;
+      cache_read_input_tokens?: number;
+      cache_creation_input_tokens?: number;
+    };
     total_input_tokens?: number;
     total_output_tokens?: number;
+    /** Legacy top-level path; modern payloads nest these under current_usage. */
     cache_read_input_tokens?: number;
     cache_creation_input_tokens?: number;
   };

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -317,6 +317,21 @@ describe('cacheHitRate normalization', () => {
   it('cacheHitRate is undefined for Qwen', () => {
     expect(normalize(qwenInput).cacheHitRate).toBeUndefined();
   });
+  it('reads cache fields from nested current_usage (modern 2.1.x payload)', () => {
+    const input = {
+      ...claudeInput,
+      context_window: {
+        ...claudeInput.context_window,
+        current_usage: { input_tokens: 50000, cache_read_input_tokens: 80000, cache_creation_input_tokens: 20000 },
+      },
+    };
+    // 80000 / (50000 + 80000 + 20000) = 53%
+    expect(normalize(input).cacheHitRate).toBe(53);
+  });
+  it('caps hit rate at 100 when cache_read exceeds total_input on legacy payload', () => {
+    const input = { ...claudeInput, context_window: { ...claudeInput.context_window, cache_read_input_tokens: 5000000, total_input_tokens: 957000 } };
+    expect(normalize(input).cacheHitRate).toBe(100);
+  });
 });
 
 describe('isQwenInput discriminant', () => {

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -332,6 +332,20 @@ describe('cacheHitRate normalization', () => {
     const input = { ...claudeInput, context_window: { ...claudeInput.context_window, cache_read_input_tokens: 5000000, total_input_tokens: 957000 } };
     expect(normalize(input).cacheHitRate).toBe(100);
   });
+  it('falls back to total_input denominator when current_usage has no cache fields', () => {
+    // Modern payload but partial — only output_tokens (no cache_read/creation/input).
+    // Cached comes from legacy top-level; denominator falls back to total_input_tokens.
+    const input = {
+      ...claudeInput,
+      context_window: {
+        ...claudeInput.context_window,
+        current_usage: { output_tokens: 25000 },
+        cache_read_input_tokens: 100000,
+        total_input_tokens: 131000,
+      },
+    };
+    expect(normalize(input).cacheHitRate).toBe(76);
+  });
 });
 
 describe('isQwenInput discriminant', () => {

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -112,6 +112,22 @@ describe('renderLine2', () => {
     expect(out).toContain('76%');
   });
 
+  it('reads cache hit rate from nested current_usage (modern 2.1.x payload)', () => {
+    const inputOverride = {
+      context_window: {
+        ...baseInput.context_window,
+        current_usage: {
+          input_tokens: 50000,
+          cache_read_input_tokens: 80000,
+          cache_creation_input_tokens: 20000,
+        },
+      },
+    };
+    const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+    // 80000 / (50000 + 80000 + 20000) = 53%
+    expect(out).toContain('cache 53%');
+  });
+
   it('caps cache hit rate at 100% when cache_read exceeds total_input (long sessions)', () => {
     const inputOverride = { context_window: { ...baseInput.context_window, cache_read_input_tokens: 5000000, total_input_tokens: 957000 } };
     const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -112,6 +112,19 @@ describe('renderLine2', () => {
     expect(out).toContain('76%');
   });
 
+  it('caps cache hit rate at 100% when cache_read exceeds total_input (long sessions)', () => {
+    const inputOverride = { context_window: { ...baseInput.context_window, cache_read_input_tokens: 5000000, total_input_tokens: 957000 } };
+    const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+    expect(out).toContain('cache 100%');
+    expect(out).not.toMatch(/cache [1-9]\d{3,}%|cache [2-9]\d{2}%|cache 1[1-9]\d%/);
+  });
+
+  it('hides cache metrics when cache_read is zero', () => {
+    const inputOverride = { context_window: { ...baseInput.context_window, cache_read_input_tokens: 0, total_input_tokens: 957000 } };
+    const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+    expect(out).not.toContain('cache');
+  });
+
   it('hides cache metrics when toggled off', () => {
     const inputOverride = { context_window: { ...baseInput.context_window, cache_read_input_tokens: 100000 } };
     const out = stripAnsi(renderLine2(makeCtx({ config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, cacheMetrics: false } } }, inputOverride), c));


### PR DESCRIPTION
## Why?

Two related cache-metrics bugs surfaced while investigating why `cache XX%` never displayed in real Claude Code sessions despite users having heavy cache hits.

### Bug 1 — silent path mismatch
Claude Code 2.1.x moved cache fields from `context_window.cache_read_input_tokens` to `context_window.current_usage.cache_read_input_tokens`. lumira was still reading the old path, so `cached` was always `undefined` and the widget silently disappeared.

### Bug 2 — overflow on long sessions
The hit-rate formula divided cumulative `total_input_tokens` into per-turn `cache_read_input_tokens`, producing values like `cache 522%` when cache reads accumulated past the cumulative input.

## What changed?

- `src/normalize.ts` — read cache fields from nested `current_usage` first, fall back to legacy top-level path. Compute proper per-turn denominator (`fresh + read + create`) with fallback to `total_input_tokens` for legacy payloads.
- `src/render/line2.ts` — use pre-computed `input.cacheHitRate` instead of duplicating the formula.
- `src/types.ts` — extend `current_usage` shape to match modern payloads.
- `src/parsers/token-speed.ts` — make `output_tokens` optional to match the new type.
- Tests for: nested-path read (modern), legacy-path fallback, overflow cap at 100%, zero-cache hide.

## How to test

```bash
npm test            # 491 passing
npm run build       # clean
```

Verified against a real captured payload from Claude Code 2.1.123 with `cache_read_input_tokens=182759` → renders `cache 100%` correctly (was hidden before).