### PR TITLE
fix(render): rebalance line 2 — move system info to line 1

### DIFF
--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -3,6 +3,7 @@ import { pathToFileURL } from 'node:url';
 import { fitSegments, truncField } from './text.js';
 import { formatGitChanges, SEP } from './shared.js';
 import { hyperlink } from './hyperlink.js';
+import { formatDuration } from '../utils/format.js';
 import type { Colors } from './colors.js';
 import type { RenderContext, TranscriptData } from '../types.js';
 
@@ -12,7 +13,7 @@ function getActiveTodo(transcript: TranscriptData): string | undefined {
 }
 
 export function renderLine1(ctx: RenderContext, c: Colors): string {
-  const { input, git, transcript, config: { display }, cols, icons } = ctx;
+  const { input, git, transcript, config: { display }, cols, icons, memory, tokenSpeed } = ctx;
   const left: string[] = [];
   const right: string[] = [];
 
@@ -47,6 +48,21 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
       // spaces and non-ASCII chars correctly.
       left.push(hyperlink(pathToFileURL(cwd).href, label));
     }
+  }
+
+  // Duration (Claude only)
+  if (display.duration && input.durationMs != null) {
+    right.push(c.dim(`${icons.clock} ${formatDuration(input.durationMs)}`));
+  }
+
+  // Memory
+  if (display.memory && memory) {
+    right.push(c.dim(`${memory.percentage}% mem`));
+  }
+
+  // Token speed
+  if (display.tokenSpeed && tokenSpeed != null) {
+    right.push(c.dim(`${icons.bolt}${tokenSpeed} tok/s`));
   }
 
   // Lines changed (right side)

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -1,7 +1,7 @@
-import { padLine, displayWidth } from './text.js';
+import { fitSegments, displayWidth } from './text.js';
 import { getQuotaColor, detectColorMode, type Colors } from './colors.js';
 import { buildContextBar, formatQwenMetrics, SEP } from './shared.js';
-import { formatTokens, formatDuration, formatCost, formatBurnRate } from '../utils/format.js';
+import { formatTokens, formatCost, formatBurnRate } from '../utils/format.js';
 import { getConfigHealth } from '../parsers/config-health.js';
 import type { RenderContext } from '../types.js';
 
@@ -26,7 +26,7 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
   // Context bar
   if (display.contextBar) {
     const pct = input.context.usedPercentage;
-    leftParts.push(buildContextBar(pct, c, { iconSet: icons }));
+    leftParts.push(buildContextBar(pct, c, { iconSet: icons, cols }));
   }
 
   // Context tokens — prefer windowSize from payload over back-derivation.
@@ -69,16 +69,6 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
     leftParts.push(costPart);
   }
 
-  // Duration (Claude only)
-  if (display.duration && input.durationMs != null) {
-    leftParts.push(`${icons.clock} ${formatDuration(input.durationMs)}`);
-  }
-
-  // Memory
-  if (display.memory && memory) {
-    leftParts.push(c.dim(`${memory.percentage}% mem`));
-  }
-
   // MCP servers
   if (display.mcp && mcp) {
     const total = mcp.servers.length;
@@ -92,11 +82,6 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
 
   // Qwen metrics (shared helper)
   leftParts.push(...formatQwenMetrics(input, c, icons));
-
-  // Token speed
-  if (display.tokenSpeed && tokenSpeed != null) {
-    leftParts.push(c.dim(`${icons.bolt}${tokenSpeed} tok/s`));
-  }
 
   // Rate limits (only show if >=50%)
   if (display.rateLimits && input.rateLimits) {
@@ -154,7 +139,6 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
     }
   }
 
-  const leftStr = leftParts.join(SEP);
-  if (rightParts.length === 0) return leftStr;
-  return padLine(leftStr, rightParts.join(' '), cols);
+  if (leftParts.length === 0 && rightParts.length === 0) return '';
+  return fitSegments(leftParts, rightParts, SEP, cols);
 }

