### PR TITLE
fix(render): parity gaps and LOW findings from Opus review

### DIFF
--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -5,8 +5,8 @@ import {
   type PowerlineStyleName,
 } from './powerline.js';
 import { QUOTA_CRITICAL } from '../types.js';
-import { buildContextBar } from './shared.js';
-import { formatTokens, formatCost } from '../utils/format.js';
+import { buildContextBar, formatQwenMetrics } from './shared.js';
+import { formatTokens, formatCost, formatBurnRate } from '../utils/format.js';
 import type { ColorMode, Colors } from './colors.js';
 import type { RenderContext } from '../types.js';
 import {
@@ -28,7 +28,7 @@ import {
 // recorded against PR #47.
 
 function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors): PowerlineSegment[] {
-  const { input, config: { display }, icons } = ctx;
+  const { input, config: { display }, icons, mcp, transcript: { thinkingEffort } } = ctx;
   const segments: PowerlineSegment[] = [];
 
   // Context bar — always highest priority. plain=true so the bar cells inherit
@@ -54,31 +54,76 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
       ?? (input.tokens.input > 0 ? Math.round(input.tokens.input / (pct / 100)) : 0);
     if (capacity > 0) {
       const used = Math.round(capacity * pct / 100);
-      segments.push({ text: `${formatTokens(used)}/${formatTokens(capacity)}`, bg: palette.dirBg, fg: palette.fg, priority: 80 });
+      segments.push({ text: `${formatTokens(used)}/${formatTokens(capacity)}`, bg: palette.dirBg, fg: palette.fg, priority: 90 });
     }
   }
 
-  // Cost
-  if (display.cost && input.cost != null) {
-    segments.push({ text: formatCost(input.cost), bg: palette.taskBg, fg: palette.fg, priority: 60 });
-  }
-
-  // Rate limits — only show if >=50%
-  // Unlike line2 (which splices critical segments after the context bar), powerline
-  // expresses urgency via priority: critical windows survive fitSegments eviction
-  // before non-critical peers. Same doctrine, different mechanism.
+  // Rate limits — urgency expressed via priority (critical survives eviction longer).
+  // Loop order (5h then 7d) is always preserved; priority is the eviction knob only.
   if (display.rateLimits && input.rateLimits) {
     const limits: [string, typeof input.rateLimits.fiveHour][] = [
       ['5h', input.rateLimits.fiveHour],
       ['7d', input.rateLimits.sevenDay],
     ];
     for (const [label, win] of limits) {
-      // Number.isFinite guards against NaN/Infinity from malformed payloads.
       if (!win || !Number.isFinite(win.usedPercentage) || win.usedPercentage < 50) continue;
       const critical = win.usedPercentage >= QUOTA_CRITICAL;
       const bg = critical ? palette.branchDirtyBg : palette.taskBg;
-      segments.push({ text: `${icons.battery(win.usedPercentage)} ${win.usedPercentage.toFixed(0)}%(${label})`, bg, fg: palette.fg, priority: critical ? 25 : 20 });
+      segments.push({ text: `${icons.battery(win.usedPercentage)} ${win.usedPercentage.toFixed(0)}%(${label})`, bg, fg: palette.fg, priority: critical ? 85 : 40 });
     }
+  }
+
+  // Cost + burn rate
+  if (display.cost && input.cost != null) {
+    let costText = formatCost(input.cost);
+    if (display.burnRate && input.durationMs != null) {
+      const burn = formatBurnRate(input.cost, input.durationMs);
+      if (burn) costText += ` ${burn}`;
+    }
+    segments.push({ text: costText, bg: palette.taskBg, fg: palette.fg, priority: 70 });
+  }
+
+  // Tokens ↑↓ (cumulative input/output)
+  if (display.tokens) {
+    const inTokens = input.tokens.input;
+    const outTokens = input.tokens.output;
+    const parts: string[] = [];
+    if (inTokens > 0) parts.push(`${formatTokens(inTokens)}↑`);
+    if (outTokens > 0) parts.push(`${formatTokens(outTokens)}↓`);
+    if (parts.length > 0) {
+      segments.push({ text: `${icons.comment} ${parts.join(' ')}`, bg: palette.dirBg, fg: palette.fg, priority: 60 });
+    }
+  }
+
+  // Cache metrics (hit rate)
+  if (display.cacheMetrics && input.cacheHitRate != null) {
+    segments.push({ text: `cache ${input.cacheHitRate}%`, bg: palette.versionBg, fg: palette.fg, priority: 55 });
+  }
+
+  // MCP servers
+  if (display.mcp && mcp) {
+    const total = mcp.servers.length;
+    const errors = mcp.servers.filter(s => s.status === 'error').length;
+    const mcpText = errors > 0 ? `MCP ${total - errors}/${total}` : `MCP ${total}`;
+    segments.push({ text: mcpText, bg: palette.taskBg, fg: palette.fg, priority: 50 });
+  }
+
+  // Qwen metrics
+  const qwenParts = formatQwenMetrics(input, c, icons);
+  for (const part of qwenParts) {
+    segments.push({ text: part, bg: palette.versionBg, fg: palette.fg, priority: 45 });
+  }
+
+
+  // Vim mode (low priority — no right side in powerline, append as left segment)
+  if (display.vim && input.vimMode) {
+    segments.push({ text: `[${input.vimMode}]`, bg: palette.dirBg, fg: palette.fg, priority: 30 });
+  }
+
+  // Effort level (hidden if medium)
+  const effort = input.effortLevel || thinkingEffort;
+  if (display.effort && effort && effort !== 'medium') {
+    segments.push({ text: `^${effort}`, bg: palette.versionBg, fg: palette.fg, priority: 30 });
   }
 
   return segments;

--- a/src/render/powerline-line3.ts
+++ b/src/render/powerline-line3.ts
@@ -32,8 +32,11 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette): Powerline
         return `◐ ${t.name}${target}`;
       }).join(' ');
       segments.push({ text: label, bg: palette.taskBg, fg: palette.fg, priority: 100 });
