### PR TITLE
test: replace false-confidence assertions with content checks

### DIFF
--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -88,6 +88,7 @@ describe('main', () => {
       getMcpInfo: () => null,
       getTermCols: () => 120,
     });
-    expect(output.length).toBeGreaterThan(0);
+    const plain = stripAnsi(output);
+    expect(plain).toContain('project'); // workspace.current_dir basename rendered in fallback path
   });
 });

--- a/tests/render/index.test.ts
+++ b/tests/render/index.test.ts
@@ -21,7 +21,7 @@ describe('render', () => {
   it('auto-minimal at <70 cols', () => { expect(render(makeCtx({ cols: 60 })).split('\n').length).toBeLessThanOrEqual(2); });
   it('renders with theme config without crashing', () => {
     const out = render(makeCtx({ config: { ...DEFAULT_CONFIG, theme: 'dracula', colors: { mode: 'truecolor' } } }));
-    expect(out).toMatch(/\x1b\[(?:38|48);2;/); // truecolor escape confirms theme colors applied
+    expect(out).toContain('\x1b[38;2;139;233;253m'); // Dracula cyan: rgb(139,233,253) — only present if theme palette is wired
   });
   it('renders with emoji icons without crashing', () => {
     const out = render(makeCtx({ icons: EMOJI_ICONS }));

--- a/tests/render/index.test.ts
+++ b/tests/render/index.test.ts
@@ -3,6 +3,7 @@ import { render } from '../../src/render/index.js';
 import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, type RenderContext } from '../../src/types.js';
 import { NERD_ICONS, EMOJI_ICONS } from '../../src/render/icons.js';
 import { normalize, type Platform } from '../../src/normalize.js';
+import { stripAnsi } from '../../src/render/colors.js';
 
 function makeCtx(ov: Partial<RenderContext> = {}): RenderContext {
   const rawInput = { model: 'Opus', session_id: 't', context_window: { used_percentage: 50, remaining_percentage: 50 }, cost: { total_cost_usd: 1, total_duration_ms: 60000 }, workspace: { current_dir: '/p' } } as any;
@@ -20,11 +21,11 @@ describe('render', () => {
   it('auto-minimal at <70 cols', () => { expect(render(makeCtx({ cols: 60 })).split('\n').length).toBeLessThanOrEqual(2); });
   it('renders with theme config without crashing', () => {
     const out = render(makeCtx({ config: { ...DEFAULT_CONFIG, theme: 'dracula', colors: { mode: 'truecolor' } } }));
-    expect(out.length).toBeGreaterThan(0);
+    expect(out).toMatch(/\x1b\[(?:38|48);2;/); // truecolor escape confirms theme colors applied
   });
   it('renders with emoji icons without crashing', () => {
     const out = render(makeCtx({ icons: EMOJI_ICONS }));
-    expect(out.length).toBeGreaterThan(0);
+    expect(stripAnsi(out)).toContain('🤖'); // EMOJI_ICONS.model glyph present
   });
   it('forces singleline when input platform is qwen-code, even with multiline layout', () => {
     const out = render(makeCtxWithPlatform('qwen-code', 'multiline'));

--- a/tests/render/powerline-line3.test.ts
+++ b/tests/render/powerline-line3.test.ts
@@ -70,7 +70,9 @@ describe('renderPowerlineLine3', () => {
       },
     });
     const out = renderPowerlineLine3(ctx, 'truecolor', null);
-    expect(out).toBeTruthy();
+    const plain = stripAnsi(out);
+    expect(plain).toContain('Edit'); // tool name segment rendered
+    expect(plain).toContain('1/1'); // todo progress segment rendered
     expect(out.endsWith('\x1b[0m')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- `render/index.test.ts` — theme test now asserts truecolor escape present; emoji test asserts `🤖` glyph from `EMOJI_ICONS.model`
- `integration.test.ts` — workspace fallback test asserts `project` basename in stripped output
- `powerline-line3.test.ts` — both-segments test asserts `Edit` (tool) and `1/1` (todo progress) in content

## Why
These tests only checked `out.length > 0` or `toBeTruthy()`. A renderer that returned `"x"` would pass. The new assertions verify the actual observable behaviour the test name claims to cover.

## Test plan
- [ ] All 15 tests in the 3 affected files pass locally
- [ ] Full suite green (`npm test`)