### PR TITLE
fix: address LOW review findings from full codebase Opus review

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -205,7 +205,7 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
 
   settings.statusLine = { ...LUMIRA_STATUSLINE };
   mkdirSync(dirname(settingsPath), { recursive: true });
-  const tmp = settingsPath + '.lumira.tmp';
+  const tmp = `${settingsPath}.${process.pid}.${Date.now()}.lumira.tmp`;
   try {
     const fd = openSync(tmp, 'wx', 0o600);
     writeSync(fd, JSON.stringify(settings, null, 2) + '\n');
@@ -263,24 +263,27 @@ export function uninstall(opts: InstallerOptions = {}): string {
     }
   }
 
+  let uninstSettings: Record<string, unknown>;
   try {
-    const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
-    delete settings.statusLine;
-    const uninstTmp = settingsPath + '.lumira.tmp';
-    try {
-      const fd = openSync(uninstTmp, 'wx', 0o600);
-      writeSync(fd, JSON.stringify(settings, null, 2) + '\n');
-      fsyncSync(fd);
-      closeSync(fd);
-      renameSync(uninstTmp, settingsPath);
-    } catch (e) {
-      try { unlinkSync(uninstTmp); } catch {}
-      throw e;
-    }
-    lines.push(ok('Removed lumira statusline from settings'));
+    uninstSettings = JSON.parse(readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
   } catch {
     lines.push(warn('Could not parse settings.json'));
+    lines.push(`\n  Restart Claude Code to apply changes.\n`);
+    return lines.join('\n') + '\n';
   }
+  delete uninstSettings.statusLine;
+  const uninstTmp = `${settingsPath}.${process.pid}.${Date.now()}.lumira.tmp`;
+  try {
+    const fd = openSync(uninstTmp, 'wx', 0o600);
+    writeSync(fd, JSON.stringify(uninstSettings, null, 2) + '\n');
+    fsyncSync(fd);
+    closeSync(fd);
+    renameSync(uninstTmp, settingsPath);
+  } catch (e) {
+    try { unlinkSync(uninstTmp); } catch {}
+    throw e;
+  }
+  lines.push(ok('Removed lumira statusline from settings'));
 
   // Remove skill from both destinations (best effort)
   for (const root of [join(home, '.claude'), join(home, '.qwen')]) {

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -7,7 +7,8 @@ import {
 import { QUOTA_CRITICAL } from '../types.js';
 import { buildContextBar, formatQwenMetrics } from './shared.js';
 import { formatTokens, formatCost, formatBurnRate } from '../utils/format.js';
-import type { ColorMode, Colors } from './colors.js';
+import { detectColorMode, type ColorMode, type Colors } from './colors.js';
+import { getConfigHealth } from '../parsers/config-health.js';
 import type { RenderContext } from '../types.js';
 import {
   type PowerlinePalette,
@@ -124,6 +125,16 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
   const effort = input.effortLevel || thinkingEffort;
   if (display.effort && effort && effort !== 'medium') {
     segments.push({ text: `^${effort}`, bg: palette.versionBg, fg: palette.fg, priority: 30 });
+  }
+
+  // Config health hints (opt-in, lowest priority — evicted first on narrow terminals)
+  if (display.health && input.cwd) {
+    const colorMode = ctx.config.colors.mode === 'auto' ? detectColorMode() : ctx.config.colors.mode;
+    const hints = getConfigHealth(ctx.config, colorMode, input.cwd);
+    for (const h of hints) {
+      const prefix = h.severity === 'warn' ? '⚠ ' : 'ℹ ';
+      segments.push({ text: `${prefix}${h.hint}`, bg: palette.versionBg, fg: palette.fg, priority: 10 });
+    }
   }
 
   return segments;

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { install, uninstall } from '../src/installer.js';
@@ -115,10 +115,12 @@ describe('install', () => {
   });
 
   it('writes temp file in same dir as settingsPath (no cross-fs rename)', async () => {
-    // The temp file must live beside settings.json so rename() is always same-fs.
-    // We verify no leftover .lumira.tmp exists after install (renamed to final dest).
+    // Temp file lives beside settings.json (same-fs rename). Includes process.pid
+    // so concurrent installs don't collide. Neither the PID-based name nor the
+    // legacy static name should remain after a successful install.
     await install(baseOpts());
-    expect(existsSync(settingsPath + '.lumira.tmp')).toBe(false);
+    const leftover = readdirSync(dir).filter(f => f.includes('lumira.tmp'));
+    expect(leftover).toHaveLength(0);
     expect(existsSync(settingsPath)).toBe(true);
   });
 
@@ -182,6 +184,21 @@ describe('uninstall', () => {
     // Should fall through to removing statusLine key
     const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
     expect(data.statusLine).toBeUndefined();
+  });
+
+  it('warns "Could not parse" (not "write") when settings.json is malformed during uninstall', () => {
+    writeFileSync(settingsPath, 'this is { not valid JSON!!');
+    const output = uninstall({ settingsPath });
+    expect(output).toContain('Could not parse');
+    expect(output).not.toContain('Could not write');
+  });
+
+  it('leaves no .lumira.tmp file after successful uninstall', () => {
+    const current = { statusLine: { type: 'command', command: 'npx lumira@latest', padding: 0 }, hooks: {} };
+    writeFileSync(settingsPath, JSON.stringify(current, null, 2));
+    uninstall({ settingsPath });
+    const leftover = readdirSync(dir).filter(f => f.includes('lumira.tmp'));
+    expect(leftover).toHaveLength(0);
   });
 });
 

--- a/tests/render/powerline-line2.test.ts
+++ b/tests/render/powerline-line2.test.ts
@@ -157,6 +157,54 @@ describe('renderPowerlineLine2', () => {
     });
   });
 
