### PR TITLE
fix(render): group context info before rate-limit segment on line 2

### DIFF
--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -24,6 +24,10 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
   const leftParts: string[] = [];
   const rightParts: string[] = [];
 
+  // Track context slots pushed so critical rate-limit segments anchor after
+  // all context info (bar + tokens), not just after the bar.
+  let contextSlotCount = 0;
+
   // Context bar
   if (display.contextBar) {
     const pct = input.context.usedPercentage;
@@ -33,6 +37,7 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
       warningThreshold: display.contextWarningThreshold,
       criticalThreshold: display.contextCriticalThreshold,
     }));
+    contextSlotCount++;
   }
 
   // Context tokens — prefer windowSize from payload over back-derivation.
@@ -46,6 +51,7 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
     if (capacity > 0) {
       const used = Math.round(capacity * pct / 100);
       leftParts.push(c.dim(`${formatTokens(used)}/${formatTokens(capacity)}`));
+      contextSlotCount++;
     }
   }
 
@@ -102,9 +108,9 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
       ['5h', input.rateLimits.fiveHour],
       ['7d', input.rateLimits.sevenDay],
     ];
-    // Anchor index: right after the context bar (slot 1) so promoted segments
-    // visually sit next to the bar rather than ahead of it.
-    let criticalInsertAt = display.contextBar ? 1 : 0;
+    // Anchor index: right after all context slots (bar + tokens) so promoted
+    // segments sit next to context info rather than between bar and tokens.
+    let criticalInsertAt = contextSlotCount;
     for (const [label, win] of limits) {
       // Number.isFinite catches NaN/Infinity from malformed payloads — without
       // it, `NaN < 50` is false and the segment falls through to render

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -179,6 +179,20 @@ describe('renderLine2', () => {
     expect(ratePos).toBeLessThan(costPos); // critical rate beats cost
   });
 
+  it('context tokens (94k/200k) appear before critical rate-limit segment', () => {
+    // context bar + context tokens are grouped; rate limits come after, even when critical.
+    const inputOverride = {
+      context_window: { used_percentage: 47, remaining_percentage: 53, context_window_size: 200000, total_input_tokens: 94000, total_output_tokens: 0 },
+      rate_limits: { five_hour: { used_percentage: 89 } },
+    };
+    const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+    const tokensPos = out.indexOf('94k/200k');
+    const ratePos = out.indexOf('89%(5h)');
+    expect(tokensPos).toBeGreaterThan(-1);
+    expect(ratePos).toBeGreaterThan(-1);
+    expect(tokensPos).toBeLessThan(ratePos); // context tokens before rate limit
+  });
+
   it('keeps non-critical rate-limit (<85%) at the end of the line — original order', () => {
     const out = stripAnsi(renderLine2(makeCtx(
       {},


### PR DESCRIPTION
## Summary
- Context tokens (94k/200k) were appearing AFTER the critical rate-limit segment because `criticalInsertAt` was anchored at slot 1 (right after the context bar), pushing the token count to slot 2
- Now tracks `contextSlotCount` as each context slot is actually pushed, so rate limits always anchor after all context info (bar + tokens)

## Before / After
Before: `████░░ 47% │ 89%(5h) 41m47s │ 94k/200k`
After:  `████░░ 47% │ 94k/200k │ 89%(5h) 41m47s`

## Test plan
- [x] New regression test: `context tokens (94k/200k) appear before critical rate-limit segment`
- [x] All existing ordering tests pass (critical promotion, non-critical at end, mixed criticality, relative 5h/7d order)
- [x] 597 tests passing