--- a/src/render/line3.ts
+++ b/src/render/line3.ts
@@ -14,7 +14,7 @@ function buildToolsPart(tools: ToolEntry[], c: Colors, ic: IconSet): string {
 
   const running = relevant.filter(t => t.status === 'running').slice(-2);
   for (const tool of running) {
-    const target = tool.target ? `: ${truncField(tool.target, 20)}` : '';
+    const target = tool.target ? `: ${truncField(tool.target, 14)}` : '';
     parts.push(c.yellow(`◐ ${tool.name}${target}`));
   }
 

--- a/src/render/powerline-line1.ts
+++ b/src/render/powerline-line1.ts
@@ -1,6 +1,7 @@
 import { basename } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { truncField } from './text.js';
+import { formatDuration } from '../utils/format.js';
 import { hyperlink } from './hyperlink.js';
 import {
   renderPowerline,
@@ -32,7 +33,7 @@ function getActiveTodo(transcript: TranscriptData): string | undefined {
  *   version:  20  (dropped first)
  */
 function buildSegments(ctx: RenderContext, palette: PowerlinePalette): PowerlineSegment[] {
-  const { input, git, transcript, config: { display }, icons } = ctx;
+  const { input, git, transcript, config: { display }, icons, memory, tokenSpeed } = ctx;
   const segments: PowerlineSegment[] = [];
 
   if (display.model) {
@@ -90,6 +91,35 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette): Powerline
       bg: palette.taskBg,
       fg: palette.fg,
       priority: 40,
+    });
+  }
+
+  // System info — moved from line 2 in fix #82 to declutter the metrics line.
+  // Mirror the classic line1 right cluster: duration, memory, tokenSpeed.
+  if (display.duration && input.durationMs != null) {
+    segments.push({
+      text: `${icons.clock} ${formatDuration(input.durationMs)}`,
+      bg: palette.branchCleanBg,
+      fg: palette.fg,
+      priority: 35,
+    });
+  }
+
+  if (display.memory && memory) {
+    segments.push({
+      text: `${memory.percentage}% mem`,
+      bg: palette.branchCleanBg,
+      fg: palette.fg,
+      priority: 30,
+    });
+  }
+
+  if (display.tokenSpeed && tokenSpeed != null) {
+    segments.push({
+      text: `${icons.bolt}${tokenSpeed} tok/s`,
+      bg: palette.branchCleanBg,
+      fg: palette.fg,
+      priority: 25,
     });
   }
 

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -33,7 +33,7 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
   // Context bar — always highest priority. plain=true so the bar cells inherit
   // the powerline segment bg; only %/icon/hint emit color escapes.
   if (display.contextBar) {
-    const bar = buildContextBar(input.context.usedPercentage, c, { iconSet: icons, plain: true });
+    const bar = buildContextBar(input.context.usedPercentage, c, { iconSet: icons, plain: true, cols: ctx.cols });
     segments.push({ text: bar, bg: palette.modelBg, fg: palette.fg, priority: 100 });
   }
 

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -5,7 +5,7 @@ import {
   type PowerlineStyleName,
 } from './powerline.js';
 import { buildContextBar } from './shared.js';
-import { formatTokens, formatCost, formatDuration } from '../utils/format.js';
+import { formatTokens, formatCost } from '../utils/format.js';
 import type { ColorMode, Colors } from './colors.js';
 import type { RenderContext } from '../types.js';
 import {
@@ -47,11 +47,6 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
   // Cost
   if (display.cost && input.cost != null) {
     segments.push({ text: formatCost(input.cost), bg: palette.taskBg, fg: palette.fg, priority: 60 });
-  }
-
-  // Duration
-  if (display.duration && input.durationMs != null) {
-    segments.push({ text: `${icons.clock} ${formatDuration(input.durationMs)}`, bg: palette.branchCleanBg, fg: palette.fg, priority: 40 });
   }
 
   // Rate limits — only show if >=50%

--- a/src/render/shared.ts
+++ b/src/render/shared.ts
@@ -22,10 +22,18 @@ export interface ContextBarOpts {
    * the powerline renderer; classic mode leaves it false.
    */
   plain?: boolean;
+  /** Terminal width; used to pick an adaptive segment count when `segments` is not set. */
+  cols?: number;
+}
+
+function adaptiveSegments(cols?: number): number {
+  if (cols == null || cols >= 100) return 20;
+  if (cols >= 60) return 12;
+  return 8;
 }
 
 export function buildContextBar(pct: number, c: Colors, opts?: ContextBarOpts): string {
-  const segments = opts?.segments ?? 20;
+  const segments = opts?.segments ?? adaptiveSegments(opts?.cols);
   const showIcons = opts?.showIcons ?? true;
   const showHint = opts?.showHint ?? true;
   const plain = opts?.plain ?? false;

--- a/tests/render/line1.test.ts
+++ b/tests/render/line1.test.ts
@@ -106,4 +106,39 @@ describe('renderLine1', () => {
     const out = stripAnsi(renderLine1(makeCtx({ git: { ...git, branch: longBranch }, cols: 120 }), c));
     expect(out.length).toBeLessThanOrEqual(120);
   });
+
+  it('shows duration when display.duration is true and durationMs is set', () => {
+    const out = stripAnsi(renderLine1(makeCtx(), c));
+    // baseInput has total_duration_ms: 60000 → 1m00s
+    expect(out).toContain('1m00s');
+  });
+
+  it('hides duration when display.duration is false', () => {
+    const out = stripAnsi(renderLine1(makeCtx({ config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, duration: false } } }), c));
+    expect(out).not.toContain('m00s');
+  });
+
+  it('shows memory when provided and display.memory is true', () => {
+    const memory = { usedBytes: 8e9, totalBytes: 16e9, percentage: 50 };
+    const out = stripAnsi(renderLine1(makeCtx({ memory }), c));
+    expect(out).toContain('50%');
+    expect(out).toContain('mem');
+  });
+
+  it('hides memory when display.memory is false', () => {
+    const memory = { usedBytes: 8e9, totalBytes: 16e9, percentage: 50 };
+    const out = stripAnsi(renderLine1(makeCtx({ memory, config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, memory: false } } }), c));
+    expect(out).not.toContain('mem');
+  });
+
+  it('shows tokenSpeed when provided and display.tokenSpeed is true', () => {
+    const out = stripAnsi(renderLine1(makeCtx({ tokenSpeed: 142 }), c));
+    expect(out).toContain('142');
+    expect(out).toContain('tok/s');
+  });
+
+  it('hides tokenSpeed when display.tokenSpeed is false', () => {
+    const out = stripAnsi(renderLine1(makeCtx({ tokenSpeed: 142, config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, tokenSpeed: false } } }), c));
+    expect(out).not.toContain('tok/s');
+  });
 });

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -59,11 +59,6 @@ describe('renderLine2', () => {
     expect(out).not.toContain('/h');
   });
 
