### PR TITLE
fix: v1.0.1 polish — cacheHitRate=0 and installer parent dir cleanup

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -251,6 +251,7 @@ export function uninstall(opts: InstallerOptions = {}): string {
           try {
             unlinkSync(skillFile);
             try { rmdirSync(dirname(skillFile)); } catch { /* dir not empty, ok */ }
+            try { rmdirSync(dirname(dirname(skillFile))); } catch { /* parent skills/ not empty, ok */ }
           } catch { /* best effort */ }
         }
       }
@@ -292,6 +293,7 @@ export function uninstall(opts: InstallerOptions = {}): string {
       try {
         unlinkSync(skillFile);
         try { rmdirSync(dirname(skillFile)); } catch { /* dir not empty, ok */ }
+        try { rmdirSync(dirname(dirname(skillFile))); } catch { /* parent skills/ not empty, ok */ }
       } catch { /* best effort */ }
     }
   }

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -211,7 +211,7 @@ export function normalize(input: RawInput): NormalizedInput {
 
   // Cache hit rate (Claude only) — denominator is the current turn's total input
   // (fresh + cache_read + cache_creation), not the cumulative session total.
-  const cacheHitRate = (cached != null && cached > 0 && cacheTurnDenominator && platform === 'claude-code')
+  const cacheHitRate = (cached != null && cacheTurnDenominator && platform === 'claude-code')
     ? Math.min(100, Math.round((cached / cacheTurnDenominator) * 100))
     : undefined;
 

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -337,4 +337,32 @@ describe('install — skill dual install for Qwen', () => {
     expect(existsSync(join(claudeHome, 'skills', 'lumira', 'SKILL.md'))).toBe(false);
     expect(existsSync(join(qwenHome, 'skills', 'lumira', 'SKILL.md'))).toBe(false);
   });
+
+  it('uninstall cleans up empty skills/ parent dir when no other skills remain', () => {
+    mkdirSync(join(claudeHome, 'skills', 'lumira'), { recursive: true });
+    writeFileSync(join(claudeHome, 'skills', 'lumira', 'SKILL.md'), 'dummy');
+
+    const settingsPath = join(claudeHome, 'settings.json');
+    writeFileSync(settingsPath, JSON.stringify({ statusLine: { type: 'command', command: 'npx lumira@latest' } }));
+
+    uninstall({ settingsPath, homeOverride: tmpHome });
+
+    expect(existsSync(join(claudeHome, 'skills', 'lumira'))).toBe(false);
+    expect(existsSync(join(claudeHome, 'skills'))).toBe(false);
+  });
+
+  it('uninstall preserves skills/ parent dir when other skills exist', () => {
+    mkdirSync(join(claudeHome, 'skills', 'lumira'), { recursive: true });
+    writeFileSync(join(claudeHome, 'skills', 'lumira', 'SKILL.md'), 'dummy');
+    mkdirSync(join(claudeHome, 'skills', 'other-skill'), { recursive: true });
+    writeFileSync(join(claudeHome, 'skills', 'other-skill', 'SKILL.md'), 'keep me');
+
+    const settingsPath = join(claudeHome, 'settings.json');
+    writeFileSync(settingsPath, JSON.stringify({ statusLine: { type: 'command', command: 'npx lumira@latest' } }));
+
+    uninstall({ settingsPath, homeOverride: tmpHome });
+
+    expect(existsSync(join(claudeHome, 'skills', 'lumira'))).toBe(false);
+    expect(existsSync(join(claudeHome, 'skills', 'other-skill', 'SKILL.md'))).toBe(true);
+  });
 });

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -360,6 +360,16 @@ describe('cacheHitRate normalization', () => {
     const input = { ...claudeInput, context_window: { ...claudeInput.context_window, cache_read_input_tokens: 5000000, total_input_tokens: 957000 } };
     expect(normalize(input).cacheHitRate).toBeUndefined();
   });
+  it('returns 0 cacheHitRate when cache_read is 0 but denominator is positive (legit no cache hits this turn)', () => {
+    const input = {
+      ...claudeInput,
+      context_window: {
+        ...claudeInput.context_window,
+        current_usage: { input_tokens: 50000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+      },
+    };
+    expect(normalize(input).cacheHitRate).toBe(0);
+  });
   it('returns undefined cacheHitRate when current_usage has no per-turn token fields', () => {
     // current_usage present but only output_tokens — no fresh/read/creation → denominator = 0.
     const input = {


### PR DESCRIPTION
## Summary

Two outstanding items from the v0.9.0 codebase review that survived all earlier fix passes (#109/#110/#111/#113). Most of the original LOW/NITPICK bucket was already addressed in prior PRs — this is the tail.

## Changes

- **`normalize.ts`** — `cacheHitRate` now allows 0 as a legitimate value when the per-turn denominator is positive. Previously the gate `cached > 0` collapsed "no cache hits this turn" into the same undefined as "no data at all".
- **`installer.ts`** — uninstall now also attempts to remove the empty `skills/` parent directory after removing `skills/lumira/`. `rmdirSync` fails with ENOTEMPTY when other skills exist, so co-installed skills are preserved.

## Audit notes

Verified that the following review items were already fixed in earlier PRs and required no action:
- `--provenance` flag (already in release.yml)
- Theme name case-sensitivity (`resolveTheme` and `commands/themes.ts` both `toLowerCase()`)
- `ThinkingEffort` ↔ `VALID_EFFORT_LEVELS` sync
- `cache.ts` Windows `userInfo()` fallback
- `monokai.ts` shared-hex comment
- `displayWidth(out)` in render tests
- `text.ts` ANSI strip before truncate

## Test plan

- [x] 741 tests passing (added 3 new — 1 for cacheHitRate=0, 2 for installer parent-dir branches)