### PR TITLE
fix(payload): correct contextTokens capacity + use stdin effort.level

### DIFF
--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -78,6 +78,9 @@ export interface NormalizedInput {
   /** Worktree name */
   worktreeName?: string;
 
+  /** Reasoning effort level (≥ 2.1.x stdin, falls back to transcript regex) */
+  effortLevel?: string;
+
   /** Rate limits (Claude only) */
   rateLimits?: {
     fiveHour?: { usedPercentage: number; resetsAt?: number };
@@ -91,10 +94,21 @@ export interface NormalizedInput {
   raw: RawInput;
 }
 
-/** Strip terminal control characters (C0 + C1 + DEL) from untrusted strings */
+/**
+ * Strip terminal control characters and bidirectional/zero-width Unicode from
+ * untrusted strings.
+ * - C0/C1 + DEL — escape sequences, ANSI, etc.
+ * - U+200B-200F — zero-width and LTR/RTL marks
+ * - U+202A-202E — explicit directional embedding/overrides (visual spoofing)
+ * - U+2028/2029 — line/paragraph separators
+ * - U+2066-2069 — directional isolates
+ */
 export function sanitizeTermString(s: string): string {
-  return s.replace(/[\x00-\x1f\x7f-\x9f]/g, '');
+  return s.replace(/[\x00-\x1f\x7f-\x9f\u200b-\u200f\u202a-\u202e\u2028\u2029\u2066-\u2069]/g, '');
 }
+
+/** Allowed values for the reasoning effort level field (CC ≥ 2.1.x). */
+const VALID_EFFORT_LEVELS = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
 
 export function normalize(input: RawInput): NormalizedInput {
   const platform: Platform = isQwenInput(input) ? 'qwen-code' : 'claude-code';
@@ -206,7 +220,9 @@ export function normalize(input: RawInput): NormalizedInput {
     },
     context: {
       usedPercentage: input.context_window.used_percentage,
-      windowSize: qwen ? qwen.context_window.context_window_size : undefined,
+      windowSize: qwen
+        ? qwen.context_window.context_window_size
+        : claude?.context_window?.context_window_size,
     },
     cost: claude ? claude.cost?.total_cost_usd : undefined,
     durationMs: claude ? claude.cost?.total_duration_ms : undefined,
@@ -218,6 +234,9 @@ export function normalize(input: RawInput): NormalizedInput {
     sessionName: input.session_name ? sanitizeTermString(input.session_name) : undefined,
     outputStyle: input.output_style?.name ? sanitizeTermString(input.output_style.name) : undefined,
     agentName: input.agent?.name ? sanitizeTermString(input.agent.name) : undefined,
+    effortLevel: claude?.effort?.level && VALID_EFFORT_LEVELS.has(claude.effort.level)
+      ? sanitizeTermString(claude.effort.level)
+      : undefined,
     worktreeName: input.worktree?.name ? sanitizeTermString(input.worktree.name) : undefined,
     rateLimits,
     cacheHitRate,

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -29,11 +29,18 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
     leftParts.push(buildContextBar(pct, c, { iconSet: icons }));
   }
 
-  // Context tokens (estimated used/capacity from percentage)
-  if (display.contextTokens && input.tokens.input > 0 && input.context.usedPercentage > 0) {
-    const used = input.tokens.input;
-    const capacity = Math.round(used / (input.context.usedPercentage / 100));
-    leftParts.push(c.dim(`${formatTokens(used)}/${formatTokens(capacity)}`));
+  // Context tokens — prefer windowSize from payload over back-derivation.
+  // total_input_tokens is cumulative across the session; current context size
+  // is windowSize × usedPercentage / 100. Fallback derives capacity for legacy
+  // payloads without context_window_size.
+  if (display.contextTokens && input.context.usedPercentage > 0) {
+    const pct = input.context.usedPercentage;
+    const capacity = input.context.windowSize
+      ?? (input.tokens.input > 0 ? Math.round(input.tokens.input / (pct / 100)) : 0);
+    if (capacity > 0) {
+      const used = Math.round(capacity * pct / 100);
+      leftParts.push(c.dim(`${formatTokens(used)}/${formatTokens(capacity)}`));
+    }
   }
 
   // Tokens
@@ -114,9 +121,12 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
     rightParts.push(c.dim(`[${input.vimMode}]`));
   }
 
-  // Right side: effort (hidden if medium)
-  if (display.effort && thinkingEffort && thinkingEffort !== 'medium') {
-    rightParts.push(c.dim(`^${thinkingEffort}`));
+  // Right side: effort (hidden if medium). Prefer stdin (≥ 2.1.x) over the
+  // transcript regex fallback — it's both more accurate and avoids a fragile
+  // log-line match that breaks when wording changes.
+  const effort = input.effortLevel || thinkingEffort;
+  if (display.effort && effort && effort !== 'medium') {
+    rightParts.push(c.dim(`^${effort}`));
   }
 
   // Config health hints (opt-in, default off). Sit on the right side as

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,10 @@ export interface ClaudeCodeInput {
     seven_day?: RateLimitWindow;
   };
   exceeds_200k_tokens?: boolean;
+  /** Modern (≥ 2.1.x) — current reasoning effort level. */
+  effort?: { level?: string };
+  /** Modern (≥ 2.1.x) — extended thinking enabled state. */
+  thinking?: { enabled?: boolean };
 }
 
 export interface RateLimitWindow {

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -102,6 +102,23 @@ describe('normalize', () => {
       expect(result.context.windowSize).toBe(1000000);
     });
 
+    it('extracts window size from Claude (≥ 2.1.x payload)', () => {
+      const input = { ...claudeInput, context_window: { ...claudeInput.context_window, context_window_size: 1000000 } };
+      expect(normalize(input).context.windowSize).toBe(1000000);
+    });
+
+    it('reads effort.level from Claude stdin (≥ 2.1.x)', () => {
+      const input = { ...claudeInput, effort: { level: 'high' } };
+      expect(normalize(input).effortLevel).toBe('high');
+    });
+
+    it('rejects effort.level not in the allowed enum', () => {
+      const input = { ...claudeInput, effort: { level: 'EXTREME' } };
+      expect(normalize(input).effortLevel).toBeUndefined();
+      const input2 = { ...claudeInput, effort: { level: '\x1b[31m' } };
+      expect(normalize(input2).effortLevel).toBeUndefined();
+    });
+
     it('window size is undefined for Claude', () => {
       const result = normalize(claudeInput);
       expect(result.context.windowSize).toBeUndefined();
@@ -232,6 +249,14 @@ describe('sanitizeTermString', () => {
   });
   it('preserves normal text and unicode', () => {
     expect(sanitizeTermString('feat/add-日本語')).toBe('feat/add-日本語');
+  });
+  it('strips Unicode bidi overrides (RTL spoofing)', () => {
+    // U+202E RIGHT-TO-LEFT OVERRIDE — visually flips trailing text
+    expect(sanitizeTermString('safe‮malicious')).toBe('safemalicious');
+    // U+200B ZERO-WIDTH SPACE
+    expect(sanitizeTermString('hi​dden')).toBe('hidden');
+    // U+2066 LEFT-TO-RIGHT ISOLATE
+    expect(sanitizeTermString('a⁦b⁩c')).toBe('abc');
   });
   it('returns empty string for all-control input', () => {
     expect(sanitizeTermString('\x1b\x9b\x00')).toBe('');

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -159,6 +159,21 @@ describe('renderLine2', () => {
     expect(out).toContain('MCP 1/2');
   });
 
+  it('uses context_window_size as capacity instead of back-deriving (≥ 2.1.x)', () => {
+    // total_input_tokens (957k) is cumulative; real context is 18% of 1M = 180k
+    const inputOverride = {
+      context_window: {
+        ...baseInput.context_window,
+        used_percentage: 18,
+        total_input_tokens: 957000,
+        context_window_size: 1000000,
+      },
+    };
+    const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+    expect(out).toContain('180k/1.0M');
+    expect(out).not.toContain('957k/');
+  });
+
   it('shows contextTokens estimate', () => {
     const inputOverride = { context_window: { ...baseInput.context_window, used_percentage: 50, total_input_tokens: 100000 } };
     const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));


### PR DESCRIPTION
## Why?

Two follow-up fixes after #78 — same root cause: lumira treating cumulative session totals as if they were per-turn / current-context values after Claude Code 2.1.x reshaped its statusline payload.

### Bug 1 — contextTokens shows wrong size

Before: `957k/2.7M` for a 1M-window session at 18% used.

The widget back-derived capacity: `capacity = total_input_tokens / (used%/100) = 957k / 0.18 ≈ 5.3M`. But `total_input_tokens` is **cumulative across the session** (per official docs), not current context. The actual capacity is the `context_window_size` field — which lumira was reading only for Qwen.

After: `180k/1M` (correct: 18% of 1M = 180k current context).

### Bug 2 — thinking effort parsed by regex on transcript

`src/parsers/transcript.ts:189-190` matches log lines like `Set model to X with high effort` per render tick. Modern payloads ship `effort.level` directly via stdin. Now prefer stdin and fall back to the regex for old CC.

Includes a runtime whitelist (`low/medium/high/xhigh/max`) — unexpected values fall through to the regex fallback rather than rendering raw. The transcript regex stays as a compatibility path.

### Hardening

`sanitizeTermString` previously stripped C0/C1 + DEL. Now also strips Unicode bidi/zero-width chars (U+200B-200F, U+202A-202E, U+2028-2029, U+2066-2069). Identified by review as a visual-spoofing surface — a malicious branch name with `‮` could flip the trailing line right-to-left.

## What changed?

- `src/normalize.ts` — read `context_window_size` from Claude (was Qwen-only). Read `effort.level` with whitelist. Strip Unicode bidi chars in `sanitizeTermString`.
- `src/render/line2.ts` — derive `used` from `capacity × pct/100` instead of using cumulative input. Prefer `input.effortLevel` over transcript regex.
- `src/types.ts` — type `effort`, `thinking`, and the nested `current_usage` cache fields.
- 5 new tests covering the modern payload, legacy fallback, capacity correction, effort validation, and bidi sanitization.

## Testing

```bash
npm test            # 499 passing
npm run build       # clean
```

Verified against the captured 2.1.123 payload for Carlos's session — `cache 100%` plus `180k/1M` (was `957k/2.7M`).