-  it('shows token speed when provided', () => {
-    const out = stripAnsi(renderLine2(makeCtx({ tokenSpeed: 142 }), c));
-    expect(out).toContain('142');
-  });
-
   it('does not show rate limits below 50%', () => {
     const inputOverride = { rate_limits: { five_hour: { used_percentage: 30 } } };
     const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
@@ -96,13 +91,6 @@ describe('renderLine2', () => {
   it('shows effort when low', () => {
     const out = stripAnsi(renderLine2(makeCtx({ transcript: { ...EMPTY_TRANSCRIPT, thinkingEffort: 'low' } }), c));
     expect(out).toContain('^low');
-  });
-
-  it('shows memory percentage when provided', () => {
-    const memory = { usedBytes: 8e9, totalBytes: 16e9, percentage: 50 };
-    const out = stripAnsi(renderLine2(makeCtx({ memory }), c));
-    expect(out).toContain('50%');
-    expect(out).toContain('mem');
   });
 
   it('shows cache hit rate when cache_read_input_tokens present', () => {
@@ -178,6 +166,16 @@ describe('renderLine2', () => {
     const inputOverride = { context_window: { ...baseInput.context_window, used_percentage: 50, total_input_tokens: 100000 } };
     const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
     expect(out).toContain('100k/200k');
+  });
+
+  it('drops trailing segments via fitSegments when cols is narrow', () => {
+    // At cols=60, many segments should still fit within the terminal width
+    const inputOverride = {
+      rate_limits: { five_hour: { used_percentage: 75 } },
+      context_window: { ...baseInput.context_window, cache_read_input_tokens: 80000 },
+    };
+    const out = stripAnsi(renderLine2(makeCtx({ cols: 60 }, inputOverride), c));
+    expect(out.length).toBeLessThanOrEqual(64); // fitSegments enforces cols - 4
   });
 });
 

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -176,6 +176,9 @@ describe('renderLine2', () => {
     };
     const out = stripAnsi(renderLine2(makeCtx({ cols: 60 }, inputOverride), c));
     expect(out.length).toBeLessThanOrEqual(64); // fitSegments enforces cols - 4
+    // High-priority segment (context bar) survives; low-priority rate limit drops.
+    expect(out).toMatch(/\d+%/); // context % is present
+    expect(out).not.toContain('75%(5h)'); // rate-limit segment got dropped
   });
 });
 

--- a/tests/render/shared.test.ts
+++ b/tests/render/shared.test.ts
@@ -68,6 +68,19 @@ describe('buildContextBar', () => {
     // 8-segment bar is shorter than 12-segment
     expect(bar50.length).toBeLessThan(bar60.length);
   });
+
+  it('pins exact bar lengths at boundaries (regression guard)', () => {
+    // The bar prefix counts filled+empty cells; the rest is " 50%" suffix.
+    const cellsAt = (cols: number) => {
+      const out = stripAnsi(buildContextBar(50, c, { cols }));
+      const m = out.match(/^[█░]+/);
+      return m ? m[0].length : 0;
+    };
+    expect(cellsAt(100)).toBe(20); // exact boundary: ≥100 → 20
+    expect(cellsAt(99)).toBe(12);  // one below → 12
+    expect(cellsAt(60)).toBe(12);  // exact boundary: ≥60 → 12
+    expect(cellsAt(59)).toBe(8);   // one below → 8
+  });
 });
 
 describe('formatGitChanges', () => {

--- a/tests/render/shared.test.ts
+++ b/tests/render/shared.test.ts
@@ -48,6 +48,26 @@ describe('buildContextBar', () => {
     const bar70 = buildContextBar(70, c, { showIcons: false });
     expect(bar70).not.toContain('\uF06D');
   });
+
+  it('uses 20 segments at cols >= 100 (adaptive default)', () => {
+    const bar100 = stripAnsi(buildContextBar(50, c, { cols: 120 }));
+    const barDefault = stripAnsi(buildContextBar(50, c));
+    expect(bar100.length).toBe(barDefault.length);
+  });
+
+  it('uses 12 segments at cols=60-99 (adaptive)', () => {
+    const bar60 = stripAnsi(buildContextBar(50, c, { cols: 60 }));
+    const bar100 = stripAnsi(buildContextBar(50, c, { cols: 120 }));
+    // 12-segment bar is shorter than 20-segment
+    expect(bar60.length).toBeLessThan(bar100.length);
+  });
+
+  it('uses 8 segments at cols < 60 (adaptive)', () => {
+    const bar50 = stripAnsi(buildContextBar(50, c, { cols: 59 }));
+    const bar60 = stripAnsi(buildContextBar(50, c, { cols: 60 }));
+    // 8-segment bar is shorter than 12-segment
+    expect(bar50.length).toBeLessThan(bar60.length);
+  });
 });
 
 describe('formatGitChanges', () => {


### PR DESCRIPTION
## Summary

- Moves `duration`, `memory`, and `tokenSpeed` segments from line 2 to line 1's right cluster, reducing line 2 density from 9 to 6 segments
- Replaces `padLine` with `fitSegments` in line 2 so segments are silently dropped when the terminal is narrow instead of overflowing
- Adds adaptive context bar width: 20 segments at ≥100 cols, 12 at 60–99, 8 below 60
- Tightens tool-target path truncation in line 3 from 20 to 14 chars

Closes #82

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 507 tests pass (8 new added)
- [x] Moved `shows memory percentage` and `shows token speed` assertions from line2 to line1 tests
- [x] New line1 tests: duration/memory/tokenSpeed shown and hidden per display toggle
- [x] New line2 test: output fits within cols when many segments present at narrow terminal
- [x] New shared tests: adaptive segment count at cols=60 and cols<60