### PR TITLE
fix(thresholds): tighten followups from PR #87 review

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,12 +253,18 @@ Create `~/.config/lumira/config.json`:
     "version": true,
     "linesChanged": true,
     "memory": true,
-    "health": false
+    "health": false,
+    "contextWarningThreshold": 70,
+    "contextCriticalThreshold": 85
   }
 }
 ```
 
 All fields are optional — defaults are shown above. `display.health` defaults to `false` (opt-in widget).
+
+**Context bar thresholds** — `contextWarningThreshold` (default 70) and `contextCriticalThreshold` (default 85) control when the bar transitions through yellow/orange/red. Both are clamped to `[0, 100]` and `warning < critical` is required (invalid pairs fall back to defaults with a one-shot stderr warning). Lower them for earlier warnings, raise them if your workflow tolerates fuller buffers.
+
+> **Migration note (post-0.7.1):** default color transitions shifted from `50/65/80` to `50/70/85`. The bar now stays yellow up to 70% (was 65%) and orange up to 85% (was 80%) before flashing red. To restore the previous behavior, set `"contextWarningThreshold": 65, "contextCriticalThreshold": 80` in your config.
 
 ### CLI Flags
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -156,8 +156,11 @@ export function applyPreset(r: HudConfig, preset: NonNullable<HudConfig['preset'
   const def = PRESET_DEFS[preset];
   r.preset = preset;
   r.layout = def.layout;
+  // PRESET_DEFS only set boolean toggles — threshold numbers are not
+  // overridable via preset. The runtime guard keeps the cast narrow and
+  // catches accidental non-boolean entries in PRESET_DEFS.
   for (const [k, v] of Object.entries(def.display)) {
-    (r.display as unknown as Record<string, unknown>)[k] = v;
+    if (typeof v === 'boolean') (r.display as unknown as Record<string, boolean>)[k] = v;
   }
 }
 

--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_CONTEXT_WARNING_THRESHOLD, DEFAULT_CONTEXT_CRITICAL_THRESHOLD } from '../types.js';
+
 export type ColorMode = 'named' | '256' | 'truecolor';
 export type ColorName = 'cyan' | 'magenta' | 'yellow' | 'green' | 'orange' | 'red' | 'blinkRed' | 'gray' | 'brightBlue' | 'dim' | 'bold';
 
@@ -82,10 +84,22 @@ export function detectColorMode(): ColorMode {
   return 'named';
 }
 
+/**
+ * Map a context-fill percentage to its alarm color.
+ *
+ * Zones (with default 70/85): green<50, yellow 50–70, orange 70–85, red 85+.
+ *
+ * **Asymmetry by design:** the green→yellow boundary is fixed at 50%, the
+ * "universally healthy" mark. So if a user sets `warning ≤ 50`, the yellow
+ * zone collapses entirely and the bar jumps green→orange at `warning`. That's
+ * consistent with the field's contract ("percentage at which the bar turns
+ * orange") — yellow is just a soft pre-alarm buffer that only exists when
+ * there's room for it between 50 and `warning`.
+ */
 export function getContextColor(
   pct: number,
-  warning = 70,
-  critical = 85,
+  warning = DEFAULT_CONTEXT_WARNING_THRESHOLD,
+  critical = DEFAULT_CONTEXT_CRITICAL_THRESHOLD,
 ): ColorName {
   if (pct < warning) return pct < 50 ? 'green' : 'yellow';
   if (pct < critical) return 'orange';

--- a/src/render/shared.ts
+++ b/src/render/shared.ts
@@ -1,7 +1,7 @@
 import { NERD_ICONS, type IconSet } from './icons.js';
 import { getContextColor, type Colors } from './colors.js';
 import { formatTokens } from '../utils/format.js';
-import type { GitStatus } from '../types.js';
+import { DEFAULT_CONTEXT_WARNING_THRESHOLD, DEFAULT_CONTEXT_CRITICAL_THRESHOLD, type GitStatus } from '../types.js';
 import type { NormalizedInput } from '../normalize.js';
 
 export const SEP = ` \x1b[90m\u2502\x1b[0m `;
@@ -24,7 +24,11 @@ export interface ContextBarOpts {
   plain?: boolean;
   /** Terminal width; used to pick an adaptive segment count when `segments` is not set. */
   cols?: number;
-  /** Percentage at which the bar turns orange and shows the fire icon. Default 70. */
+  /**
+   * Percentage at which the bar turns orange and shows the fire icon. Default 70.
+   * Note: yellow zone exists only when `warningThreshold > 50`; below that, the
+   * bar jumps green→orange directly. See `getContextColor` for details.
+   */
   warningThreshold?: number;
   /** Percentage at which the bar turns red/blinking and shows the skull icon. Default 85. */
   criticalThreshold?: number;
@@ -42,8 +46,8 @@ export function buildContextBar(pct: number, c: Colors, opts?: ContextBarOpts): 
   const showHint = opts?.showHint ?? true;
   const plain = opts?.plain ?? false;
   const ic = opts?.iconSet ?? NERD_ICONS;
-  const warning = opts?.warningThreshold ?? 70;
-  const critical = opts?.criticalThreshold ?? 85;
+  const warning = opts?.warningThreshold ?? DEFAULT_CONTEXT_WARNING_THRESHOLD;
+  const critical = opts?.criticalThreshold ?? DEFAULT_CONTEXT_CRITICAL_THRESHOLD;
 
   const filled = Math.round((pct / 100) * segments);
   const colorFn = c[getContextColor(pct, warning, critical)];

--- a/src/types.ts
+++ b/src/types.ts
@@ -218,7 +218,10 @@ export interface DisplayToggles {
   cacheMetrics: boolean;
   mcp: boolean;
   health: boolean;
-  /** Percentage at which the context bar turns orange and shows the fire icon. Default 70. Clamped [0,100]. */
+  /**
+   * Percentage at which the context bar turns orange and shows the fire icon. Default 70. Clamped [0,100].
+   * Setting this ≤ 50 collapses the yellow zone; the bar jumps green→orange directly at this value.
+   */
   contextWarningThreshold: number;
   /** Percentage at which the context bar turns red/blinking and shows the skull icon. Default 85. Clamped [0,100]. Must be > contextWarningThreshold. */
   contextCriticalThreshold: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -231,6 +231,10 @@ export interface ColorConfig {
   mode: 'auto' | 'named' | '256' | 'truecolor';
 }
 
+/** Default thresholds — used as fallback when user-provided values are invalid. */
+export const DEFAULT_CONTEXT_WARNING_THRESHOLD = 70;
+export const DEFAULT_CONTEXT_CRITICAL_THRESHOLD = 85;
+
 export const DEFAULT_DISPLAY: DisplayToggles = {
   model: true,
   branch: true,
@@ -258,13 +262,9 @@ export const DEFAULT_DISPLAY: DisplayToggles = {
   cacheMetrics: true,
   mcp: true,
   health: false,
-  contextWarningThreshold: 70,
-  contextCriticalThreshold: 85,
+  contextWarningThreshold: DEFAULT_CONTEXT_WARNING_THRESHOLD,
+  contextCriticalThreshold: DEFAULT_CONTEXT_CRITICAL_THRESHOLD,
 };
-
-/** Default thresholds — used as fallback when user-provided values are invalid. */
-export const DEFAULT_CONTEXT_WARNING_THRESHOLD = 70;
-export const DEFAULT_CONTEXT_CRITICAL_THRESHOLD = 85;
 
 export const DEFAULT_CONFIG: HudConfig = {
   layout: 'auto',


### PR DESCRIPTION
Five small follow-ups from the post-merge deep review of #87. Bundled into one PR since each is a few lines.

## Changes

1. **`getContextColor` + `buildContextBar`** now reference `DEFAULT_CONTEXT_WARNING_THRESHOLD` / `DEFAULT_CONTEXT_CRITICAL_THRESHOLD` constants instead of hardcoded `70` / `85` literals. Single source of truth, no drift risk.
2. **Yellow-zone collapse documented.** When `warning <= 50`, the bar jumps green→orange directly with no yellow zone. Added JSDoc notes on `getContextColor`, `ContextBarOpts.warningThreshold`, and `DisplayToggles.contextWarningThreshold` so users setting low thresholds aren't surprised.
3. **README config example** now lists the two threshold fields with a migration callout for the 50/65/80 → 50/70/85 default shift, including the snippet to restore prior behavior.
4. **`applyPreset` cast tightened.** Runtime `typeof === 'boolean'` guard + single `as unknown as Record<string, boolean>` cast (TS rejects the direct cast since `DisplayToggles` now has number fields). Catches accidental non-boolean entries in `PRESET_DEFS`.

## Out of scope

The 5th item from the review (no migration warning to existing users on default config) is addressed via the README callout; CHANGELOG already covers it. A runtime first-run notice would require persisting state — not justified for a default-color shift.

## Tests

527 passing (no behavior change, so no new tests needed). Build clean.