### PR TITLE
refactor(mcp): add McpReader injection seam; replace node:fs mock

### DIFF
--- a/src/parsers/mcp.ts
+++ b/src/parsers/mcp.ts
@@ -6,11 +6,18 @@ import { debug } from '../utils/debug.js';
 
 const log = debug('mcp');
 
+export interface McpReader {
+  existsSync(path: string): boolean;
+  readFileSync(path: string, encoding: 'utf8'): string;
+}
+
+const defaultReader: McpReader = { existsSync, readFileSync };
+
 /**
  * Read MCP server configurations from .mcp.json files.
  * Checks both cwd and ~/.claude/ for server definitions.
  */
-export function getMcpInfo(cwd: string): McpInfo | null {
+export function getMcpInfo(cwd: string, reader: McpReader = defaultReader): McpInfo | null {
   const servers: McpServerInfo[] = [];
 
   const paths = [
@@ -19,9 +26,9 @@ export function getMcpInfo(cwd: string): McpInfo | null {
   ];
 
   for (const p of paths) {
-    if (!existsSync(p)) continue;
+    if (!reader.existsSync(p)) continue;
     try {
-      const raw = JSON.parse(readFileSync(p, 'utf8'));
+      const raw = JSON.parse(reader.readFileSync(p, 'utf8'));
       const mcpServers = raw?.mcpServers ?? {};
       const added: string[] = [];
       for (const name of Object.keys(mcpServers)) {

--- a/tests/parsers/mcp.test.ts
+++ b/tests/parsers/mcp.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect } from 'vitest';
+import { homedir } from 'node:os';
 import { getMcpInfo, type McpReader } from '../../src/parsers/mcp.js';
 
 function makeReader(files: Record<string, string>): McpReader {
   return {
     existsSync: (p: string) => p in files,
-    readFileSync: (p: string) => files[p] ?? '',
+    readFileSync: (p: string) => {
+      if (!(p in files)) throw new Error(`readFileSync called for unregistered path: ${p}`);
+      return files[p]!;
+    },
   };
 }
 
@@ -30,7 +34,7 @@ describe('getMcpInfo', () => {
     const content = JSON.stringify({ mcpServers: { 'shared-server': { command: 'node' } } });
     const reader = makeReader({
       '/project/.mcp.json': content,
-      [`${process.env['HOME'] ?? '/root'}/.claude/.mcp.json`]: content,
+      [`${homedir()}/.claude/.mcp.json`]: content, // homedir() matches what getMcpInfo uses
     });
     const result = getMcpInfo('/project', reader);
     expect(result!.servers).toHaveLength(1);

--- a/tests/parsers/mcp.test.ts
+++ b/tests/parsers/mcp.test.ts
@@ -1,27 +1,25 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getMcpInfo } from '../../src/parsers/mcp.js';
-import * as fs from 'node:fs';
+import { describe, it, expect } from 'vitest';
+import { getMcpInfo, type McpReader } from '../../src/parsers/mcp.js';
 
-vi.mock('node:fs');
-
-const mockedExistsSync = vi.mocked(fs.existsSync);
-const mockedReadFileSync = vi.mocked(fs.readFileSync);
-
-beforeEach(() => { vi.resetAllMocks(); });
-afterEach(() => { vi.restoreAllMocks(); });
+function makeReader(files: Record<string, string>): McpReader {
+  return {
+    existsSync: (p: string) => p in files,
+    readFileSync: (p: string) => files[p] ?? '',
+  };
+}
 
 describe('getMcpInfo', () => {
   it('returns null when no .mcp.json files exist', () => {
-    mockedExistsSync.mockReturnValue(false);
-    expect(getMcpInfo('/project')).toBeNull();
+    expect(getMcpInfo('/project', makeReader({}))).toBeNull();
   });
 
   it('reads servers from cwd .mcp.json', () => {
-    mockedExistsSync.mockImplementation((p) => String(p).includes('/project/'));
-    mockedReadFileSync.mockReturnValue(JSON.stringify({
-      mcpServers: { 'my-server': { command: 'node', args: ['server.js'] } },
-    }));
-    const result = getMcpInfo('/project');
+    const reader = makeReader({
+      '/project/.mcp.json': JSON.stringify({
+        mcpServers: { 'my-server': { command: 'node', args: ['server.js'] } },
+      }),
+    });
+    const result = getMcpInfo('/project', reader);
     expect(result).not.toBeNull();
     expect(result!.servers).toHaveLength(1);
     expect(result!.servers[0].name).toBe('my-server');
@@ -29,23 +27,24 @@ describe('getMcpInfo', () => {
   });
 
   it('deduplicates servers across files', () => {
-    mockedExistsSync.mockReturnValue(true);
-    mockedReadFileSync.mockReturnValue(JSON.stringify({
-      mcpServers: { 'shared-server': { command: 'node' } },
-    }));
-    const result = getMcpInfo('/project');
+    const content = JSON.stringify({ mcpServers: { 'shared-server': { command: 'node' } } });
+    const reader = makeReader({
+      '/project/.mcp.json': content,
+      [`${process.env['HOME'] ?? '/root'}/.claude/.mcp.json`]: content,
+    });
+    const result = getMcpInfo('/project', reader);
     expect(result!.servers).toHaveLength(1);
   });
 
   it('handles malformed JSON gracefully', () => {
-    mockedExistsSync.mockReturnValue(true);
-    mockedReadFileSync.mockReturnValue('not valid json');
-    expect(getMcpInfo('/project')).toBeNull();
+    const reader = makeReader({ '/project/.mcp.json': 'not valid json' });
+    expect(getMcpInfo('/project', reader)).toBeNull();
   });
 
   it('handles missing mcpServers key', () => {
-    mockedExistsSync.mockImplementation((p) => String(p).includes('/project/'));
-    mockedReadFileSync.mockReturnValue(JSON.stringify({ other: 'data' }));
-    expect(getMcpInfo('/project')).toBeNull();
+    const reader = makeReader({
+      '/project/.mcp.json': JSON.stringify({ other: 'data' }),
+    });
+    expect(getMcpInfo('/project', reader)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
`mcp.test.ts` used `vi.mock('node:fs')` — mocking a module we don't own couples tests to Node.js internals rather than the behaviour of `getMcpInfo` itself (TDD doctrine: don't mock what you don't own).

**Source change** (`src/parsers/mcp.ts`):
- Exported a new `McpReader` interface with `existsSync` and `readFileSync` methods
- Added an optional `reader` parameter to `getMcpInfo`, defaulting to the real `node:fs` functions
- All internal `existsSync`/`readFileSync` calls route through `reader`

**Test change** (`tests/parsers/mcp.test.ts`):
- Removed all `vi.mock` / `vi.mocked` usage
- Added a `makeReader(files)` helper that returns an in-memory `McpReader`
- Tests inject the fake reader directly — no patching of global module state

Coverage unchanged: null path, cwd-only read, deduplication, malformed JSON, missing mcpServers key.

## Test plan
- [ ] 5 mcp tests pass
- [ ] Full suite 581/581 green (`npm test`)