-    } else if (completed.length > 0) {
-      // Group by name, show top 3.
+    }
+
+    if (completed.length > 0) {
+      // Group by name, show top 3. Show at priority 80 alongside running (100),
+      // or at 100 when running is empty — mirrors classic line3 behaviour.
       const groups = new Map<string, number>();
       for (const t of completed) groups.set(t.name, (groups.get(t.name) ?? 0) + 1);
       const label = Array.from(groups.entries())
@@ -41,20 +44,25 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette): Powerline
         .slice(0, 3)
         .map(([name, count]) => `${icons.checkmark} ${name}${count > 1 ? ` ×${count}` : ''}`)
         .join(' ');
-      if (label) segments.push({ text: label, bg: palette.versionBg, fg: palette.fg, priority: 100 });
+      if (label) {
+        const priority = running.length > 0 ? 80 : 100;
+        segments.push({ text: label, bg: palette.versionBg, fg: palette.fg, priority });
+      }
     }
   }
 
-  // Todos segment — progress bar + counts.
+  // Todos segment — progress bar + counts. Mirrors classic line3 (pending, in-progress counts).
   if (display.todos !== false && todos.length > 0) {
     const total = todos.length;
     const done = todos.filter(t => t.status === 'completed').length;
     const inProg = todos.filter(t => t.status === 'in_progress').length;
+    const pending = todos.filter(t => t.status === 'pending').length;
     const SEGS = 8;
     const filled = Math.round((done / total) * SEGS);
     const bar = icons.barFull.repeat(filled) + icons.barEmpty.repeat(SEGS - filled);
     let label = `${bar} ${done}/${total}`;
     if (inProg > 0) label += ` ◐ ${inProg}`;
+    if (pending > 0) label += ` ○ ${pending}`;
     segments.push({ text: label, bg: palette.branchCleanBg, fg: palette.fg, priority: 80 });
   }
 

