### PR TITLE
feat(config): configurable context bar thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Configurable context bar thresholds** — `display.contextWarningThreshold` (default `70`) and `display.contextCriticalThreshold` (default `85`) let users tune when the context bar transitions through yellow/orange/red. Set both lower if you prefer earlier warnings, or higher if your workflow tolerates fuller buffers.
+
+### Changed
+- **Default color transitions shifted from 50/65/80 to 50/70/85.** The bar now stays yellow up to 70% (was 65%) and orange up to 85% (was 80%) before flashing red. If you preferred the old behavior, set `display.contextWarningThreshold: 65` and `display.contextCriticalThreshold: 80` in your config.
+
+### Fixed
+- **`getContextColor` now respects custom warning thresholds below the 50% green floor.** Previously a hardcoded `pct < 50 → green` short-circuit ignored `contextWarningThreshold` when set below 50, so a user with `contextWarningThreshold: 30` would still see green at 40%. The function now only returns green when both `pct < warning` and `pct < 50`.
+
 ## [0.7.1] - 2026-05-04
 
 ### Fixed

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,14 +1,47 @@
 import { readFileSync, existsSync, writeFileSync, renameSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
-import { DEFAULT_CONFIG, DEFAULT_DISPLAY, POWERLINE_STYLE_NAMES, type HudConfig, type DisplayToggles, type ColorConfig } from './types.js';
+import { DEFAULT_CONFIG, DEFAULT_DISPLAY, DEFAULT_CONTEXT_WARNING_THRESHOLD, DEFAULT_CONTEXT_CRITICAL_THRESHOLD, POWERLINE_STYLE_NAMES, type HudConfig, type DisplayToggles, type ColorConfig } from './types.js';
 
 // Module-level flag: fires the qwen→minimal deprecation warning once per
 // Node process. Process-scoped by design — tests must run in forked workers
 // (see vitest.config.ts `pool: 'forks'`). Issue #20.
 let qwenWarningShown = false;
+let thresholdWarningShown = false;
 /** Test-only — resets the process-scoped qwenWarningShown flag. Do not call in production. */
-export function _resetMigrationFlags(): void { qwenWarningShown = false; }
+export function _resetMigrationFlags(): void { qwenWarningShown = false; thresholdWarningShown = false; }
+
+const clampPct = (n: number): number => Math.max(0, Math.min(100, n));
+
+/**
+ * Validate context-bar threshold pair. Clamps each to [0, 100]. If `warning`
+ * is not strictly less than `critical` after clamping, emits a one-shot warn
+ * to stderr and returns the defaults (70/85). Falls back to defaults if a
+ * value is missing or non-finite.
+ */
+function resolveThresholds(
+  rawWarn: unknown,
+  rawCrit: unknown,
+): { warning: number; critical: number } {
+  const hasWarn = typeof rawWarn === 'number' && Number.isFinite(rawWarn);
+  const hasCrit = typeof rawCrit === 'number' && Number.isFinite(rawCrit);
+  if (!hasWarn && !hasCrit) {
+    return { warning: DEFAULT_CONTEXT_WARNING_THRESHOLD, critical: DEFAULT_CONTEXT_CRITICAL_THRESHOLD };
+  }
+  const warning = hasWarn ? clampPct(rawWarn as number) : DEFAULT_CONTEXT_WARNING_THRESHOLD;
+  const critical = hasCrit ? clampPct(rawCrit as number) : DEFAULT_CONTEXT_CRITICAL_THRESHOLD;
+  if (warning >= critical) {
+    if (!thresholdWarningShown) {
+      process.stderr.write(
+        `[lumira] context thresholds invalid (warning=${warning}, critical=${critical}); ` +
+        `falling back to defaults (${DEFAULT_CONTEXT_WARNING_THRESHOLD}/${DEFAULT_CONTEXT_CRITICAL_THRESHOLD})\n`,
+      );
+      thresholdWarningShown = true;
+    }
+    return { warning: DEFAULT_CONTEXT_WARNING_THRESHOLD, critical: DEFAULT_CONTEXT_CRITICAL_THRESHOLD };
+  }
+  return { warning, critical };
+}
 
 export function loadConfig(configDir: string = join(homedir(), '.config', 'lumira')): HudConfig {
   const p = join(configDir, 'config.json');
@@ -42,9 +75,13 @@ function mergeConfig(rawIn: Record<string, unknown>): HudConfig {
 
   // Then overlay user's explicit display toggles (user wins over preset)
   if (raw.display && typeof raw.display === 'object') {
+    const rawDisplay = raw.display as Record<string, unknown>;
     for (const k of Object.keys(DEFAULT_DISPLAY) as (keyof DisplayToggles)[]) {
-      if (typeof (raw.display as Record<string, unknown>)[k] === 'boolean') result.display[k] = (raw.display as Record<string, boolean>)[k];
+      if (typeof rawDisplay[k] === 'boolean') (result.display[k] as boolean) = rawDisplay[k] as boolean;
     }
+    const { warning, critical } = resolveThresholds(rawDisplay.contextWarningThreshold, rawDisplay.contextCriticalThreshold);
+    result.display.contextWarningThreshold = warning;
+    result.display.contextCriticalThreshold = critical;
   }
 
   if (typeof raw.theme === 'string' && raw.theme.length > 0) result.theme = raw.theme;
@@ -120,7 +157,7 @@ export function applyPreset(r: HudConfig, preset: NonNullable<HudConfig['preset'
   r.preset = preset;
   r.layout = def.layout;
   for (const [k, v] of Object.entries(def.display)) {
-    r.display[k as keyof DisplayToggles] = v as boolean;
+    (r.display as unknown as Record<string, unknown>)[k] = v;
   }
 }
 

--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -87,8 +87,7 @@ export function getContextColor(
   warning = 70,
   critical = 85,
 ): ColorName {
-  if (pct < 50) return 'green';
-  if (pct < warning) return 'yellow';
+  if (pct < warning) return pct < 50 ? 'green' : 'yellow';
   if (pct < critical) return 'orange';
   return 'blinkRed';
 }

--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -82,10 +82,14 @@ export function detectColorMode(): ColorMode {
   return 'named';
 }
 
-export function getContextColor(pct: number): ColorName {
+export function getContextColor(
+  pct: number,
+  warning = 70,
+  critical = 85,
+): ColorName {
   if (pct < 50) return 'green';
-  if (pct < 65) return 'yellow';
-  if (pct < 80) return 'orange';
+  if (pct < warning) return 'yellow';
+  if (pct < critical) return 'orange';
   return 'blinkRed';
 }
 

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -26,7 +26,12 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
   // Context bar
   if (display.contextBar) {
     const pct = input.context.usedPercentage;
-    leftParts.push(buildContextBar(pct, c, { iconSet: icons, cols }));
+    leftParts.push(buildContextBar(pct, c, {
+      iconSet: icons,
+      cols,
+      warningThreshold: display.contextWarningThreshold,
+      criticalThreshold: display.contextCriticalThreshold,
+    }));
   }
 
   // Context tokens — prefer windowSize from payload over back-derivation.

--- a/src/render/minimal.ts
+++ b/src/render/minimal.ts
@@ -40,7 +40,13 @@ export function renderMinimal(ctx: RenderContext, c: Colors): string {
     // `showHint: false` — the minimal preset targets tight single-line terminals,
     // where the /compact hint's ~10 trailing chars pushes truncation earlier. Users
     // on minimal can still read the blinking skull icon as an at-risk signal.
-    parts.push(buildContextBar(input.context.usedPercentage, c, { segments: 10, iconSet: icons, showHint: false }));
+    parts.push(buildContextBar(input.context.usedPercentage, c, {
+      segments: 10,
+      iconSet: icons,
+      showHint: false,
+      warningThreshold: display.contextWarningThreshold,
+      criticalThreshold: display.contextCriticalThreshold,
+    }));
   }
 
   // Only add these if cols >= 60

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -33,7 +33,13 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
   // Context bar — always highest priority. plain=true so the bar cells inherit
   // the powerline segment bg; only %/icon/hint emit color escapes.
   if (display.contextBar) {
-    const bar = buildContextBar(input.context.usedPercentage, c, { iconSet: icons, plain: true, cols: ctx.cols });
+    const bar = buildContextBar(input.context.usedPercentage, c, {
+      iconSet: icons,
+      plain: true,
+      cols: ctx.cols,
+      warningThreshold: display.contextWarningThreshold,
+      criticalThreshold: display.contextCriticalThreshold,
+    });
     segments.push({ text: bar, bg: palette.modelBg, fg: palette.fg, priority: 100 });
   }
 

--- a/src/render/shared.ts
+++ b/src/render/shared.ts
@@ -24,6 +24,10 @@ export interface ContextBarOpts {
   plain?: boolean;
   /** Terminal width; used to pick an adaptive segment count when `segments` is not set. */
   cols?: number;
+  /** Percentage at which the bar turns orange and shows the fire icon. Default 70. */
+  warningThreshold?: number;
+  /** Percentage at which the bar turns red/blinking and shows the skull icon. Default 85. */
+  criticalThreshold?: number;
 }
 
 function adaptiveSegments(cols?: number): number {
@@ -38,9 +42,11 @@ export function buildContextBar(pct: number, c: Colors, opts?: ContextBarOpts): 
   const showHint = opts?.showHint ?? true;
   const plain = opts?.plain ?? false;
   const ic = opts?.iconSet ?? NERD_ICONS;
+  const warning = opts?.warningThreshold ?? 70;
+  const critical = opts?.criticalThreshold ?? 85;
 
   const filled = Math.round((pct / 100) * segments);
-  const colorFn = c[getContextColor(pct)];
+  const colorFn = c[getContextColor(pct, warning, critical)];
   // In plain mode the bar cells emit no ANSI — terminal default fg over
   // whatever bg the caller has set. The empty-cell `dim` is also suppressed
   // because `\x1b[2m...\x1b[0m` would still close out the caller's bg.
@@ -50,16 +56,16 @@ export function buildContextBar(pct: number, c: Colors, opts?: ContextBarOpts): 
 
   let icon = '';
   if (showIcons) {
-    if (pct >= 80) icon = c.blinkRed(ic.skull);
-    else if (pct >= 65) icon = c.orange(ic.fire);
+    if (pct >= critical) icon = c.blinkRed(ic.skull);
+    else if (pct >= warning) icon = c.orange(ic.fire);
   }
 
   // Actionable hint at high fill — nudges the user to reclaim context before
   // the session stalls. Thresholds align with the color/icon tiers above.
   let hint = '';
   if (showHint) {
-    if (pct >= 90) hint = ' ' + c.red('/compact!');
-    else if (pct >= 80) hint = ' ' + c.dim('/compact?');
+    if (pct >= critical + 5) hint = ' ' + c.red('/compact!');
+    else if (pct >= critical) hint = ' ' + c.dim('/compact?');
   }
 
   const pctStr = colorFn(`${pct < 10 ? pct.toFixed(1) : pct.toFixed(0)}%`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -218,6 +218,10 @@ export interface DisplayToggles {
   cacheMetrics: boolean;
   mcp: boolean;
   health: boolean;
+  /** Percentage at which the context bar turns orange and shows the fire icon. Default 70. Clamped [0,100]. */
+  contextWarningThreshold: number;
+  /** Percentage at which the context bar turns red/blinking and shows the skull icon. Default 85. Clamped [0,100]. Must be > contextWarningThreshold. */
+  contextCriticalThreshold: number;
 }
 
 export interface ColorConfig {
@@ -251,7 +255,13 @@ export const DEFAULT_DISPLAY: DisplayToggles = {
   cacheMetrics: true,
   mcp: true,
   health: false,
+  contextWarningThreshold: 70,
+  contextCriticalThreshold: 85,
 };
+
+/** Default thresholds — used as fallback when user-provided values are invalid. */
+export const DEFAULT_CONTEXT_WARNING_THRESHOLD = 70;
+export const DEFAULT_CONTEXT_CRITICAL_THRESHOLD = 85;
 
 export const DEFAULT_CONFIG: HudConfig = {
   layout: 'auto',

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -129,6 +129,70 @@ describe('loadConfig', () => {
       expect(loadConfig(dir).powerline?.style).toBe(s);
     }
   });
+
+  describe('context bar thresholds', () => {
+    beforeEach(() => { _resetMigrationFlags(); });
+
+    it('defaults to 70/85 when omitted', () => {
+      expect(loadConfig(join(dir, 'nope')).display.contextWarningThreshold).toBe(70);
+      expect(loadConfig(join(dir, 'nope')).display.contextCriticalThreshold).toBe(85);
+    });
+
+    it('accepts valid user values', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), '{"display":{"contextWarningThreshold":60,"contextCriticalThreshold":80}}');
+      const c = loadConfig(dir);
+      expect(c.display.contextWarningThreshold).toBe(60);
+      expect(c.display.contextCriticalThreshold).toBe(80);
+    });
+
+    it('clamps values above 100 to 100', () => {
+      mkdirSync(dir, { recursive: true });
+      // 150 → 100, 50 → 50, but 100 >= 50 means inverted → falls back to defaults
+      writeFileSync(join(dir, 'config.json'), '{"display":{"contextWarningThreshold":50,"contextCriticalThreshold":150}}');
+      const c = loadConfig(dir);
+      expect(c.display.contextWarningThreshold).toBe(50);
+      expect(c.display.contextCriticalThreshold).toBe(100);
+    });
+
+    it('clamps negative values to 0', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), '{"display":{"contextWarningThreshold":-10,"contextCriticalThreshold":50}}');
+      const c = loadConfig(dir);
+      expect(c.display.contextWarningThreshold).toBe(0);
+      expect(c.display.contextCriticalThreshold).toBe(50);
+    });
+
+    it('falls back to defaults when warning >= critical (inverted)', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), '{"display":{"contextWarningThreshold":90,"contextCriticalThreshold":50}}');
+      const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const c = loadConfig(dir);
+      expect(c.display.contextWarningThreshold).toBe(70);
+      expect(c.display.contextCriticalThreshold).toBe(85);
+      expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('thresholds invalid'));
+      errSpy.mockRestore();
+    });
+
+    it('emits the inversion warn only once per process', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), '{"display":{"contextWarningThreshold":90,"contextCriticalThreshold":50}}');
+      const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      loadConfig(dir);
+      loadConfig(dir);
+      loadConfig(dir);
+      expect(errSpy.mock.calls.filter(c => String(c[0]).includes('thresholds invalid')).length).toBe(1);
+      errSpy.mockRestore();
+    });
+
+    it('preserves defaults when only one value is supplied and the pair is valid', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), '{"display":{"contextWarningThreshold":60}}');
+      const c = loadConfig(dir);
+      expect(c.display.contextWarningThreshold).toBe(60);
+      expect(c.display.contextCriticalThreshold).toBe(85);
+    });
+  });
 });
 
 describe('mergeCliFlags', () => {

--- a/tests/render/colors.test.ts
+++ b/tests/render/colors.test.ts
@@ -62,10 +62,36 @@ describe('createColors', () => {
 });
 
 describe('getContextColor', () => {
-  it('returns green for <50%', () => { expect(getContextColor(30)).toBe('green'); });
-  it('returns yellow for 50-64%', () => { expect(getContextColor(55)).toBe('yellow'); });
-  it('returns orange for 65-79%', () => { expect(getContextColor(70)).toBe('orange'); });
-  it('returns blinkRed for >=80%', () => { expect(getContextColor(85)).toBe('blinkRed'); });
+  it('returns green for <50% with default thresholds', () => { expect(getContextColor(30)).toBe('green'); });
+  it('returns yellow for 50-69% with default thresholds', () => { expect(getContextColor(55)).toBe('yellow'); });
+  it('returns orange for 70-84% with default thresholds', () => { expect(getContextColor(70)).toBe('orange'); });
+  it('returns blinkRed for >=85% with default thresholds', () => { expect(getContextColor(85)).toBe('blinkRed'); });
+
+  describe('with custom thresholds where warning < 50', () => {
+    // warning=30, critical=60: green floor (50) is above warning, so semantics
+    // collapse to green = below warning, orange = warning..critical, red = >=critical.
+    it('returns green when below warning and below 50 floor', () => {
+      expect(getContextColor(20, 30, 60)).toBe('green');
+    });
+    it('returns orange when at or above warning but below critical', () => {
+      expect(getContextColor(40, 30, 60)).toBe('orange');
+    });
+    it('returns orange just below critical', () => {
+      expect(getContextColor(55, 30, 60)).toBe('orange');
+    });
+    it('returns blinkRed when at or above critical', () => {
+      expect(getContextColor(70, 30, 60)).toBe('blinkRed');
+    });
+  });
+
+  describe('with custom thresholds where warning > 50', () => {
+    it('returns green below 50 even with high warning threshold', () => {
+      expect(getContextColor(48, 60, 80)).toBe('green');
+    });
+    it('returns yellow between 50 and warning', () => {
+      expect(getContextColor(55, 60, 80)).toBe('yellow');
+    });
+  });
 });
 
 describe('getQuotaColor', () => {

--- a/tests/render/shared.test.ts
+++ b/tests/render/shared.test.ts
@@ -115,29 +115,29 @@ describe('formatGitChanges', () => {
 });
 
 describe('buildContextBar — compact hint', () => {
-  it('shows /compact? hint at 80-89%', () => {
+  it('shows /compact? hint at critical-(critical+5)% (default 85-89%)', () => {
+    const bar = stripAnsi(buildContextBar(87, c));
+    expect(bar).toContain('/compact?');
+    expect(bar).not.toContain('/compact!');
+  });
+
+  it('shows /compact! hint at >= critical+5% (default 90%+)', () => {
+    const bar = stripAnsi(buildContextBar(95, c));
+    expect(bar).toContain('/compact!');
+  });
+
+  it('does not show compact hint below critical (default 85%)', () => {
+    const bar = stripAnsi(buildContextBar(80, c));
+    expect(bar).not.toContain('/compact');
+  });
+
+  it('shows /compact? at exactly critical (default 85%) — boundary inclusive', () => {
     const bar = stripAnsi(buildContextBar(85, c));
     expect(bar).toContain('/compact?');
     expect(bar).not.toContain('/compact!');
   });
 
-  it('shows /compact! hint at 90%+', () => {
-    const bar = stripAnsi(buildContextBar(95, c));
-    expect(bar).toContain('/compact!');
-  });
-
-  it('does not show compact hint below 80%', () => {
-    const bar = stripAnsi(buildContextBar(70, c));
-    expect(bar).not.toContain('/compact');
-  });
-
-  it('shows /compact? at exactly 80% (boundary inclusive)', () => {
-    const bar = stripAnsi(buildContextBar(80, c));
-    expect(bar).toContain('/compact?');
-    expect(bar).not.toContain('/compact!');
-  });
-
-  it('shows /compact! at exactly 90% (boundary inclusive)', () => {
+  it('shows /compact! at exactly critical+5 (default 90%) — boundary inclusive', () => {
     const bar = stripAnsi(buildContextBar(90, c));
     expect(bar).toContain('/compact!');
   });
@@ -176,6 +176,42 @@ describe('buildContextBar — plain mode (powerline)', () => {
   it('classic mode (plain=false) is unchanged — still uses \\x1b[0m', () => {
     const out = buildContextBar(50, c, { plain: false });
     expect(out).toContain('\x1b[0m');
+  });
+});
+
+describe('buildContextBar — configurable thresholds', () => {
+  it('respects custom warningThreshold for fire icon', () => {
+    // With warning=50, fire should show at 50% (no longer green/yellow zone)
+    const bar = buildContextBar(50, c, { warningThreshold: 50, criticalThreshold: 90 });
+    expect(bar).toContain(''); // fire icon
+  });
+
+  it('respects custom criticalThreshold for skull icon', () => {
+    // With critical=60, skull should show at 60%
+    const bar = buildContextBar(60, c, { warningThreshold: 30, criticalThreshold: 60 });
+    expect(bar).toContain(''); // skull icon
+  });
+
+  it('color transitions to orange at custom warning threshold', () => {
+    // With warning=40, pct=45 should be orange (\x1b[38;5;208m), not yellow
+    const bar = buildContextBar(45, c, { warningThreshold: 40, criticalThreshold: 80 });
+    expect(bar).toContain('\x1b[38;5;208m');
+  });
+
+  it('color transitions to blinkRed at custom critical threshold', () => {
+    // With critical=50, pct=55 should be blinkRed (\x1b[5;31m)
+    const bar = buildContextBar(55, c, { warningThreshold: 30, criticalThreshold: 50 });
+    expect(bar).toContain('\x1b[5;31m');
+  });
+
+  it('default thresholds (70/85) preserved when opts omitted', () => {
+    // pct=72 → fire icon (>=70), still orange (<85)
+    const bar = buildContextBar(72, c);
+    expect(bar).toContain('');
+    expect(bar).not.toContain('');
+    // pct=86 → skull icon (>=85)
+    const skullBar = buildContextBar(86, c);
+    expect(skullBar).toContain('');
   });
 });
 


### PR DESCRIPTION
Closes #86

## Summary
- Adds `display.contextWarningThreshold` (default 70) and `display.contextCriticalThreshold` (default 85) to `DisplayToggles`. Drive context-bar color, fire/skull icon, and `/compact` hint transitions.
- `getContextColor(pct, warning?, critical?)` and `buildContextBar(..., { warningThreshold, criticalThreshold })` accept the thresholds; line2, minimal, and powerline-line2 forward them from config.
- `loadConfig` clamps each value to [0, 100]; if `warning >= critical`, emits a one-shot stderr warn and falls back to defaults (70/85). Reuses the same module-flag pattern as the qwen preset deprecation.
- Note: previous hardcoded color breakpoints were 50/65/80; new defaults align color, icon, and hint with the documented 70/85 contract. The `/compact!` urgent hint trips at `critical + 5` (default 90), preserving the prior dual-tier behavior.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 521 passing (was 509; +12 new)
- [x] New tests cover clamp (>100, <0), inversion fallback + warn-once, defaults preserved when omitted, partial config, and color transitions at custom warning/critical