### PR TITLE
refactor(normalize): drop legacy top-level cache_read fallback

### DIFF
--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -158,9 +158,11 @@ export function normalize(input: RawInput): NormalizedInput {
     }
   } else if (claude) {
     // Modern Claude Code (≥ 2.1.x) nests cache fields under current_usage.
-    // Fall back to the legacy top-level path for payloads without current_usage.
-    const { cached: nestedCached } = getCacheFields(claude.context_window?.current_usage);
-    cached = nestedCached ?? claude.context_window?.cache_read_input_tokens;
+    // Pre-2.1.x payloads exposed cache_read_input_tokens at the top level of
+    // context_window, but those versions are no longer in use. Reading only from
+    // current_usage keeps tokens.cached consistent with cacheHitRate: both are
+    // undefined for legacy payloads (no per-turn denominator, no cached count).
+    ({ cached } = getCacheFields(claude.context_window?.current_usage));
   }
 
   // Per-turn cache denominator (Claude only): fresh input + cache_read + cache_creation

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -373,6 +373,21 @@ describe('cacheHitRate normalization', () => {
     };
     expect(normalize(input).cacheHitRate).toBeUndefined();
   });
+  it('tokens.cached is undefined when payload has top-level cache_read_input_tokens but no current_usage', () => {
+    // Verifies the legacy top-level fallback is gone: pre-2.1.x payloads that only expose
+    // cache_read_input_tokens at context_window root (no current_usage) must produce
+    // tokens.cached === undefined, not a stale numeric value.
+    const input = {
+      ...claudeInput,
+      context_window: {
+        ...claudeInput.context_window,
+        cache_read_input_tokens: 50000,
+        total_input_tokens: 120000,
+        // deliberately no current_usage
+      },
+    };
+    expect(normalize(input).tokens.cached).toBeUndefined();
+  });
 });
 
 describe('normalize — missing context_window', () => {


### PR DESCRIPTION
## Summary
- Removes the `?? claude.context_window?.cache_read_input_tokens` fallback from `tokens.cached` extraction
- Pre-2.1.x payloads now produce `undefined` for both `tokens.cached` and `cacheHitRate` (consistent behavior)
- Updates the stale "Fall back to the legacy top-level path" comment
- `getCacheFields` helper already existed (from PR #78) — this closes the last open item

## Test plan
- [x] New test: top-level `cache_read_input_tokens` without `current_usage` → `tokens.cached` is `undefined`
- [x] All existing cache hit rate tests pass unchanged
- [x] npm test green (598 tests passed)

Closes #79, #80