--- a/src/render/text.ts
+++ b/src/render/text.ts
@@ -71,7 +71,7 @@ export function fitSegments(left: string[], right: string[], sep: string, cols: 
   // Safe because left[0] is the model name (~20 chars) — callers must ensure
   // the first segment is short enough to truncate gracefully.
   // Strip ANSI before hard-truncating to avoid cutting mid-escape-sequence.
-  return truncField(stripAnsi(left[0] ?? ''), safeCols) + '\x1b[0m';
+  return truncField(stripAnsi(left[0] ?? ''), safeCols);
 }
 
 export function padLine(left: string, right: string, cols: number): string {

--- a/src/tui/select.ts
+++ b/src/tui/select.ts
@@ -46,6 +46,13 @@ const CLEAR_SCREEN = '\x1b[2J\x1b[H';
 // registered once per Node process. Process-scoped by design — tests must
 // run in forked workers (see vitest.config.ts `pool: 'forks'`). Issue #20.
 let exitHandlerInstalled = false;
+
+// Active Promise resolver — set by interactiveSelect while it is waiting for
+// input, cleared on settlement. SIGINT/SIGTERM handlers call this so the
+// Promise always settles (resolves null = cancellation) before the process
+// is re-killed. Without this, embedded/library callers would hang forever.
+let activeFinish: ((v: string | null) => void) | null = null;
+
 function installExitHandler(stdin: SelectStdin, stdout: SelectStdout): void {
   if (exitHandlerInstalled) return;
   exitHandlerInstalled = true;
@@ -56,10 +63,15 @@ function installExitHandler(stdin: SelectStdin, stdout: SelectStdout): void {
     } catch { /* best effort */ }
   };
   process.once('exit', restoreTerminal);
-  // SIGINT/SIGTERM bypass the 'exit' handler — restore terminal state and re-raise
-  // so the default signal behaviour (process termination) still occurs.
+  // SIGINT/SIGTERM bypass the 'exit' handler — resolve any active Promise
+  // (cancellation), restore terminal state, then re-raise so default signal
+  // behaviour (process termination) still occurs.
   for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP'] as const) {
-    process.once(sig, () => { restoreTerminal(); process.kill(process.pid, sig); });
+    process.once(sig, () => {
+      if (activeFinish) { activeFinish(null); activeFinish = null; }
+      restoreTerminal();
+      process.kill(process.pid, sig);
+    });
   }
 }
 