+  describe('config health hints', () => {
+    it('renders GSD-missing info hint when gsd is on but no .planning/STATE.md found', () => {
+      // This is the only health hint reachable in powerline mode (powerline requires
+      // truecolor/256, so named-color hints are never shown through this path).
+      // gsd:true + cwd with no STATE.md → getConfigHealth returns the info hint.
+      const ctx = makeCtx({
+        input: { ...normalize({ model: 'Claude', session_id: 't', context_window: { used_percentage: 10, remaining_percentage: 90, total_input_tokens: 0, total_output_tokens: 0 } }), cwd: '/tmp' },
+        config: {
+          ...DEFAULT_CONFIG,
+          display: { ...DEFAULT_DISPLAY, health: true },
+          colors: { mode: 'truecolor' },
+          gsd: true,
+        },
+      });
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).toContain('ℹ');
+      expect(out).toContain('GSD on but no .planning/STATE.md found');
+    });
+
+    it('does not render health hints when display.health is false', () => {
+      const ctx = makeCtx({
+        input: { ...normalize({ model: 'Claude', session_id: 't', context_window: { used_percentage: 10, remaining_percentage: 90, total_input_tokens: 0, total_output_tokens: 0 } }), cwd: '/tmp' },
+        config: {
+          ...DEFAULT_CONFIG,
+          display: { ...DEFAULT_DISPLAY, health: false },
+          colors: { mode: 'truecolor' },
+          gsd: true,
+        },
+      });
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).not.toContain('ℹ');
+    });
+
+    it('does not render health hints when getConfigHealth returns no hints', () => {
+      // truecolor + no theme + no gsd → getConfigHealth returns []
+      const ctx = makeCtx({
+        config: {
+          ...DEFAULT_CONFIG,
+          display: { ...DEFAULT_DISPLAY, health: true },
+          colors: { mode: 'truecolor' },
+          gsd: false,
+        },
+      });
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).not.toMatch(/[⚠ℹ]/);
+    });
+  });
+
   describe('rate-limit battery glyph', () => {
     function ctxWithRateLimit(usedPercentage: number, iconMode: 'nerd' | 'emoji' | 'none' = 'nerd') {
       const rawInput = {


### PR DESCRIPTION
## Summary

Three LOW-severity findings from the full Opus codebase review, deferred from PR #109/#110:

- **PID in tmp file name** (`installer.ts`) — `settingsPath + '.lumira.tmp'` → `` settingsPath + `.<pid>.lumira.tmp` ``. Eliminates collision risk between concurrent installs and makes stale cleanup unambiguous.
- **Uninstall error message split** (`installer.ts`) — the outer `try/catch` in `uninstall()` wrapped both `JSON.parse` and the atomic write, so a write failure showed "Could not parse settings.json". Now the parse is extracted into its own block with an early return, so the message is accurate.
- **Health hints in powerline-line2** (`powerline-line2.ts`) — `display.health` + `getConfigHealth` was present in classic line2 but missing from the powerline path. Added as priority-10 segments (lowest, evicted first on narrow terminals), mirroring the classic line2 behaviour.

## Tests

- 628 tests passing (5 new)
- TDD: failing tests written first, then implementation