### PR TITLE
fix(render): dead arithmetic, defensive reset, gsd body status fallback

### DIFF
--- a/src/parsers/gsd.ts
+++ b/src/parsers/gsd.ts
@@ -45,8 +45,9 @@ export function parseStateMd(content: string): GsdState {
     state.phaseNum = phaseMatch[1];
     state.phaseTotal = phaseMatch[2];
     state.phaseName = phaseMatch[3];
-  } else if (!state.status) {
-    // Fallback: parse body Status line when frontmatter is absent
+  }
+  if (!state.status) {
+    // Fallback: parse body Status line when frontmatter status is missing
     const bodyStatus = content.match(/^Status:\s*(.+)/m);
     if (bodyStatus) {
       const raw = bodyStatus[1].trim().toLowerCase();

--- a/src/render/powerline.ts
+++ b/src/render/powerline.ts
@@ -87,7 +87,7 @@ export function powerlineWidth(segments: PowerlineSegment[], style: Style): numb
 
   if (style.gap) {
     // diamond: leftCap + body + rightCap per segment, space between segments.
-    return segments.length * (style.sepWidth + 0) // caps already included in sepWidth=2
+    return segments.length * style.sepWidth // caps already included in sepWidth=2
       + bodyW
       + (segments.length - 1); // spaces between pills
   }

--- a/src/render/text.ts
+++ b/src/render/text.ts
@@ -71,7 +71,7 @@ export function fitSegments(left: string[], right: string[], sep: string, cols: 
   // Safe because left[0] is the model name (~20 chars) — callers must ensure
   // the first segment is short enough to truncate gracefully.
   // Strip ANSI before hard-truncating to avoid cutting mid-escape-sequence.
-  return truncField(stripAnsi(left[0] ?? ''), safeCols);
+  return truncField(stripAnsi(left[0] ?? ''), safeCols) + '\x1b[0m';
 }
 
 export function padLine(left: string, right: string, cols: number): string {

--- a/tests/parsers/gsd.test.ts
+++ b/tests/parsers/gsd.test.ts
@@ -32,6 +32,13 @@ status: executing
     expect(parseStateMd(content).status).toBe('planning');
   });
 
+  it('picks up body Status even when Phase line is present but frontmatter has no status', () => {
+    const content = `# State\n\nPhase: 2 of 5 (auth)\n\nStatus: Executing`;
+    const s = parseStateMd(content);
+    expect(s.phaseNum).toBe('2');
+    expect(s.status).toBe('executing'); // was undefined before fix — body Status ignored when phaseMatch fired
+  });
+
   it('treats `null` frontmatter values as absent', () => {
     const content = `---\nstatus: null\nmilestone: v1.0\n---`;
     const s = parseStateMd(content);

--- a/tests/parsers/gsd.test.ts
+++ b/tests/parsers/gsd.test.ts
@@ -39,6 +39,13 @@ status: executing
     expect(s.status).toBe('executing'); // was undefined before fix — body Status ignored when phaseMatch fired
   });
 
+  it('frontmatter status wins over body Status when both are present', () => {
+    const content = `---\nstatus: planning\n---\n\nPhase: 2 of 5 (auth)\n\nStatus: Executing`;
+    const s = parseStateMd(content);
+    expect(s.status).toBe('planning'); // frontmatter always wins; body Status is fallback only
+    expect(s.phaseNum).toBe('2');
+  });
+
   it('treats `null` frontmatter values as absent', () => {
     const content = `---\nstatus: null\nmilestone: v1.0\n---`;
     const s = parseStateMd(content);

--- a/tests/render/text.test.ts
+++ b/tests/render/text.test.ts
@@ -60,7 +60,8 @@ describe('fitSegments', () => {
   it('last-resort: truncates single oversized segment without ANSI bleed', () => {
     const result = fitSegments(['X'.repeat(200)], [], ' | ', 50);
     expect(displayWidth(result)).toBeLessThanOrEqual(46);
-    expect(result.endsWith('…')).toBe(true);
+    expect(result).toContain('…'); // ellipsis present; result ends with \x1b[0m defensive reset
+    expect(result.endsWith('\x1b[0m')).toBe(true);
   });
 
   it('ANSI-colored left that overflows stays within displayWidth bounds', () => {


### PR DESCRIPTION
## Summary
Three independent LOW-priority source fixes grouped by render/parser scope:

**`src/render/powerline.ts`** — removed `+ 0` from `segments.length * (style.sepWidth + 0)`. Dead arithmetic with zero effect on output; removed for clarity.

**`src/render/text.ts`** — appended `\x1b[0m` to the last-resort `fitSegments` return path. When every segment overflows `safeCols`, the function hard-truncates `left[0]` after stripping ANSI. The reset escape defensively closes any open color sequence carried by the calling context. Test updated to assert both `'…'` presence and the trailing `\x1b[0m`.

**`src/parsers/gsd.ts`** — moved the body `Status:` parse from `else if (!state.status)` to a standalone `if (!state.status)`. Previously the fallback only ran when `phaseMatch` was null, so a file with `Phase: X of Y` in the body but no `status:` in frontmatter never had its body Status line read. Added regression test (was red before fix).

## Test plan
- [ ] 582/582 tests pass (`npm test`)
- [ ] New gsd regression test was red before the fix, green after