@@ -112,7 +124,12 @@ export async function interactiveSelect<T>(opts: SelectOpts<T>): Promise<T | nul
     render();
 
     return await new Promise<T | null>((resolve) => {
-      const finish = (v: T | null) => resolve(v);
+      // Register the resolver so signal handlers can settle this Promise.
+      activeFinish = resolve as (v: string | null) => void;
+      const finish = (v: T | null) => {
+        activeFinish = null; // clear before resolving to avoid double-call
+        resolve(v);
+      };
 
       keypressListener = (_str, key) => {
         if (!key || !key.name) return;

--- a/tests/render/powerline-line2.test.ts
+++ b/tests/render/powerline-line2.test.ts
@@ -73,7 +73,20 @@ describe('renderPowerlineLine2', () => {
     const ctx = makeCtx({
       config: {
         ...DEFAULT_CONFIG,
-        display: { ...DEFAULT_DISPLAY, contextBar: false, contextTokens: false, cost: false, duration: false, rateLimits: false },
+        display: {
+          ...DEFAULT_DISPLAY,
+          contextBar: false,
+          contextTokens: false,
+          cost: false,
+          duration: false,
+          rateLimits: false,
+          tokens: false,
+          cacheMetrics: false,
+          burnRate: false,
+          mcp: false,
+          vim: false,
+          effort: false,
+        },
       },
     });
     const out = renderPowerlineLine2(ctx, 'truecolor', null, c);
@@ -89,6 +102,61 @@ describe('renderPowerlineLine2', () => {
 
   // Battery glyph in the rate-limit segment — mirrors the line2.test.ts coverage
   // so the powerline path is not silently regressed when the glyph mapping moves.
+  describe('parity segments', () => {
+    it('tokens segment appears when display.tokens true and input has token counts', () => {
+      const rawInput = {
+        model: 'Claude Sonnet 4.6',
+        session_id: 'test',
+        context_window: { used_percentage: 42, remaining_percentage: 58, total_input_tokens: 50000, total_output_tokens: 5000 },
+        cost: { total_cost_usd: 0.42, total_duration_ms: 185000 },
+      };
+      const ctx = makeCtx({
+        input: normalize(rawInput),
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, tokens: true } },
+      });
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      // Should contain ↑ or ↓ token indicators
+      expect(out).toMatch(/↑|↓/);
+    });
+
+    it('cacheMetrics segment appears when display.cacheMetrics true and input has cacheHitRate', () => {
+      const rawInput = {
+        model: 'claude-code',
+        session_id: 'test',
+        context_window: { used_percentage: 42, remaining_percentage: 58, total_input_tokens: 50000, total_output_tokens: 5000 },
+        cost: { total_cost_usd: 0.42, total_duration_ms: 185000 },
+        usage: { input_tokens: 5000, output_tokens: 1000, cache_read_input_tokens: 4000, cache_creation_input_tokens: 1000 },
+      };
+      // Directly set cacheHitRate on the normalized input
+      const normalizedInput = normalize(rawInput);
+      // Patch cacheHitRate in since the test payload may not trigger the parser logic
+      const patchedInput = { ...normalizedInput, cacheHitRate: 75 };
+      const ctx = makeCtx({
+        input: patchedInput,
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, cacheMetrics: true } },
+      });
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).toContain('cache');
+      expect(out).toContain('75%');
+    });
+
+    it('burnRate segment appears next to cost when display.burnRate true', () => {
+      const rawInput = {
+        model: 'Claude Sonnet 4.6',
+        session_id: 'test',
+        context_window: { used_percentage: 42, remaining_percentage: 58, total_input_tokens: 12000, total_output_tokens: 1800 },
+        cost: { total_cost_usd: 0.42, total_duration_ms: 185000 },
+      };
+      const ctx = makeCtx({
+        input: normalize(rawInput),
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, cost: true, burnRate: true } },
+      });
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      // burnRate formatted as $/h or $/min — check for $/
+      expect(out).toMatch(/\$.*\/[hm]/);
+    });
+  });
+
   describe('rate-limit battery glyph', () => {
     function ctxWithRateLimit(usedPercentage: number, iconMode: 'nerd' | 'emoji' | 'none' = 'nerd') {
       const rawInput = {

--- a/tests/render/powerline-line3.test.ts
+++ b/tests/render/powerline-line3.test.ts
@@ -75,4 +75,35 @@ describe('renderPowerlineLine3', () => {
     expect(plain).toContain('1/1'); // todo progress segment rendered
     expect(out.endsWith('\x1b[0m')).toBe(true);
   });
+
+  it('shows completed tools alongside running tools', () => {
+    const ctx = makeCtx({
+      transcript: {
+        ...EMPTY_TRANSCRIPT,
+        tools: [
+          { id: '1', name: 'Read', status: 'running', startTime: new Date() },
+          { id: '2', name: 'Edit', status: 'completed', startTime: new Date(), endTime: new Date() },
+        ],
+      },
+    });
+    const plain = stripAnsi(renderPowerlineLine3(ctx, 'truecolor', null));
+    expect(plain).toContain('Read');   // running tool shown
+    expect(plain).toContain('Edit');   // completed tool also shown
+    expect(plain).toContain('◐');      // running indicator
+  });
+
+  it('shows pending todo count (○ N) when pending todos exist', () => {
+    const ctx = makeCtx({
+      transcript: {
+        ...EMPTY_TRANSCRIPT,
+        todos: [
+          { id: '1', content: 'Done', status: 'completed' },
+          { id: '2', content: 'Pending A', status: 'pending' },
+          { id: '3', content: 'Pending B', status: 'pending' },
+        ],
+      },
+    });
+    const plain = stripAnsi(renderPowerlineLine3(ctx, 'truecolor', null));
+    expect(plain).toContain('○ 2'); // pending count
+  });
 });

--- a/tests/render/text.test.ts
+++ b/tests/render/text.test.ts
@@ -60,8 +60,8 @@ describe('fitSegments', () => {
   it('last-resort: truncates single oversized segment without ANSI bleed', () => {
     const result = fitSegments(['X'.repeat(200)], [], ' | ', 50);
     expect(displayWidth(result)).toBeLessThanOrEqual(46);
-    expect(result).toContain('…'); // ellipsis present; result ends with \x1b[0m defensive reset
-    expect(result.endsWith('\x1b[0m')).toBe(true);
+    expect(result).toContain('…'); // ellipsis present
+    expect(result.endsWith('…')).toBe(true); // no stray ANSI reset after plain-text truncation
   });
 
   it('ANSI-colored left that overflows stays within displayWidth bounds', () => {

--- a/tests/tui/select.test.ts
+++ b/tests/tui/select.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { interactiveSelect } from '../../src/tui/select.js';
 import { createMockStdin, createMockStdout } from './_mock-stdin.js';
 
@@ -196,5 +196,43 @@ describe('interactiveSelect — abort and resize', () => {
     // After cleanup, there should be no more listeners on 'resize' / 'end'
     expect(opts.stdout.listenerCount('resize')).toBe(0);
     expect(opts.stdin.listenerCount('end')).toBe(0);
+  });
+});
+
+describe('interactiveSelect — SIGINT handling', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('Promise resolves with null when SIGINT fires while select is active', async () => {
+    // Prevent process.kill from actually terminating the test worker.
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    const stdin = createMockStdin(true);
+    const stdout = createMockStdout();
+
+    const promise = interactiveSelect({
+      title: 'pick',
+      options: [{ label: 'a', value: 'a' }],
+      initial: 'a',
+      preview: () => '',
+      stdin,
+      stdout,
+    });
+
+    // Wait for the Promise to be suspended inside the keypress listener.
+    await new Promise((r) => setImmediate(r));
+
+    // Simulate SIGINT arriving while select is waiting.
+    process.emit('SIGINT');
+
+    // The Promise must settle (resolve null) — not hang.
+    const result = await Promise.race([
+      promise,
+      new Promise<'timeout'>((r) => setTimeout(() => r('timeout'), 500)),
+    ]);
+
+    expect(result).toBeNull();
+    expect(killSpy).toHaveBeenCalledWith(process.pid, 'SIGINT');
   });
 });


### PR DESCRIPTION
## Summary

Addresses render-layer findings from the Opus full-codebase review:

- **LOW**: text.ts — remove stray ANSI reset from fitSegments last-resort truncation
- **MEDIUM**: powerline-line3 — show completed tools alongside running; add pending todos count
- **MEDIUM**: powerline-line2 — add tokens, cacheMetrics, burnRate, MCP, effort segments (parity with classic line2)
- **MEDIUM**: tui/select — SIGINT/SIGTERM now calls finish(null) so Promise always settles

## Test plan
- [ ] npm test green (≥ 598) — **604 passing**
- [ ] powerline-line3 shows both running + completed
- [ ] powerline-line2 shows tokens/cache/burnRate when display flags enabled