### PR TITLE
test: fix structural assertion quality in line1-4 tests

### DIFF
--- a/tests/render/line1.test.ts
+++ b/tests/render/line1.test.ts
@@ -5,6 +5,7 @@ import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '..
 import type { ClaudeCodeInput, GitStatus, RenderContext } from '../../src/types.js';
 import { NERD_ICONS } from '../../src/render/icons.js';
 import { normalize } from '../../src/normalize.js';
+import { displayWidth } from '../../src/render/text.js';
 
 const c = createColors('named');
 
@@ -104,7 +105,7 @@ describe('renderLine1', () => {
   it('does not overflow layout at cols=120 with long model and branch', () => {
     const longBranch = 'feat/ca-71-some-long-description-that-was-truncated-before';
     const out = stripAnsi(renderLine1(makeCtx({ git: { ...git, branch: longBranch }, cols: 120 }), c));
-    expect(out.length).toBeLessThanOrEqual(120);
+    expect(displayWidth(out)).toBeLessThanOrEqual(120);
   });
 
   it('shows duration when display.duration is true and durationMs is set', () => {

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -5,6 +5,7 @@ import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '..
 import type { ClaudeCodeInput, RenderContext } from '../../src/types.js';
 import { NERD_ICONS, EMOJI_ICONS, NO_ICONS } from '../../src/render/icons.js';
 import { normalize } from '../../src/normalize.js';
+import { displayWidth } from '../../src/render/text.js';
 
 const c = createColors('named');
 
@@ -333,7 +334,7 @@ describe('renderLine2', () => {
       context_window: { ...baseInput.context_window, cache_read_input_tokens: 80000 },
     };
     const out = stripAnsi(renderLine2(makeCtx({ cols: 60 }, inputOverride), c));
-    expect(out.length).toBeLessThanOrEqual(64); // fitSegments enforces cols - 4
+    expect(displayWidth(out)).toBeLessThanOrEqual(64); // fitSegments enforces cols - 4
     // High-priority segment (context bar) survives; low-priority rate limit drops.
     expect(out).toMatch(/\d+%/); // context % is present
     expect(out).not.toContain('75%(5h)'); // rate-limit segment got dropped

--- a/tests/render/line3.test.ts
+++ b/tests/render/line3.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect } from 'vitest';
 import { renderLine3 } from '../../src/render/line3.js';
 import { createColors, stripAnsi } from '../../src/render/colors.js';
 import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '../../src/types.js';
-import type { ToolEntry, TodoEntry, RenderContext } from '../../src/types.js';
+import type { ClaudeCodeInput, ToolEntry, TodoEntry, RenderContext } from '../../src/types.js';
 import { NERD_ICONS } from '../../src/render/icons.js';
 import { normalize } from '../../src/normalize.js';
 
 const c = createColors('named');
 
-const baseInput = {
+const baseInput: ClaudeCodeInput = {
   model: 'Claude Opus 4',
   session_id: 'test-123',
   context_window: { used_percentage: 50, remaining_percentage: 50 },
@@ -30,7 +30,7 @@ const todo = (id: string, content: string, status: 'pending' | 'in_progress' | '
 
 function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
   return {
-    input: normalize(baseInput as any), git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
+    input: normalize(baseInput), git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
     tokenSpeed: null, memory: null, gsd: null, mcp: null, cols: 120,
     config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
     icons: NERD_ICONS,

--- a/tests/render/line3.test.ts
+++ b/tests/render/line3.test.ts
@@ -4,6 +4,7 @@ import { createColors, stripAnsi } from '../../src/render/colors.js';
 import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '../../src/types.js';
 import type { ToolEntry, TodoEntry, RenderContext } from '../../src/types.js';
 import { NERD_ICONS } from '../../src/render/icons.js';
+import { normalize } from '../../src/normalize.js';
 
 const c = createColors('named');
 
@@ -29,7 +30,7 @@ const todo = (id: string, content: string, status: 'pending' | 'in_progress' | '
 
 function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
   return {
-    input: baseInput, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
+    input: normalize(baseInput as any), git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
     tokenSpeed: null, memory: null, gsd: null, mcp: null, cols: 120,
     config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
     icons: NERD_ICONS,
@@ -75,7 +76,6 @@ describe('renderLine3', () => {
     const transcript = { ...EMPTY_TRANSCRIPT, todos };
     const out = stripAnsi(renderLine3(makeCtx({ transcript }), c));
     expect(out).toContain('1/3');
-    expect(out).toContain('1'); // in_progress count
   });
 
   it('shows tools and todos together', () => {

--- a/tests/render/line4.test.ts
+++ b/tests/render/line4.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect } from 'vitest';
 import { renderLine4 } from '../../src/render/line4.js';
 import { createColors, stripAnsi } from '../../src/render/colors.js';
 import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '../../src/types.js';
-import type { GsdInfo, RenderContext } from '../../src/types.js';
+import type { ClaudeCodeInput, GsdInfo, RenderContext } from '../../src/types.js';
 import { NERD_ICONS } from '../../src/render/icons.js';
 import { normalize } from '../../src/normalize.js';
 
 const c = createColors('named');
 
-const baseInput = {
+const baseInput: ClaudeCodeInput = {
   model: 'Claude Opus 4',
   session_id: 'test-123',
   context_window: { used_percentage: 50, remaining_percentage: 50 },
@@ -18,7 +18,7 @@ const baseInput = {
 
 function makeCtx(gsd: GsdInfo | null): RenderContext {
   return {
-    input: normalize(baseInput as any), git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
+    input: normalize(baseInput), git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
     tokenSpeed: null, memory: null, gsd, mcp: null, cols: 120,
     config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
     icons: NERD_ICONS,

--- a/tests/render/line4.test.ts
+++ b/tests/render/line4.test.ts
@@ -4,6 +4,7 @@ import { createColors, stripAnsi } from '../../src/render/colors.js';
 import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '../../src/types.js';
 import type { GsdInfo, RenderContext } from '../../src/types.js';
 import { NERD_ICONS } from '../../src/render/icons.js';
+import { normalize } from '../../src/normalize.js';
 
 const c = createColors('named');
 
@@ -17,7 +18,7 @@ const baseInput = {
 
 function makeCtx(gsd: GsdInfo | null): RenderContext {
   return {
-    input: baseInput, git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
+    input: normalize(baseInput as any), git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
     tokenSpeed: null, memory: null, gsd, mcp: null, cols: 120,
     config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
     icons: NERD_ICONS,


### PR DESCRIPTION
## Summary
- `line1.test.ts`, `line2.test.ts` — replace `out.length` with `displayWidth(out)` in layout-overflow assertions; `.length` counts code units, so multi-byte emoji/wide chars in model/branch names would silently let an overflowing layout pass
- `line3.test.ts`, `line4.test.ts` — wrap raw `baseInput` through `normalize()` in `makeCtx`, matching the established line1/line2 pattern; renderers receive a `NormalizedInput` with sanitized/derived fields instead of a plain object
- `line3.test.ts` — remove redundant `toContain('1')` immediately after `toContain('1/3')`; the latter subsumes the former

## Test plan
- [ ] 71 tests across the 4 files pass locally
- [ ] Full suite green (`npm test`)