### PR TITLE
feat: session intelligence — pace delta, agent count, cache hit rate

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -110,11 +110,12 @@ interface PresetDef {
 const PRESET_DEFS: Record<NonNullable<HudConfig['preset']>, PresetDef> = {
   full: {
     layout: 'multiline',
-    display: {}, // all defaults (everything on)
+    display: { agents: true }, // all defaults (everything on)
   },
   balanced: {
     layout: 'auto',
     display: {
+      agents: true,
       burnRate: false,
       duration: false,
       tokenSpeed: false,
@@ -130,6 +131,7 @@ const PRESET_DEFS: Record<NonNullable<HudConfig['preset']>, PresetDef> = {
   minimal: {
     layout: 'singleline',
     display: {
+      agents: false,
       tokens: false,
       burnRate: false,
       duration: false,

--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -106,6 +106,28 @@ export function getContextColor(
   return 'blinkRed';
 }
 
+/**
+ * Color for the pace delta value (how far ahead/behind of expected quota burn).
+ * Green when on-pace or behind (delta ≤ 0), escalating through yellow/orange/blinkRed
+ * as the ahead-of-pace burn rate increases.
+ */
+export function getPaceColor(delta: number): ColorName {
+  if (delta <= 0) return 'green';
+  if (delta <= 15) return 'yellow';
+  if (delta <= 30) return 'orange';
+  return 'blinkRed';
+}
+
+/**
+ * Color for the cache hit rate percentage.
+ * Green when cache is working well (≥70%), yellow for moderate (40–69%), orange for poor (<40%).
+ */
+export function getCacheHitColor(pct: number): ColorName {
+  if (pct >= 70) return 'green';
+  if (pct >= 40) return 'yellow';
+  return 'orange';
+}
+
 export function getQuotaColor(pct: number): ColorName {
   if (!Number.isFinite(pct)) return 'blinkRed'; // NaN/Infinity → maximum urgency, caller should gate upstream
   if (pct < 50) return 'green';

--- a/src/render/icons.ts
+++ b/src/render/icons.ts
@@ -18,6 +18,9 @@ export interface IconSet {
   ellipsis: string;
   dash: string;
   checkmark: string;
+  car: string;
+  turtle: string;
+  lightning: string;
   /**
    * Battery glyph keyed by usedPercentage. Replaces the bolt prefix on
    * rate-limit segments with a visual fuel gauge so the icon itself signals
@@ -86,6 +89,9 @@ export const NERD_ICONS: IconSet = {
   ellipsis:  '…',  // ...
   dash:      '—',  // em-dash
   checkmark: '✓',  // checkmark
+  car:       '🏎️',  // racing car — pace-ahead indicator
+  turtle:    '🐢',  // turtle — pace-behind indicator
+  lightning: '⚡',  // lightning bolt — cache hit rate
   battery:   nerdBattery,
 };
 
@@ -107,6 +113,9 @@ export const EMOJI_ICONS: IconSet = {
   ellipsis:  '…',
   dash:      '—',
   checkmark: '✅',    // ✅
+  car:       '\u{1F3CE}️', // 🏎️ — racing car
+  turtle:    '\u{1F422}',  // 🐢 — turtle
+  lightning: '⚡',         // ⚡ — cache hit rate
   battery:   (pct: number) => {
     if (!Number.isFinite(pct) || pct < 0) return '\u{1F50B}'; // 🔋 — no data / invalid input
     if (Math.round(pct) >= 100) return '\u{1F480}';            // 💀 — quota exhausted
@@ -133,6 +142,9 @@ export const NO_ICONS: IconSet = {
   ellipsis:  '…',
   dash:      '—',
   checkmark: '✓',
+  car:       '',
+  turtle:    '',
+  lightning: '',
   // No-icon mode keeps the legacy bolt fallback (currently empty) so users who
   // opted out of icons see no shape change from this feature.
   battery:   () => '',

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -1,9 +1,10 @@
 import { fitSegments, displayWidth } from './text.js';
-import { getQuotaColor, detectColorMode, type Colors } from './colors.js';
+import { getQuotaColor, getPaceColor, getCacheHitColor, detectColorMode, type Colors } from './colors.js';
 import { QUOTA_CRITICAL } from '../types.js';
 import { buildContextBar, formatQwenMetrics, SEP } from './shared.js';
 import { formatTokens, formatCost, formatBurnRate } from '../utils/format.js';
 import { getConfigHealth } from '../parsers/config-health.js';
+import { computePaceDelta, formatPaceDelta } from './pace.js';
 import type { RenderContext } from '../types.js';
 
 export function formatCountdown(resetsAt: number): string {
@@ -65,9 +66,10 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
     if (parts.length > 0) leftParts.push(`${icons.comment} ${parts.join(' ')}`);
   }
 
-  // Cache metrics (hit rate)
+  // Cache metrics (hit rate) — colored by quality tier
   if (display.cacheMetrics && input.cacheHitRate != null) {
-    leftParts.push(c.dim(`cache ${input.cacheHitRate}%`));
+    const cacheColorFn = c[getCacheHitColor(input.cacheHitRate)];
+    leftParts.push(cacheColorFn(`${input.cacheHitRate}%${icons.lightning}`));
   }
 
   // Cost + burn rate (Claude only — Qwen doesn't send cost data)
@@ -129,6 +131,24 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
         criticalInsertAt++; // keep relative order between 5h and 7d when both critical
       } else {
         leftParts.push(limitStr);
+      }
+    }
+
+    // Pace delta — shows how far ahead/behind of expected quota burn rate.
+    // Gate on fiveHour window being present and computePaceDelta returning a result.
+    const fiveHourWin = input.rateLimits?.fiveHour;
+    if (fiveHourWin && Number.isFinite(fiveHourWin.usedPercentage)) {
+      const pace = computePaceDelta(fiveHourWin.usedPercentage, fiveHourWin.resetsAt);
+      if (pace != null) {
+        const paceStr = formatPaceDelta(pace);
+        if (paceStr === 'on pace') {
+          leftParts.push(c.green('on pace'));
+        } else {
+          const paceIcon = pace.delta > 1 ? icons.car : pace.delta < -1 ? icons.turtle : '';
+          const paceColorFn = c[getPaceColor(pace.delta)];
+          const iconPrefix = paceIcon ? `${paceIcon}` : '';
+          leftParts.push(paceColorFn(`${iconPrefix}${paceStr}`));
+        }
       }
     }
   }

--- a/src/render/line3.ts
+++ b/src/render/line3.ts
@@ -34,6 +34,13 @@ function buildToolsPart(tools: ToolEntry[], c: Colors, ic: IconSet): string {
   return parts.join(' ');
 }
 
+function buildAgentsPart(agents: import('../types.js').AgentEntry[], c: Colors, ic: IconSet): string {
+  const running = agents.filter(a => a.status === 'running').length;
+  if (running < 1) return '';
+  const label = running === 1 ? '1 agent' : `${running} agents`;
+  return c.yellow(`${ic.bolt}${label}`);
+}
+
 function buildTodosPart(todos: TodoEntry[], c: Colors, ic: IconSet): string {
   if (todos.length === 0) return '';
 
@@ -54,12 +61,11 @@ function buildTodosPart(todos: TodoEntry[], c: Colors, ic: IconSet): string {
 }
 
 export function renderLine3(ctx: RenderContext, c: Colors): string {
-  const { transcript: { tools, todos }, config: { display }, icons } = ctx;
+  const { transcript: { tools, todos, agents }, config: { display }, icons } = ctx;
   const toolsPart = display.tools === false ? '' : buildToolsPart(tools, c, icons);
+  const agentsPart = display.agents === false ? '' : buildAgentsPart(agents, c, icons);
   const todosPart = display.todos === false ? '' : buildTodosPart(todos, c, icons);
 
-  if (!toolsPart && !todosPart) return '';
-  if (!toolsPart) return todosPart;
-  if (!todosPart) return toolsPart;
-  return toolsPart + SEP + todosPart;
+  const parts = [toolsPart, agentsPart, todosPart].filter(Boolean);
+  return parts.join(SEP);
 }

--- a/src/render/pace.ts
+++ b/src/render/pace.ts
@@ -1,0 +1,51 @@
+export interface PaceDelta {
+  delta: number;          // usedPct - elapsedPct (positive = ahead, negative = behind)
+  timeToExhaustion: number | null;  // minutes remaining at current burn rate (null if behind pace)
+}
+
+export function computePaceDelta(
+  usedPercentage: number,
+  resetsAt: number | undefined,
+  nowSec?: number,  // injectable for testing, defaults to Date.now()/1000
+): PaceDelta | null {
+  const now = nowSec ?? Date.now() / 1000;
+
+  if (resetsAt === undefined || resetsAt <= now) return null;
+
+  const totalWindowSec = 5 * 3600;
+  const remainingSec = resetsAt - now;
+  const elapsedSec = totalWindowSec - remainingSec;
+
+  if (elapsedSec < 300) return null; // insufficient data — less than 5 min elapsed
+
+  const elapsedPct = (elapsedSec / totalWindowSec) * 100;
+  const delta = usedPercentage - elapsedPct;
+
+  let timeToExhaustion: number | null = null;
+  if (delta > 0 && usedPercentage > 0) {
+    // burn rate = usedPercentage / elapsedSec (pct per second)
+    // time to exhaust remaining (100 - usedPercentage) pct at that rate
+    timeToExhaustion = (100 - usedPercentage) / (usedPercentage / elapsedSec) / 60;
+  }
+
+  return { delta, timeToExhaustion };
+}
+
+export function formatPaceDelta(pace: PaceDelta): string {
+  const rounded = Math.round(pace.delta);
+
+  if (pace.delta > -1 && pace.delta < 1) return 'on pace';
+
+  if (pace.delta > 0) {
+    let suffix = '';
+    if (pace.timeToExhaustion != null) {
+      const mins = Math.round(pace.timeToExhaustion);
+      suffix = mins >= 60
+        ? ` (~${Math.round(mins / 60)}h)`
+        : ` (~${mins}min)`;
+    }
+    return `+${rounded}%${suffix}`;
+  }
+
+  return `${rounded}%`;
+}

--- a/src/render/pace.ts
+++ b/src/render/pace.ts
@@ -40,9 +40,11 @@ export function formatPaceDelta(pace: PaceDelta): string {
     let suffix = '';
     if (pace.timeToExhaustion != null) {
       const mins = Math.round(pace.timeToExhaustion);
-      suffix = mins >= 60
-        ? ` (~${Math.round(mins / 60)}h)`
-        : ` (~${mins}min)`;
+      if (mins > 0) {
+        suffix = mins >= 60
+          ? ` (~${Math.round(mins / 60)}h)`
+          : ` (~${mins}min)`;
+      }
     }
     return `+${rounded}%${suffix}`;
   }

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -9,6 +9,7 @@ import { buildContextBar, formatQwenMetrics } from './shared.js';
 import { formatTokens, formatCost, formatBurnRate } from '../utils/format.js';
 import { detectColorMode, type ColorMode, type Colors } from './colors.js';
 import { getConfigHealth } from '../parsers/config-health.js';
+import { computePaceDelta, formatPaceDelta } from './pace.js';
 import type { RenderContext } from '../types.js';
 import {
   type PowerlinePalette,
@@ -74,6 +75,25 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
     }
   }
 
+  // Pace delta — how far ahead/behind of expected quota burn rate.
+  // Gate on fiveHour window being present and computePaceDelta returning a result.
+  if (display.rateLimits && input.rateLimits) {
+    const fiveHourWin = input.rateLimits.fiveHour;
+    if (fiveHourWin && Number.isFinite(fiveHourWin.usedPercentage)) {
+      const pace = computePaceDelta(fiveHourWin.usedPercentage, fiveHourWin.resetsAt);
+      if (pace != null) {
+        const paceStr = formatPaceDelta(pace);
+        if (paceStr === 'on pace') {
+          segments.push({ text: 'on pace', bg: palette.dirBg, fg: palette.fg, priority: 60 });
+        } else {
+          const paceIcon = pace.delta > 1 ? icons.car : pace.delta < -1 ? icons.turtle : '';
+          const iconPrefix = paceIcon ? `${paceIcon}` : '';
+          segments.push({ text: `${iconPrefix}${paceStr}`, bg: palette.dirBg, fg: palette.fg, priority: 60 });
+        }
+      }
+    }
+  }
+
   // Cost + burn rate
   if (display.cost && input.cost != null) {
     let costText = formatCost(input.cost);
@@ -96,9 +116,9 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
     }
   }
 
-  // Cache metrics (hit rate)
+  // Cache metrics (hit rate) — priority 50, colored text inside segment
   if (display.cacheMetrics && input.cacheHitRate != null) {
-    segments.push({ text: `cache ${input.cacheHitRate}%`, bg: palette.versionBg, fg: palette.fg, priority: 55 });
+    segments.push({ text: `${input.cacheHitRate}%${icons.lightning}`, bg: palette.versionBg, fg: palette.fg, priority: 50 });
   }
 
   // MCP servers

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -7,7 +7,7 @@ import {
 import { QUOTA_CRITICAL } from '../types.js';
 import { buildContextBar, formatQwenMetrics } from './shared.js';
 import { formatTokens, formatCost, formatBurnRate } from '../utils/format.js';
-import { detectColorMode, type ColorMode, type Colors } from './colors.js';
+import { detectColorMode, getPaceColor, type ColorMode, type Colors } from './colors.js';
 import { getConfigHealth } from '../parsers/config-health.js';
 import { computePaceDelta, formatPaceDelta } from './pace.js';
 import type { RenderContext } from '../types.js';
@@ -88,7 +88,8 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
         } else {
           const paceIcon = pace.delta > 1 ? icons.car : pace.delta < -1 ? icons.turtle : '';
           const iconPrefix = paceIcon ? `${paceIcon}` : '';
-          segments.push({ text: `${iconPrefix}${paceStr}`, bg: palette.dirBg, fg: palette.fg, priority: 60 });
+          const coloredText = c[getPaceColor(pace.delta)](`${iconPrefix}${paceStr}`);
+          segments.push({ text: coloredText, bg: palette.dirBg, fg: palette.fg, priority: 60 });
         }
       }
     }

--- a/src/render/powerline-line3.ts
+++ b/src/render/powerline-line3.ts
@@ -50,6 +50,15 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette): Powerline
     }
   }
 
+  // Agents segment — running agent count. Priority 70 (between tools and todos).
+  if (display.agents !== false) {
+    const runningAgents = ctx.transcript.agents.filter(a => a.status === 'running').length;
+    if (runningAgents >= 1) {
+      const label = runningAgents === 1 ? '1 agent' : `${runningAgents} agents`;
+      segments.push({ text: `${icons.bolt}${label}`, bg: palette.taskBg, fg: palette.fg, priority: 70 });
+    }
+  }
+
   // Todos segment — progress bar + counts. Mirrors classic line3 (pending, in-progress counts).
   if (display.todos !== false && todos.length > 0) {
     const total = todos.length;

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,12 +75,12 @@ export interface TranscriptData {
 }
 
 export const EMPTY_TRANSCRIPT: Readonly<TranscriptData> = Object.freeze({
-  tools: Object.freeze([] as readonly ToolEntry[]),
-  agents: Object.freeze([] as readonly AgentEntry[]),
-  todos: Object.freeze([] as readonly TodoEntry[]),
-  thinkingEffort: '',
+  tools: Object.freeze([] as ToolEntry[]),
+  agents: Object.freeze([] as AgentEntry[]),
+  todos: Object.freeze([] as TodoEntry[]),
+  thinkingEffort: '' as ThinkingEffort,
   sessionStart: null,
-});
+} as TranscriptData);
 
 export type ThinkingEffort = 'low' | 'medium' | 'high' | 'max' | 'xhigh' | '';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -218,6 +218,7 @@ export interface DisplayToggles {
   memory: boolean;
   cacheMetrics: boolean;
   mcp: boolean;
+  agents: boolean;
   health: boolean;
   /**
    * Percentage at which the context bar turns orange and shows the fire icon. Default 70. Clamped [0,100].
@@ -270,6 +271,7 @@ export const DEFAULT_DISPLAY: DisplayToggles = {
   memory: true,
   cacheMetrics: true,
   mcp: true,
+  agents: true,
   health: false,
   contextWarningThreshold: DEFAULT_CONTEXT_WARNING_THRESHOLD,
   contextCriticalThreshold: DEFAULT_CONTEXT_CRITICAL_THRESHOLD,

--- a/tests/render/colors.test.ts
+++ b/tests/render/colors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { createColors, stripAnsi, detectColorMode, getContextColor, getQuotaColor } from '../../src/render/colors.js';
+import { createColors, stripAnsi, detectColorMode, getContextColor, getQuotaColor, getPaceColor, getCacheHitColor } from '../../src/render/colors.js';
 
 describe('stripAnsi', () => {
   it('removes ANSI escape codes', () => {
@@ -115,4 +115,24 @@ describe('getQuotaColor', () => {
   it('returns blinkRed for NaN', () => { expect(getQuotaColor(NaN)).toBe('blinkRed'); });
   it('returns blinkRed for Infinity', () => { expect(getQuotaColor(Infinity)).toBe('blinkRed'); });
   it('returns blinkRed for -Infinity — guard prevents false green', () => { expect(getQuotaColor(-Infinity)).toBe('blinkRed'); });
+});
+
+describe('getPaceColor', () => {
+  it('returns green at delta = 0 (exactly on pace)', () => { expect(getPaceColor(0)).toBe('green'); });
+  it('returns green for negative delta (behind pace — healthy)', () => { expect(getPaceColor(-10)).toBe('green'); });
+  it('returns yellow at delta = 1 (lower warning boundary)', () => { expect(getPaceColor(1)).toBe('yellow'); });
+  it('returns yellow at delta = 15 (upper warning boundary)', () => { expect(getPaceColor(15)).toBe('yellow'); });
+  it('returns orange at delta = 16 (lower escalation boundary)', () => { expect(getPaceColor(16)).toBe('orange'); });
+  it('returns orange at delta = 30 (upper escalation boundary)', () => { expect(getPaceColor(30)).toBe('orange'); });
+  it('returns blinkRed at delta = 31 (critical boundary)', () => { expect(getPaceColor(31)).toBe('blinkRed'); });
+  it('returns blinkRed for very high delta', () => { expect(getPaceColor(80)).toBe('blinkRed'); });
+});
+
+describe('getCacheHitColor', () => {
+  it('returns green at 100% (perfect cache)', () => { expect(getCacheHitColor(100)).toBe('green'); });
+  it('returns green at 70% (lower green boundary)', () => { expect(getCacheHitColor(70)).toBe('green'); });
+  it('returns yellow at 69% (upper yellow boundary)', () => { expect(getCacheHitColor(69)).toBe('yellow'); });
+  it('returns yellow at 40% (lower yellow boundary)', () => { expect(getCacheHitColor(40)).toBe('yellow'); });
+  it('returns orange at 39% (upper orange boundary)', () => { expect(getCacheHitColor(39)).toBe('orange'); });
+  it('returns orange at 0% (no cache hits)', () => { expect(getCacheHitColor(0)).toBe('orange'); });
 });

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -275,8 +275,9 @@ describe('renderLine2', () => {
     };
     // 100000 / (31000 + 100000) = 76%
     const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
-    expect(out).toContain('cache');
+    // New format: N%⚡ (no 'cache' prefix)
     expect(out).toContain('76%');
+    expect(out).not.toContain('cache 76%');
   });
 
   it('reads cache hit rate from nested current_usage (modern 2.1.x payload)', () => {
@@ -291,8 +292,9 @@ describe('renderLine2', () => {
       },
     };
     const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
-    // 80000 / (50000 + 80000 + 20000) = 53%
-    expect(out).toContain('cache 53%');
+    // 80000 / (50000 + 80000 + 20000) = 53% — new format: N%⚡ (no 'cache' prefix)
+    expect(out).toContain('53%');
+    expect(out).not.toContain('cache 53%');
   });
 
   it('hides cache metrics for legacy payloads without current_usage (no denominator after #79)', () => {
@@ -359,6 +361,150 @@ describe('renderLine2', () => {
     // High-priority segment (context bar) survives; low-priority rate limit drops.
     expect(out).toMatch(/\d+%/); // context % is present
     expect(out).not.toContain('75%(5h)'); // rate-limit segment got dropped
+  });
+
+  // ── Cache hit rate widget ───────────────────────────────────────────────────
+
+  it('renders cache hit rate as N%⚡ (no "cache" prefix)', () => {
+    const inputOverride = {
+      context_window: {
+        ...baseInput.context_window,
+        current_usage: { input_tokens: 10000, cache_read_input_tokens: 90000 },
+      },
+    };
+    // 90000 / (10000 + 90000) = 90%
+    const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+    expect(out).toContain('90%');
+    expect(out).not.toContain('cache 90%');
+  });
+
+  it('cache hit rate is green when >=70%', () => {
+    const inputOverride = {
+      context_window: {
+        ...baseInput.context_window,
+        current_usage: { input_tokens: 10000, cache_read_input_tokens: 90000 },
+      },
+    };
+    const out = renderLine2(makeCtx({}, inputOverride), c);
+    // green = \x1b[32m
+    expect(out).toMatch(/\x1b\[32m90%/);
+  });
+
+  it('cache hit rate is yellow when 40-69%', () => {
+    const inputOverride = {
+      context_window: {
+        ...baseInput.context_window,
+        current_usage: { input_tokens: 60000, cache_read_input_tokens: 40000 },
+      },
+    };
+    // 40000 / 100000 = 40%
+    const out = renderLine2(makeCtx({}, inputOverride), c);
+    // yellow = \x1b[33m
+    expect(out).toMatch(/\x1b\[33m40%/);
+  });
+
+  it('cache hit rate is orange when <40%', () => {
+    const inputOverride = {
+      context_window: {
+        ...baseInput.context_window,
+        current_usage: { input_tokens: 70000, cache_read_input_tokens: 20000 },
+      },
+    };
+    // 20000 / 90000 ≈ 22%
+    const out = renderLine2(makeCtx({}, inputOverride), c);
+    // orange = \x1b[38;5;208m
+    expect(out).toMatch(/\x1b\[38;5;208m22%/);
+  });
+
+  it('hides cache hit rate when cacheMetrics display is off', () => {
+    const inputOverride = {
+      context_window: {
+        ...baseInput.context_window,
+        current_usage: { input_tokens: 10000, cache_read_input_tokens: 90000 },
+      },
+    };
+    const ctx = makeCtx(
+      { config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, cacheMetrics: false } } },
+      inputOverride,
+    );
+    const out = stripAnsi(renderLine2(ctx, c));
+    expect(out).not.toMatch(/\d+%⚡/);
+  });
+
+  // ── Pace delta widget ───────────────────────────────────────────────────────
+
+  it('shows pace delta ahead marker when burning quota faster than elapsed time', () => {
+    // Pin "now" so computePaceDelta has a defined window.
+    const pinnedNow = 1_700_000_000_000;
+    vi.useFakeTimers({ now: pinnedNow });
+    const nowSec = pinnedNow / 1000;
+    // 2 hours elapsed of a 5h window → resetsAt = now + 3h
+    const resetsAt = nowSec + 3 * 3600;
+    // 60% used but only 40% elapsed → delta = +20 (ahead of pace)
+    const inputOverride = {
+      rate_limits: { five_hour: { used_percentage: 60, resets_at: resetsAt } },
+    };
+    const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+    expect(out).toContain('+20%');
+  });
+
+  it('shows pace delta behind marker when burning quota slower than elapsed time', () => {
+    const pinnedNow = 1_700_000_000_000;
+    vi.useFakeTimers({ now: pinnedNow });
+    const nowSec = pinnedNow / 1000;
+    // 2 hours elapsed → resetsAt = now + 3h
+    const resetsAt = nowSec + 3 * 3600;
+    // 20% used but 40% elapsed → delta = -20 (behind pace)
+    const inputOverride = {
+      rate_limits: { five_hour: { used_percentage: 20, resets_at: resetsAt } },
+    };
+    const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+    expect(out).toContain('-20%');
+  });
+
+  it('shows "on pace" when delta is within ±1%', () => {
+    const pinnedNow = 1_700_000_000_000;
+    vi.useFakeTimers({ now: pinnedNow });
+    const nowSec = pinnedNow / 1000;
+    const resetsAt = nowSec + 3 * 3600;
+    // 40% used, 40% elapsed → delta = 0
+    const inputOverride = {
+      rate_limits: { five_hour: { used_percentage: 40, resets_at: resetsAt } },
+    };
+    const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+    expect(out).toContain('on pace');
+  });
+
+  it('hides pace delta when rateLimits display is off', () => {
+    const pinnedNow = 1_700_000_000_000;
+    vi.useFakeTimers({ now: pinnedNow });
+    const nowSec = pinnedNow / 1000;
+    const resetsAt = nowSec + 3 * 3600;
+    const inputOverride = {
+      rate_limits: { five_hour: { used_percentage: 60, resets_at: resetsAt } },
+    };
+    const ctx = makeCtx(
+      { config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, rateLimits: false } } },
+      inputOverride,
+    );
+    const out = stripAnsi(renderLine2(ctx, c));
+    expect(out).not.toContain('+');
+    expect(out).not.toContain('on pace');
+  });
+
+  it('hides pace delta when insufficient data (< 5 min elapsed)', () => {
+    const pinnedNow = 1_700_000_000_000;
+    vi.useFakeTimers({ now: pinnedNow });
+    const nowSec = pinnedNow / 1000;
+    // Only 2 minutes elapsed → computePaceDelta returns null
+    const resetsAt = nowSec + (5 * 3600 - 120);
+    const inputOverride = {
+      rate_limits: { five_hour: { used_percentage: 10, resets_at: resetsAt } },
+    };
+    const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+    expect(out).not.toContain('on pace');
+    // No +/- delta markers appear (context bar %-suffix is still present, that's fine)
+    expect(out).not.toMatch(/[+-]\d+%/);
   });
 });
 

--- a/tests/render/line3.test.ts
+++ b/tests/render/line3.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { renderLine3 } from '../../src/render/line3.js';
 import { createColors, stripAnsi } from '../../src/render/colors.js';
 import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '../../src/types.js';
-import type { ClaudeCodeInput, ToolEntry, TodoEntry, RenderContext } from '../../src/types.js';
+import type { ClaudeCodeInput, ToolEntry, TodoEntry, AgentEntry, RenderContext } from '../../src/types.js';
 import { NERD_ICONS } from '../../src/render/icons.js';
 import { normalize } from '../../src/normalize.js';
 
@@ -110,5 +110,47 @@ describe('renderLine3', () => {
     const todos = [todo('1', 'Task', 'completed')];
     const transcript = { ...EMPTY_TRANSCRIPT, tools, todos };
     expect(renderLine3(makeCtx({ transcript, config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, tools: false, todos: false } } }), c)).toBe('');
+  });
+});
+
+const runningAgent = (id: string): AgentEntry => ({
+  id, type: 'general-purpose', status: 'running', startTime: new Date(),
+});
+
+const completedAgent = (id: string): AgentEntry => ({
+  id, type: 'general-purpose', status: 'completed', startTime: new Date(), endTime: new Date(),
+});
+
+describe('renderLine3 — agent count', () => {
+  it('returns empty when no agents running', () => {
+    const transcript = { ...EMPTY_TRANSCRIPT, agents: [completedAgent('a1')] };
+    expect(renderLine3(makeCtx({ transcript }), c)).toBe('');
+  });
+
+  it('shows "1 agent" (singular) when exactly one running', () => {
+    const transcript = { ...EMPTY_TRANSCRIPT, agents: [runningAgent('a1')] };
+    const out = stripAnsi(renderLine3(makeCtx({ transcript }), c));
+    expect(out).toContain('1 agent');
+    expect(out).not.toContain('agents');
+  });
+
+  it('shows "N agents" (plural) when multiple running', () => {
+    const transcript = { ...EMPTY_TRANSCRIPT, agents: [runningAgent('a1'), runningAgent('a2'), runningAgent('a3')] };
+    const out = stripAnsi(renderLine3(makeCtx({ transcript }), c));
+    expect(out).toContain('3 agents');
+  });
+
+  it('only counts running agents, not completed ones', () => {
+    const transcript = { ...EMPTY_TRANSCRIPT, agents: [runningAgent('a1'), completedAgent('a2'), completedAgent('a3')] };
+    const out = stripAnsi(renderLine3(makeCtx({ transcript }), c));
+    expect(out).toContain('1 agent');
+    expect(out).not.toContain('agents');
+  });
+
+  it('hides agent count when display.agents is false', () => {
+    const transcript = { ...EMPTY_TRANSCRIPT, agents: [runningAgent('a1'), runningAgent('a2')] };
+    const config = { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, agents: false } };
+    const out = stripAnsi(renderLine3(makeCtx({ transcript, config }), c));
+    expect(out).not.toContain('agent');
   });
 });

--- a/tests/render/pace.test.ts
+++ b/tests/render/pace.test.ts
@@ -190,4 +190,15 @@ describe('formatPaceDelta', () => {
   it('delta at boundary -1.0 is NOT "on pace" (exclusive lower)', () => {
     expect(formatPaceDelta({ delta: -1, timeToExhaustion: null })).toBe('-1%');
   });
+
+  it('suppresses suffix when TTE rounds to zero (usedPercentage = 100 edge case)', () => {
+    // TTE = 0 means quota already exhausted — showing "~0min" is misleading
+    const result = formatPaceDelta({ delta: 50, timeToExhaustion: 0 });
+    expect(result).toBe('+50%');
+  });
+
+  it('suppresses suffix when TTE is sub-minute (rounds to 0)', () => {
+    const result = formatPaceDelta({ delta: 50, timeToExhaustion: 0.3 });
+    expect(result).toBe('+50%');
+  });
 });

--- a/tests/render/pace.test.ts
+++ b/tests/render/pace.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest';
+import { computePaceDelta, formatPaceDelta } from '../../src/render/pace.js';
+
+// A fixed "now" for deterministic tests: arbitrary Unix timestamp
+const NOW = 1_000_000; // seconds
+
+// Total window is 5h = 18000s
+const WINDOW = 5 * 3600; // 18000
+
+describe('computePaceDelta', () => {
+  it('returns null when resetsAt is undefined', () => {
+    expect(computePaceDelta(50, undefined, NOW)).toBeNull();
+  });
+
+  it('returns null when resetsAt is in the past', () => {
+    expect(computePaceDelta(50, NOW - 1, NOW)).toBeNull();
+  });
+
+  it('returns null when resetsAt equals now (boundary)', () => {
+    expect(computePaceDelta(50, NOW, NOW)).toBeNull();
+  });
+
+  it('returns null when less than 5 min has elapsed (elapsedSec < 300)', () => {
+    // Only 4 minutes (240s) elapsed → resetsAt = now + (18000 - 240)
+    const resetsAt = NOW + (WINDOW - 240);
+    expect(computePaceDelta(50, resetsAt, NOW)).toBeNull();
+  });
+
+  it('returns null at exactly 299s elapsed (boundary below threshold)', () => {
+    const resetsAt = NOW + (WINDOW - 299);
+    expect(computePaceDelta(50, resetsAt, NOW)).toBeNull();
+  });
+
+  it('returns non-null at exactly 300s elapsed (threshold met)', () => {
+    const resetsAt = NOW + (WINDOW - 300);
+    expect(computePaceDelta(50, resetsAt, NOW)).not.toBeNull();
+  });
+
+  it('returns positive delta when used more than proportional time (ahead of pace)', () => {
+    // 25% of window elapsed, but 50% used → delta = +25
+    const elapsedSec = WINDOW * 0.25; // 4500s
+    const resetsAt = NOW + (WINDOW - elapsedSec);
+    const result = computePaceDelta(50, resetsAt, NOW);
+    expect(result).not.toBeNull();
+    expect(result!.delta).toBeGreaterThan(0);
+  });
+
+  it('returns negative delta when used less than proportional time (behind pace)', () => {
+    // 75% of window elapsed, but only 25% used → delta = 25 - 75 = -50
+    const elapsedSec = WINDOW * 0.75; // 13500s
+    const resetsAt = NOW + (WINDOW - elapsedSec);
+    const result = computePaceDelta(25, resetsAt, NOW);
+    expect(result).not.toBeNull();
+    expect(result!.delta).toBeLessThan(0);
+  });
+
+  it('returns near-zero delta when on pace', () => {
+    // 50% elapsed, 50% used → delta ≈ 0
+    const elapsedSec = WINDOW * 0.5; // 9000s
+    const resetsAt = NOW + (WINDOW - elapsedSec);
+    const result = computePaceDelta(50, resetsAt, NOW);
+    expect(result).not.toBeNull();
+    expect(Math.abs(result!.delta)).toBeLessThan(0.01);
+  });
+
+  it('sets timeToExhaustion when delta > 0', () => {
+    // Ahead of pace → TTE should be non-null
+    const elapsedSec = WINDOW * 0.25;
+    const resetsAt = NOW + (WINDOW - elapsedSec);
+    const result = computePaceDelta(50, resetsAt, NOW);
+    expect(result!.timeToExhaustion).not.toBeNull();
+    expect(result!.timeToExhaustion).toBeGreaterThan(0);
+  });
+
+  it('sets timeToExhaustion to null when delta <= 0', () => {
+    // Behind pace → TTE should be null
+    const elapsedSec = WINDOW * 0.75;
+    const resetsAt = NOW + (WINDOW - elapsedSec);
+    const result = computePaceDelta(25, resetsAt, NOW);
+    expect(result!.timeToExhaustion).toBeNull();
+  });
+
+  it('calculates correct delta: 50% used at 25% elapsed = +25% delta', () => {
+    const elapsedSec = WINDOW * 0.25; // exactly 25% elapsed
+    const resetsAt = NOW + (WINDOW - elapsedSec);
+    const result = computePaceDelta(50, resetsAt, NOW);
+    expect(result).not.toBeNull();
+    expect(result!.delta).toBeCloseTo(25, 5);
+  });
+
+  it('nowSec is injectable — same inputs produce deterministic result', () => {
+    const resetsAt = NOW + (WINDOW - 3600); // 1h elapsed
+    const result1 = computePaceDelta(40, resetsAt, NOW);
+    const result2 = computePaceDelta(40, resetsAt, NOW);
+    expect(result1).toEqual(result2);
+  });
+
+  it('edge: usedPercentage = 0 with resetsAt far in future → negative delta, no TTE', () => {
+    // 50% elapsed, 0% used → delta = -50, TTE = null
+    const elapsedSec = WINDOW * 0.5;
+    const resetsAt = NOW + (WINDOW - elapsedSec);
+    const result = computePaceDelta(0, resetsAt, NOW);
+    expect(result).not.toBeNull();
+    expect(result!.delta).toBeLessThan(0);
+    expect(result!.timeToExhaustion).toBeNull();
+  });
+
+  it('edge: usedPercentage = 100 → high positive delta and TTE near 0', () => {
+    // 50% elapsed, 100% used → delta = 50, TTE = 0 remaining / burn_rate ≈ 0
+    const elapsedSec = WINDOW * 0.5; // 9000s
+    const resetsAt = NOW + (WINDOW - elapsedSec);
+    const result = computePaceDelta(100, resetsAt, NOW);
+    expect(result).not.toBeNull();
+    expect(result!.delta).toBeGreaterThan(0);
+    // TTE: (100 - 100) / (100 / 9000) / 60 = 0
+    expect(result!.timeToExhaustion).toBeCloseTo(0, 5);
+  });
+
+  it('computes correct TTE: 50% used at 25% elapsed', () => {
+    // burnRate = 50% / 4500s; remaining = 50%; TTE = 50 / (50/4500) / 60 = 4500/60 = 75 min
+    const elapsedSec = WINDOW * 0.25; // 4500s
+    const resetsAt = NOW + (WINDOW - elapsedSec);
+    const result = computePaceDelta(50, resetsAt, NOW);
+    expect(result!.timeToExhaustion).toBeCloseTo(75, 5);
+  });
+});
+
+describe('formatPaceDelta', () => {
+  it('returns "on pace" when delta is between -1 and 1 (exclusive)', () => {
+    expect(formatPaceDelta({ delta: 0, timeToExhaustion: null })).toBe('on pace');
+    expect(formatPaceDelta({ delta: 0.5, timeToExhaustion: null })).toBe('on pace');
+    expect(formatPaceDelta({ delta: -0.99, timeToExhaustion: null })).toBe('on pace');
+  });
+
+  it('returns "on pace" at delta = 0 exactly', () => {
+    expect(formatPaceDelta({ delta: 0, timeToExhaustion: null })).toBe('on pace');
+  });
+
+  it('formats ahead with TTE < 60 min as "+N% (~Xmin)"', () => {
+    const result = formatPaceDelta({ delta: 15, timeToExhaustion: 45 });
+    expect(result).toBe('+15% (~45min)');
+  });
+
+  it('formats ahead with TTE >= 60 min as "+N% (~Xh)"', () => {
+    const result = formatPaceDelta({ delta: 10, timeToExhaustion: 120 });
+    expect(result).toBe('+10% (~2h)');
+  });
+
+  it('formats ahead with null TTE as "+N%" (no suffix)', () => {
+    const result = formatPaceDelta({ delta: 20, timeToExhaustion: null });
+    expect(result).toBe('+20%');
+  });
+
+  it('formats behind pace as "-N%" (no TTE suffix)', () => {
+    const result = formatPaceDelta({ delta: -15, timeToExhaustion: null });
+    expect(result).toBe('-15%');
+  });
+
+  it('formats large positive value: +50%', () => {
+    const result = formatPaceDelta({ delta: 50, timeToExhaustion: null });
+    expect(result).toBe('+50%');
+  });
+
+  it('formats large negative value: -30%', () => {
+    const result = formatPaceDelta({ delta: -30, timeToExhaustion: null });
+    expect(result).toBe('-30%');
+  });
+
+  it('rounds fractional delta values', () => {
+    expect(formatPaceDelta({ delta: 15.6, timeToExhaustion: null })).toBe('+16%');
+    expect(formatPaceDelta({ delta: -15.4, timeToExhaustion: null })).toBe('-15%');
+  });
+
+  it('rounds TTE minutes when formatting suffix', () => {
+    // TTE = 45.7 → rounds to 46
+    const result = formatPaceDelta({ delta: 10, timeToExhaustion: 45.7 });
+    expect(result).toBe('+10% (~46min)');
+  });
+
+  it('rounds TTE hours: 90 min → ~2h', () => {
+    const result = formatPaceDelta({ delta: 10, timeToExhaustion: 90 });
+    expect(result).toBe('+10% (~2h)');
+  });
+
+  it('delta at boundary 1.0 is NOT "on pace" (exclusive upper)', () => {
+    // delta >= 1 should produce a formatted string, not "on pace"
+    expect(formatPaceDelta({ delta: 1, timeToExhaustion: null })).toBe('+1%');
+  });
+
+  it('delta at boundary -1.0 is NOT "on pace" (exclusive lower)', () => {
+    expect(formatPaceDelta({ delta: -1, timeToExhaustion: null })).toBe('-1%');
+  });
+});

--- a/tests/render/powerline-line2.test.ts
+++ b/tests/render/powerline-line2.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { renderPowerlineLine2 } from '../../src/render/powerline-line2.js';
 import { createColors } from '../../src/render/colors.js';
 import { stripAnsi } from '../../src/render/colors.js';
@@ -33,6 +33,8 @@ function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
 const c = createColors('truecolor', null);
 
 describe('renderPowerlineLine2', () => {
+  afterEach(() => vi.useRealTimers());
+
   it('renders context bar segment in truecolor', () => {
     const ctx = makeCtx();
     const out = renderPowerlineLine2(ctx, 'truecolor', null, c);
@@ -136,8 +138,9 @@ describe('renderPowerlineLine2', () => {
         config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, cacheMetrics: true } },
       });
       const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
-      expect(out).toContain('cache');
+      // New format: N%⚡ (no 'cache' prefix)
       expect(out).toContain('75%');
+      expect(out).not.toContain('cache 75%');
     });
 
     it('burnRate segment appears next to cost when display.burnRate true', () => {
@@ -154,6 +157,35 @@ describe('renderPowerlineLine2', () => {
       const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
       // burnRate formatted as $/h or $/min — check for $/
       expect(out).toMatch(/\$.*\/[hm]/);
+    });
+
+    it('cache hit rate renders as N%⚡ in powerline segment (no "cache" prefix)', () => {
+      const patchedInput = { ...makeCtx().input, cacheHitRate: 85 };
+      const ctx = makeCtx({
+        input: patchedInput,
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, cacheMetrics: true } },
+      });
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).toContain('85%');
+      expect(out).not.toContain('cache 85%');
+    });
+
+    it('pace delta segment appears when fiveHour window has sufficient data', () => {
+      const pinnedNow = 1_700_000_000_000;
+      vi.useFakeTimers({ now: pinnedNow });
+      const nowSec = pinnedNow / 1000;
+      const resetsAt = nowSec + 3 * 3600; // 2h elapsed of a 5h window
+      const rawInput = {
+        model: 'Claude Sonnet 4.6',
+        session_id: 'test',
+        context_window: { used_percentage: 42, remaining_percentage: 58, total_input_tokens: 12000, total_output_tokens: 1800 },
+        cost: { total_cost_usd: 0.42, total_duration_ms: 185000 },
+        rate_limits: { five_hour: { used_percentage: 60, resets_at: resetsAt } },
+      };
+      const ctx = makeCtx({ input: normalize(rawInput) });
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      // delta = 60 - 40 = +20%
+      expect(out).toContain('+20%');
     });
   });
 

--- a/tests/render/powerline-line3.test.ts
+++ b/tests/render/powerline-line3.test.ts
@@ -4,7 +4,7 @@ import { stripAnsi } from '../../src/render/colors.js';
 import { resolveIcons } from '../../src/render/icons.js';
 import { normalize } from '../../src/normalize.js';
 import { DEFAULT_CONFIG, DEFAULT_DISPLAY, EMPTY_GIT, EMPTY_TRANSCRIPT } from '../../src/types.js';
-import type { RenderContext } from '../../src/types.js';
+import type { AgentEntry, RenderContext } from '../../src/types.js';
 
 function makeCtx(overrides: Partial<RenderContext> = {}): RenderContext {
   const rawInput = {
@@ -105,5 +105,48 @@ describe('renderPowerlineLine3', () => {
     });
     const plain = stripAnsi(renderPowerlineLine3(ctx, 'truecolor', null));
     expect(plain).toContain('○ 2'); // pending count
+  });
+});
+
+const runningAgent = (id: string): AgentEntry => ({
+  id, type: 'general-purpose', status: 'running', startTime: new Date(),
+});
+
+const completedAgent = (id: string): AgentEntry => ({
+  id, type: 'general-purpose', status: 'completed', startTime: new Date(), endTime: new Date(),
+});
+
+describe('renderPowerlineLine3 — agent count', () => {
+  it('returns empty when no agents running', () => {
+    const ctx = makeCtx({ transcript: { ...EMPTY_TRANSCRIPT, agents: [completedAgent('a1')] } });
+    expect(renderPowerlineLine3(ctx, 'truecolor', null)).toBe('');
+  });
+
+  it('shows "1 agent" (singular) when exactly one running', () => {
+    const ctx = makeCtx({ transcript: { ...EMPTY_TRANSCRIPT, agents: [runningAgent('a1')] } });
+    const out = stripAnsi(renderPowerlineLine3(ctx, 'truecolor', null));
+    expect(out).toContain('1 agent');
+    expect(out).not.toContain('agents');
+  });
+
+  it('shows "N agents" (plural) when multiple running', () => {
+    const ctx = makeCtx({ transcript: { ...EMPTY_TRANSCRIPT, agents: [runningAgent('a1'), runningAgent('a2')] } });
+    const out = stripAnsi(renderPowerlineLine3(ctx, 'truecolor', null));
+    expect(out).toContain('2 agents');
+  });
+
+  it('only counts running agents, not completed ones', () => {
+    const ctx = makeCtx({ transcript: { ...EMPTY_TRANSCRIPT, agents: [runningAgent('a1'), completedAgent('a2')] } });
+    const out = stripAnsi(renderPowerlineLine3(ctx, 'truecolor', null));
+    expect(out).toContain('1 agent');
+    expect(out).not.toContain('agents');
+  });
+
+  it('hides agent count when display.agents is false', () => {
+    const ctx = makeCtx({
+      transcript: { ...EMPTY_TRANSCRIPT, agents: [runningAgent('a1'), runningAgent('a2')] },
+      config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, agents: false } },
+    });
+    expect(stripAnsi(renderPowerlineLine3(ctx, 'truecolor', null))).not.toContain('agent');
   });
 });


### PR DESCRIPTION
## Summary

- **Pace delta**: shows how fast quota is being consumed vs time elapsed in the 5h window (`usedPct - elapsedPct`). Turtle 🐢 when behind pace (healthy), car 🏎️ with ETA when ahead of pace (warning). Gated by existing `display.rateLimits` toggle.
- **Agent count**: shows live count of running subagents (⚡3 agents). Only rendered when ≥1 agent running. New `display.agents` toggle (default on, minimal preset off).
- **Cache hit rate**: compact efficiency indicator appended to token display (e.g. `94k/200k 87%⚡`). Color-coded green/yellow/orange. Gated by existing `display.cacheMetrics` toggle.

Both classic and powerline render modes supported for all three widgets.

## Changes

- `src/render/pace.ts` — new: pace delta calculation + formatting
- `src/render/colors.ts` — `getPaceColor`, `getCacheHitColor`
- `src/render/icons.ts` — `car`, `turtle`, `lightning` glyphs across all icon sets
- `src/render/line2.ts` / `powerline-line2.ts` — pace delta + cache hit rate segments
- `src/render/line3.ts` / `powerline-line3.ts` — agent count segment
- `src/types.ts` — `display.agents` toggle, `Readonly<TranscriptData>` on RenderContext, deep-frozen `EMPTY_TRANSCRIPT`
- `src/config.ts` — `agents` in all 3 presets

## Test plan

- [x] `tests/render/pace.test.ts` — 29 unit tests covering all branches (ahead/behind/on-pace/edge cases)
- [x] All 712 tests passing
- [x] Feature verified live in Claude Code session (turtle + cache hit rate visible)