### PR TITLE
fix(misc): cast removal, xhigh sync, config regex, Windows uid, monokai comments

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -174,16 +174,16 @@ export function mergeCliFlags(config: HudConfig, argv: string[]): HudConfig {
   if (argv.includes('--powerline')) r.style = 'powerline';
   if (argv.includes('--classic'))   r.style = 'classic';
   for (const arg of argv) {
-    const presetMatch = arg.match(/^--preset[= ]?(full|balanced|minimal)$/);
+    const presetMatch = arg.match(/^--preset=?(full|balanced|minimal)$/);
     if (presetMatch) { applyPreset(r, presetMatch[1] as NonNullable<HudConfig['preset']>); continue; }
-    const iconsMatch = arg.match(/^--icons[= ]?(nerd|emoji|none)$/);
+    const iconsMatch = arg.match(/^--icons=?(nerd|emoji|none)$/);
     if (iconsMatch) { r.icons = iconsMatch[1] as HudConfig['icons']; continue; }
     // Build the alternation from POWERLINE_STYLE_NAMES so this regex stays
     // in sync when a new style is added — single source of truth in types.ts.
     // Escape regex metacharacters defensively in case a future style name
     // ever contains one (today they're all `[a-z]+`, but the safety is free).
     const escaped = POWERLINE_STYLE_NAMES.map(n => n.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-    const plStyleMatch = arg.match(new RegExp(`^--powerline-style[= ](${escaped.join('|')})$`));
+    const plStyleMatch = arg.match(new RegExp(`^--powerline-style=(${escaped.join('|')})$`));
     if (plStyleMatch) {
       r.style = 'powerline';
       r.powerline = { ...(r.powerline ?? {}), style: plStyleMatch[1] as NonNullable<HudConfig['powerline']>['style'] };

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -136,7 +136,7 @@ export function normalize(input: RawInput): NormalizedInput {
   const modelName = typeof input.model === 'string'
     ? input.model
     : (input.model?.display_name ?? '');
-  const cwd = (input as { cwd?: string }).cwd || input.workspace?.current_dir || process.cwd();
+  const cwd = input.cwd || input.workspace?.current_dir || process.cwd();
 
   // Token unification — context_window is required by type but can be absent
   // from malformed payloads; default to an empty object so all field accesses

--- a/src/parsers/transcript.ts
+++ b/src/parsers/transcript.ts
@@ -186,7 +186,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
         const entry = JSON.parse(line);
         if (!result.sessionStart && entry.timestamp) result.sessionStart = new Date(entry.timestamp);
 
-        const effortMatch = line.match(/Set model to .+ with (low|medium|high|max) effort/);
+        const effortMatch = JSON.stringify(entry).match(/Set model to .+ with (low|medium|high|max|xhigh) effort/);
         if (effortMatch) thinkingEffort = effortMatch[1] as ThinkingEffort;
 
         const timestamp = entry.timestamp ? new Date(entry.timestamp) : new Date();

--- a/src/themes/monokai.ts
+++ b/src/themes/monokai.ts
@@ -13,8 +13,8 @@ export const palette: ThemePalette = {
   yellow:     rgb(230, 219, 116),
   green:      rgb(166, 226, 46),
   orange:     rgb(253, 151, 31),
-  red:        rgb(249, 38,  114),
-  brightBlue: rgb(102, 217, 239),
+  red:        rgb(249, 38,  114), // intentional: Monokai uses magenta for red
+  brightBlue: rgb(102, 217, 239), // intentional: Monokai uses cyan for brightBlue
   gray:       rgb(117, 113, 94),
   powerline: {
     modelBg:       { r: 42,  g: 93,  b: 110 },

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,7 +82,7 @@ export const EMPTY_TRANSCRIPT: TranscriptData = {
   sessionStart: null,
 };
 
-export type ThinkingEffort = 'low' | 'medium' | 'high' | 'max' | '';
+export type ThinkingEffort = 'low' | 'medium' | 'high' | 'max' | 'xhigh' | '';
 
 export type ToolStatus = 'running' | 'completed' | 'error';
 

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,8 +1,9 @@
 import { readFileSync, statSync, unlinkSync, openSync, writeSync, closeSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { userInfo } from 'node:os';
 
 function cacheDirPath(dir: string): string {
-  return join(dir, `lumira-${process.getuid?.() ?? 'default'}`);
+  return join(dir, `lumira-${process.getuid?.() ?? userInfo().username ?? 'default'}`);
 }
 
 function ensureCacheDir(dir: string): string {

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -2,8 +2,13 @@ import { readFileSync, statSync, unlinkSync, openSync, writeSync, closeSync, mkd
 import { join } from 'node:path';
 import { userInfo } from 'node:os';
 
+function getUid(): string {
+  if (process.getuid) return String(process.getuid());
+  try { return userInfo().username ?? 'default'; } catch { return 'default'; }
+}
+
 function cacheDirPath(dir: string): string {
-  return join(dir, `lumira-${process.getuid?.() ?? userInfo().username ?? 'default'}`);
+  return join(dir, `lumira-${getUid()}`);
 }
 
 function ensureCacheDir(dir: string): string {

--- a/tests/fixtures/transcript-effort-xhigh.jsonl
+++ b/tests/fixtures/transcript-effort-xhigh.jsonl
@@ -1,0 +1,1 @@
+{"timestamp":"2026-04-08T10:00:00Z","message":{"content":[{"type":"text","text":"Set model to claude-opus-4-6 with xhigh effort"}]}}

--- a/tests/parsers/transcript.test.ts
+++ b/tests/parsers/transcript.test.ts
@@ -39,6 +39,11 @@ describe('parseTranscript', () => {
     expect(result.thinkingEffort).toBe('high');
   });
 
+  it('extracts thinkingEffort xhigh from transcript', async () => {
+    const result = await parseTranscript(join(FIXTURES, 'transcript-effort-xhigh.jsonl'));
+    expect(result.thinkingEffort).toBe('xhigh');
+  });
+
   it('sets sessionStart from first timestamp', async () => {
     const result = await parseTranscript(join(FIXTURES, 'transcript-basic.jsonl'));
     expect(result.sessionStart).toBeInstanceOf(Date);


### PR DESCRIPTION
## Summary
- Remove unnecessary cast in normalize.ts (RawInput already has cwd on both members)
- Sync ThinkingEffort type with VALID_EFFORT_LEVELS by adding 'xhigh'
- Fix effort regex in transcript.ts: add xhigh variant, scope match to parsed content
- Fix config.ts argv-tokenized regexes: [= ]? → =? and [= ] → =
- Add Windows uid fallback in cache.ts via userInfo().username
- Add intentional-duplicate comments in monokai.ts for red/magenta and brightBlue/cyan

## Test plan
- [ ] npm test passes (≥ 582 tests)
- [ ] ThinkingEffort type includes xhigh
- [ ] effort regex matches xhigh effort lines
- [ ] config regex only matches = separator not space separator