### PR TITLE
fix(render): use windowSize for context tokens in powerline-line2

### DIFF
--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -37,11 +37,18 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
     segments.push({ text: bar, bg: palette.modelBg, fg: palette.fg, priority: 100 });
   }
 
-  // Context tokens
-  if (display.contextTokens && input.tokens.input > 0 && input.context.usedPercentage > 0) {
-    const used = input.tokens.input;
-    const capacity = Math.round(used / (input.context.usedPercentage / 100));
-    segments.push({ text: `${formatTokens(used)}/${formatTokens(capacity)}`, bg: palette.dirBg, fg: palette.fg, priority: 80 });
+  // Context tokens — prefer windowSize from payload over back-derivation.
+  // total_input_tokens is cumulative across the session; current context size
+  // is windowSize × usedPercentage / 100. Falls back to back-derivation for
+  // legacy payloads without context_window_size. Mirrors line2.ts behaviour.
+  if (display.contextTokens && input.context.usedPercentage > 0) {
+    const pct = input.context.usedPercentage;
+    const capacity = input.context.windowSize
+      ?? (input.tokens.input > 0 ? Math.round(input.tokens.input / (pct / 100)) : 0);
+    if (capacity > 0) {
+      const used = Math.round(capacity * pct / 100);
+      segments.push({ text: `${formatTokens(used)}/${formatTokens(capacity)}`, bg: palette.dirBg, fg: palette.fg, priority: 80 });
+    }
   }
 
   // Cost

--- a/tests/render/powerline-line2.test.ts
+++ b/tests/render/powerline-line2.test.ts
@@ -46,6 +46,28 @@ describe('renderPowerlineLine2', () => {
     expect(out).toContain('$');
   });
 
+  it('uses context_window_size as capacity, not back-derived from cumulative input', () => {
+    // total_input_tokens (957k) is cumulative; real context = 18% of 1M = 180k.
+    // Pre-fix would have shown 957k/5.3M (back-derived from 957k/0.18).
+    const rawInput = {
+      model: 'Claude Sonnet 4.6',
+      session_id: 'test',
+      context_window: {
+        used_percentage: 18,
+        remaining_percentage: 82,
+        total_input_tokens: 957000,
+        total_output_tokens: 1656000,
+        context_window_size: 1000000,
+      },
+      cost: { total_cost_usd: 0.42, total_duration_ms: 185000 },
+    };
+    const ctx = makeCtx({ input: normalize(rawInput) });
+    const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+    expect(out).toContain('180k/1.0M');
+    expect(out).not.toContain('5.3M');
+    expect(out).not.toContain('957k/');
+  });
+
   it('returns empty string when all display toggles are off', () => {
     const ctx = makeCtx({
       config: {


### PR DESCRIPTION
## Why?

PR #81 (`fix/cache-metrics-overflow`) corrected the contextTokens calculation in classic `line2.ts` but missed the powerline equivalent. Found by post-merge review of #84 — same root-cause regression in a different render path.

`powerline-line2.ts` was still back-deriving capacity from cumulative `total_input_tokens`, producing wrong displays like `957k/5.3M` for a 1M-context session at 18% used. The classic renderer correctly shows `180k/1.0M` — powerline users were silently seeing wrong numbers.

## What changed?

`src/render/powerline-line2.ts:40-50` — mirrors the same `windowSize ?? back-derivation` pattern from `line2.ts`:

```ts
const capacity = input.context.windowSize
  ?? (input.tokens.input > 0 ? Math.round(input.tokens.input / (pct / 100)) : 0);
const used = Math.round(capacity * pct / 100);
```

Falls back to back-derivation only if the modern `context_window_size` field is absent (legacy CC payloads pre-2.1.x).

## Tests

- New test in `tests/render/powerline-line2.test.ts` asserts `180k/1.0M` from a real-shape 2.1.x payload (1M window, 18% used, 957k cumulative input)
- 509 tests passing, build clean