### PR TITLE
fix: subagent state from on-disk transcripts + line 1 cubes widget for running agents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,14 @@ jobs:
       - run: npm run test:coverage
       - run: npm run lint
       - run: npm run build
-      # Bundle size guard: dist/ ships to npm. Currently ~368 KB; the
-      # ceiling is set to 384 KB so meaningful growth is a deliberate
-      # decision rather than accidental. Raise alongside the corresponding
-      # PR if a feature genuinely needs the headroom.
+      # Bundle size guard: dist/ ships to npm. Currently ~404 KB after
+      # the subagents-dir reader + line 1 cubes widget; the ceiling is
+      # set to 440 KB so meaningful growth is a deliberate decision
+      # rather than accidental. Raise alongside the corresponding PR if
+      # a feature genuinely needs the headroom.
       - name: Bundle size guard
         env:
-          CEILING: '393216'
+          CEILING: '450560'
         run: |
           SIZE=$(du -sb dist/ | cut -f1)
           echo "dist/ size: $SIZE bytes (ceiling: $CEILING)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - run: npm run build
       - name: Bundle size guard
         env:
-          CEILING: '393216'
+          CEILING: '450560'
         run: |
           SIZE=$(du -sb dist/ | cut -f1)
           echo "dist/ size: $SIZE bytes (ceiling: $CEILING)"

--- a/src/parsers/subagents.ts
+++ b/src/parsers/subagents.ts
@@ -28,8 +28,9 @@ const MAX_AGENTS = 10;
 // Generic dispatch types Claude Code attaches to anonymous Agent calls. The
 // list is hard-coded today; extend it when Claude Code adds new generic
 // types so the statusline doesn't accidentally surface their names as if
-// they were user-named subagents.
-const GENERIC_AGENT_TYPES: ReadonlySet<string> = new Set(['general-purpose', 'unknown']);
+// they were user-named subagents. Exported so tests can assert membership
+// directly without re-encoding the values.
+export const GENERIC_AGENT_TYPES: ReadonlySet<string> = new Set(['general-purpose', 'unknown']);
 
 /**
  * Returns true when `type` identifies a *named* subagent — i.e. one defined
@@ -67,6 +68,19 @@ interface MetaSidecar {
   description?: unknown;
 }
 
+/**
+ * Per-file metadata captured by `scanSubagentsDir`. Phase 1 of the parse:
+ * a stat-only summary the cache uses for fingerprinting and that the full
+ * parse re-uses to avoid re-running readdir/stat on miss.
+ */
+export interface AgentCandidate {
+  id: string;
+  jsonlFile: string;
+  metaFile: string;
+  mtimeMs: number;
+  size: number;
+}
+
 export function deriveSubagentsDir(jsonlPath: string): string {
   const dir = dirname(jsonlPath);
   const base = basename(jsonlPath).replace(/\.jsonl$/i, '');
@@ -75,9 +89,13 @@ export function deriveSubagentsDir(jsonlPath: string): string {
 
 /**
  * Cheap filesystem fingerprint of a session's subagents dir, suitable for
- * folding into a transcript-level cache key. Returns the directory mtime plus
- * the count and aggregate mtime/size of agent JSONL files inside. A change to
- * any agent file flips at least one of these values.
+ * folding into a transcript-level cache key. Captures (a) the number of
+ * matching agent files, (b) the most recent file mtime in the dir, and
+ * (c) the aggregate file size. A change to any agent file flips at least
+ * one of these — `maxMtimeMs` is monotonic across writes (every new write
+ * either bumps mtime or leaves it unchanged on the same-second case where
+ * the size delta still fires), and `totalSize` catches in-place edits that
+ * happen at exactly the same mtime tick.
  *
  * Intentionally O(N) on dir size: the dir is small (≤ MAX_AGENTS handful)
  * and `stat` is fast. Returns null when the dir doesn't exist or isn't
@@ -86,40 +104,68 @@ export function deriveSubagentsDir(jsonlPath: string): string {
  */
 export interface SubagentsDirState {
   count: number;
-  totalMtimeMs: number;
+  maxMtimeMs: number;
   totalSize: number;
 }
 
-export async function getSubagentsDirState(jsonlPath: string): Promise<SubagentsDirState | null> {
-  if (!jsonlPath) return null;
+/**
+ * Unified scan: walks the subagents/ dir once, gathering both the cache
+ * fingerprint AND the per-file stat metadata needed for the full parse.
+ * Callers that only need the fingerprint can ignore `candidates`; callers
+ * doing a full parse can hand the candidates to `readSubagentDetails`
+ * without re-running readdir/stat.
+ */
+export async function scanSubagentsDir(jsonlPath: string): Promise<{ state: SubagentsDirState | null; candidates: AgentCandidate[] }> {
+  if (!jsonlPath) return { state: null, candidates: [] };
   const dir = deriveSubagentsDir(jsonlPath);
-  if (!isUnderAllowedRoot(resolve(dir), LUMIRA_ALLOWED_ROOTS)) return null;
+  const resolved = resolve(dir);
+  if (!isUnderAllowedRoot(resolved, LUMIRA_ALLOWED_ROOTS)) {
+    log('skip — subagents dir outside allowed roots:', resolved);
+    return { state: null, candidates: [] };
+  }
   let entries: string[];
   try {
-    entries = await readdir(dir);
-  } catch {
-    return null;
+    entries = await readdir(resolved);
+  } catch (err) {
+    log('readdir failed:', resolved, err);
+    return { state: null, candidates: [] };
   }
   let count = 0;
-  let totalMtimeMs = 0;
+  let maxMtimeMs = 0;
   let totalSize = 0;
+  const candidates: AgentCandidate[] = [];
   for (const file of entries) {
-    if (!AGENT_FILE_RE.test(file)) continue;
+    const m = file.match(AGENT_FILE_RE);
+    if (!m) continue;
     try {
-      const st = await stat(join(dir, file));
+      const jsonlFile = join(resolved, file);
+      const st = await stat(jsonlFile);
       if (!st.isFile()) continue;
       count += 1;
-      totalMtimeMs += st.mtimeMs;
+      if (st.mtimeMs > maxMtimeMs) maxMtimeMs = st.mtimeMs;
       totalSize += st.size;
+      candidates.push({
+        id: m[1],
+        jsonlFile,
+        metaFile: join(resolved, `agent-${m[1]}.meta.json`),
+        mtimeMs: st.mtimeMs,
+        size: st.size,
+      });
     } catch { /* file disappeared mid-scan — skip */ }
   }
-  return { count, totalMtimeMs, totalSize };
+  return { state: { count, maxMtimeMs, totalSize }, candidates };
+}
+
+// Thin wrapper retained for callers that only want the cache fingerprint.
+// Internally re-uses `scanSubagentsDir` so the two paths can never drift.
+export async function getSubagentsDirState(jsonlPath: string): Promise<SubagentsDirState | null> {
+  return (await scanSubagentsDir(jsonlPath)).state;
 }
 
 export function subagentsDirStateEqual(a: SubagentsDirState | null, b: SubagentsDirState | null): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
-  return a.count === b.count && a.totalMtimeMs === b.totalMtimeMs && a.totalSize === b.totalSize;
+  return a.count === b.count && a.maxMtimeMs === b.maxMtimeMs && a.totalSize === b.totalSize;
 }
 
 async function readMeta(metaPath: string): Promise<MetaSidecar | null> {
@@ -131,17 +177,33 @@ async function readMeta(metaPath: string): Promise<MetaSidecar | null> {
   return null;
 }
 
-async function readLastJsonLine(filePath: string): Promise<unknown> {
+interface JsonlBoundaryLines {
+  first: unknown | null;
+  last: unknown | null;
+}
+
+// One pass over the file extracts both the first and last well-formed JSON
+// objects. We need the first line's timestamp for `startTime` (file mtime
+// drifts to the *last* write) and the last line for completion markers.
+async function readBoundaryJsonLines(filePath: string): Promise<JsonlBoundaryLines> {
   try {
     const raw = await readFile(filePath, 'utf8');
     const lines = raw.split('\n');
-    for (let i = lines.length - 1; i >= 0; i--) {
-      const line = lines[i].trim();
-      if (!line) continue;
-      try { return JSON.parse(line); } catch { /* try previous line */ }
+    let first: unknown | null = null;
+    for (const l of lines) {
+      const t = l.trim();
+      if (!t) continue;
+      try { first = JSON.parse(t); break; } catch { /* try next line */ }
     }
+    let last: unknown | null = null;
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const t = lines[i].trim();
+      if (!t) continue;
+      try { last = JSON.parse(t); break; } catch { /* try previous line */ }
+    }
+    return { first, last };
   } catch { /* unreadable */ }
-  return null;
+  return { first: null, last: null };
 }
 
 function extractStopReason(lastLine: unknown): string | null {
@@ -164,9 +226,14 @@ function extractTimestamp(lastLine: unknown): Date | null {
 }
 
 // When the user stops a running subagent, Claude Code appends a synthetic
-// user-role message whose text marker is "[Request interrupted by user…]".
-// That's the only on-disk signal of a kill — the assistant message that
-// preceded it never gets its closing stop_reason rewritten.
+// user-role message whose text is bracket-wrapped, e.g.
+// "[Request interrupted by user for tool use]". That's the only on-disk
+// signal of a kill — the assistant message that preceded it never gets its
+// closing stop_reason rewritten. Matching is anchored on both ends to avoid
+// false positives if Claude Code ever ships an unrelated message that
+// starts with the same prefix.
+const INTERRUPT_MARKER_RE = /^\[Request interrupted by user[^\]]*\]$/;
+
 function wasInterruptedByUser(lastLine: unknown): boolean {
   if (!lastLine || typeof lastLine !== 'object') return false;
   const d = lastLine as { type?: unknown; message?: { role?: unknown; content?: unknown } };
@@ -176,28 +243,16 @@ function wasInterruptedByUser(lastLine: unknown): boolean {
   for (const block of content) {
     if (block && typeof block === 'object') {
       const text = (block as { text?: unknown }).text;
-      if (typeof text === 'string' && text.startsWith('[Request interrupted by user')) return true;
+      if (typeof text === 'string' && INTERRUPT_MARKER_RE.test(text.trim())) return true;
     }
   }
   return false;
 }
 
-// Phase 1 entry: stat-only metadata for ranking. Phase 2 (`readAgentDetails`)
-// reads JSONL + meta only for files that survive the MAX_AGENTS slice — this
-// avoids opening the entire dir on every statusline tick when a session has
-// accumulated dozens of historical agent files.
-interface AgentCandidate {
-  id: string;
-  jsonlFile: string;
-  metaFile: string;
-  mtimeMs: number;
-  size: number;
-}
-
 async function readAgentDetails(c: AgentCandidate): Promise<AgentEntry | null> {
-  const lastLine = await readLastJsonLine(c.jsonlFile);
-  const stopReason = extractStopReason(lastLine);
-  const interrupted = wasInterruptedByUser(lastLine);
+  const { first, last } = await readBoundaryJsonLines(c.jsonlFile);
+  const stopReason = extractStopReason(last);
+  const interrupted = wasInterruptedByUser(last);
 
   const meta = await readMeta(c.metaFile);
   const agentType = sanitizeTermString(typeof meta?.agentType === 'string' ? meta.agentType : 'unknown');
@@ -205,76 +260,58 @@ async function readAgentDetails(c: AgentCandidate): Promise<AgentEntry | null> {
 
   const status: ToolStatus = (stopReason === 'end_turn' || interrupted) ? 'completed' : 'running';
 
-  // birthtimeMs is unreliable across filesystems (often 0/unset, can't be
-  // updated by tests via utimes). Fall back to mtimeMs whenever it's missing.
-  const startTimeMs = c.mtimeMs;
+  // startTime: prefer the first JSONL line's embedded ISO timestamp (the
+  // dispatch moment) over the file mtime. mtime tracks the *last* write,
+  // which for a long-running agent is the close-out — using it as
+  // startTime would make duration calculations meaningless. birthtimeMs
+  // is unreliable across filesystems (often 0/unset, can't be updated by
+  // utimes() so tests can't simulate it), hence we don't try it.
+  const startTime = extractTimestamp(first) ?? new Date(c.mtimeMs);
   const agent: AgentEntry = {
     id: c.id,
     type: agentType,
     status,
-    startTime: new Date(startTimeMs),
+    startTime,
   };
   if (description) agent.description = description;
   if (status === 'completed') {
-    const tsFromLine = extractTimestamp(lastLine);
+    const tsFromLine = extractTimestamp(last);
     agent.endTime = tsFromLine ?? new Date(c.mtimeMs);
   }
   return agent;
 }
 
-export async function parseSubagentsDir(jsonlPath: string): Promise<AgentEntry[]> {
-  if (!jsonlPath) return [];
-  const subagentsDir = deriveSubagentsDir(jsonlPath);
-  const resolved = resolve(subagentsDir);
-  if (!isUnderAllowedRoot(resolved, LUMIRA_ALLOWED_ROOTS)) {
-    log('skip — subagents dir outside allowed roots:', resolved);
-    return [];
-  }
-
-  // No `existsSync` guard: the readdir below already returns ENOENT on a
-  // missing dir, and skipping the sync stat removes the TOCTOU window where
-  // the dir could be deleted between check and use.
-  let entries: string[];
-  try {
-    entries = await readdir(resolved);
-  } catch (err) {
-    log('readdir failed:', resolved, err);
-    return [];
-  }
-
-  // Phase 1 — stat all candidate files. `stat` is cheap; reading the JSONL
-  // bodies is what we want to keep bounded.
-  const candidates: AgentCandidate[] = [];
-  for (const file of entries) {
-    const m = file.match(AGENT_FILE_RE);
-    if (!m) continue;
-    const id = m[1];
-    const jsonlFile = join(resolved, file);
-    try {
-      const st = await stat(jsonlFile);
-      if (!st.isFile()) continue;
-      candidates.push({
-        id,
-        jsonlFile,
-        metaFile: join(resolved, `agent-${id}.meta.json`),
-        mtimeMs: st.mtimeMs,
-        size: st.size,
-      });
-    } catch { /* race with deletion — skip */ }
-  }
-
-  // Sort oldest → newest by file mtime, then keep only the most recent
-  // MAX_AGENTS. mtime is the on-disk last-write timestamp, not the
-  // subagent's logical "last activity" — those are usually the same but can
-  // drift when the OS journal flushes well after the write.
-  candidates.sort((a, b) => a.mtimeMs - b.mtimeMs);
-  const top = candidates.slice(-MAX_AGENTS);
-
-  // Phase 2 — read JSONL bodies + meta sidecars only for the survivors.
+/**
+ * Phase 2 of the parse — reads JSONL bodies + meta sidecars only for the
+ * MAX_AGENTS most recent files in `candidates`. Sorts oldest → newest by
+ * file mtime; the survivors of `slice(-MAX_AGENTS)` are read.
+ *
+ * `mtime` is the on-disk last-write timestamp, not the subagent's logical
+ * "last activity" — those are usually the same but can drift when the OS
+ * journal flushes well after the write.
+ *
+ * Exported so callers that already ran `scanSubagentsDir` (e.g. the
+ * transcript parser, which uses the same scan to build its cache key) can
+ * skip a second readdir+stat pass.
+ */
+export async function readSubagentDetails(candidates: AgentCandidate[]): Promise<AgentEntry[]> {
+  const sorted = candidates.slice().sort((a, b) => a.mtimeMs - b.mtimeMs);
+  const top = sorted.slice(-MAX_AGENTS);
   const agents: AgentEntry[] = [];
   for (const c of top) {
     const a = await readAgentDetails(c);
     if (a) agents.push(a);
   }
   return agents;
+}
+
+/**
+ * Convenience wrapper: full scan + full parse. Equivalent to
+ * `(await scanSubagentsDir(p)).candidates → readSubagentDetails`.
+ * Callers that need the cache fingerprint *and* the agents in the same
+ * tick should call `scanSubagentsDir` directly to avoid a second scan.
+ */
+export async function parseSubagentsDir(jsonlPath: string): Promise<AgentEntry[]> {
+  const { candidates } = await scanSubagentsDir(jsonlPath);
+  return readSubagentDetails(candidates);
 }

--- a/src/parsers/subagents.ts
+++ b/src/parsers/subagents.ts
@@ -224,10 +224,24 @@ async function readBoundaryJsonLines(filePath: string, fileSize: number): Promis
     await fd.read(tailBuf, 0, tailSize, fileSize - tailSize);
     const tail = tailBuf.toString('utf8');
 
-    // The tail chunk likely starts mid-line (we sliced at a byte offset).
-    // Drop the first partial line so JSON.parse doesn't choke on it.
+    // The tail window starts at an arbitrary byte offset; if that byte
+    // happens to be inside a JSON line, the leading fragment is malformed
+    // and we discard everything up to the first newline. If the offset
+    // lands cleanly on a line boundary the slice still drops only the
+    // single leading newline byte (harmless), so the same logic covers
+    // both cases without an extra branch.
     const tailFromBoundary = tail.includes('\n') ? tail.slice(tail.indexOf('\n') + 1) : tail;
-    return { first: parseFirstJson(head), last: parseLastJson(tailFromBoundary) };
+    const first = parseFirstJson(head);
+    const last = parseLastJson(tailFromBoundary);
+    if (log.enabled) {
+      // When a single first/last line exceeds the boundary chunk size,
+      // JSON.parse fails silently and we fall back to mtime / "running".
+      // Surface that in debug logs so users tracking down a stuck agent
+      // can spot it.
+      if (first === null) log('warn — first-line parse missed (likely >', BOUNDARY_CHUNK_SIZE, 'bytes):', filePath);
+      if (last === null) log('warn — last-line parse missed (likely >', BOUNDARY_CHUNK_SIZE, 'bytes):', filePath);
+    }
+    return { first, last };
   } catch { return { first: null, last: null }; }
   finally { await fd.close().catch(() => undefined); }
 }

--- a/src/parsers/subagents.ts
+++ b/src/parsers/subagents.ts
@@ -3,7 +3,7 @@
 // `utils/path.ts`. We do not gate any I/O behind `existsSync` here — the
 // async readdir/stat calls have try/catch fallbacks, which avoids the
 // existsSync→readdir TOCTOU window.
-import { readdir, readFile, stat } from 'node:fs/promises';
+import { open, readdir, readFile, stat } from 'node:fs/promises';
 import { join, dirname, basename, resolve } from 'node:path';
 import type { AgentEntry, ToolStatus } from '../types.js';
 import { isUnderAllowedRoot, LUMIRA_ALLOWED_ROOTS } from '../utils/path.js';
@@ -115,10 +115,14 @@ export interface SubagentsDirState {
  * doing a full parse can hand the candidates to `readSubagentDetails`
  * without re-running readdir/stat.
  */
-export async function scanSubagentsDir(jsonlPath: string): Promise<{ state: SubagentsDirState | null; candidates: AgentCandidate[] }> {
-  if (!jsonlPath) return { state: null, candidates: [] };
-  const dir = deriveSubagentsDir(jsonlPath);
-  const resolved = resolve(dir);
+export async function scanSubagentsDir(rawJsonlPath: string): Promise<{ state: SubagentsDirState | null; candidates: AgentCandidate[] }> {
+  if (!rawJsonlPath) return { state: null, candidates: [] };
+  // Canonicalise the input path here so public callers (relative paths,
+  // `..` segments) and internal callers (`transcript.ts` already passes a
+  // resolved absolute path) get identical results. `deriveSubagentsDir`
+  // remains a pure string operation; this is the single point of resolution.
+  const jsonlPath = resolve(rawJsonlPath);
+  const resolved = deriveSubagentsDir(jsonlPath);
   if (!isUnderAllowedRoot(resolved, LUMIRA_ALLOWED_ROOTS)) {
     log('skip — subagents dir outside allowed roots:', resolved);
     return { state: null, candidates: [] };
@@ -182,28 +186,69 @@ interface JsonlBoundaryLines {
   last: unknown | null;
 }
 
-// One pass over the file extracts both the first and last well-formed JSON
-// objects. We need the first line's timestamp for `startTime` (file mtime
+// Files larger than this threshold are read via head/tail chunks rather
+// than slurped whole. Subagent transcripts can grow into the megabytes
+// when the agent runs many tool calls — buffering all of them on every
+// cache miss caused real memory pressure in the wild.
+const LARGE_FILE_THRESHOLD = 64 * 1024;
+// Window we read at each end of a large file. 16 KB is comfortably bigger
+// than any single JSONL line we've observed (Claude Code wraps very long
+// content), and small enough to keep a 10-agent miss under 320 KB peak.
+const BOUNDARY_CHUNK_SIZE = 16 * 1024;
+
+// Extracts both the first and last well-formed JSON objects from a JSONL
+// file. We need the first line's timestamp for `startTime` (file mtime
 // drifts to the *last* write) and the last line for completion markers.
-async function readBoundaryJsonLines(filePath: string): Promise<JsonlBoundaryLines> {
+//
+// For files at or below `LARGE_FILE_THRESHOLD` we slurp via `readFile`
+// (one syscall, no chunking). For larger files we open the fd and read
+// only the head and tail windows — bounding peak memory regardless of
+// transcript size.
+async function readBoundaryJsonLines(filePath: string, fileSize: number): Promise<JsonlBoundaryLines> {
+  if (fileSize <= LARGE_FILE_THRESHOLD) {
+    try {
+      const raw = await readFile(filePath, 'utf8');
+      return { first: parseFirstJson(raw), last: parseLastJson(raw) };
+    } catch { return { first: null, last: null }; }
+  }
+  let fd;
+  try { fd = await open(filePath, 'r'); } catch { return { first: null, last: null }; }
   try {
-    const raw = await readFile(filePath, 'utf8');
-    const lines = raw.split('\n');
-    let first: unknown | null = null;
-    for (const l of lines) {
-      const t = l.trim();
-      if (!t) continue;
-      try { first = JSON.parse(t); break; } catch { /* try next line */ }
-    }
-    let last: unknown | null = null;
-    for (let i = lines.length - 1; i >= 0; i--) {
-      const t = lines[i].trim();
-      if (!t) continue;
-      try { last = JSON.parse(t); break; } catch { /* try previous line */ }
-    }
-    return { first, last };
-  } catch { /* unreadable */ }
-  return { first: null, last: null };
+    const headSize = Math.min(BOUNDARY_CHUNK_SIZE, fileSize);
+    const headBuf = Buffer.alloc(headSize);
+    await fd.read(headBuf, 0, headSize, 0);
+    const head = headBuf.toString('utf8');
+
+    const tailSize = Math.min(BOUNDARY_CHUNK_SIZE, fileSize);
+    const tailBuf = Buffer.alloc(tailSize);
+    await fd.read(tailBuf, 0, tailSize, fileSize - tailSize);
+    const tail = tailBuf.toString('utf8');
+
+    // The tail chunk likely starts mid-line (we sliced at a byte offset).
+    // Drop the first partial line so JSON.parse doesn't choke on it.
+    const tailFromBoundary = tail.includes('\n') ? tail.slice(tail.indexOf('\n') + 1) : tail;
+    return { first: parseFirstJson(head), last: parseLastJson(tailFromBoundary) };
+  } catch { return { first: null, last: null }; }
+  finally { await fd.close().catch(() => undefined); }
+}
+
+function parseFirstJson(raw: string): unknown | null {
+  for (const l of raw.split('\n')) {
+    const t = l.trim();
+    if (!t) continue;
+    try { return JSON.parse(t); } catch { /* try next line */ }
+  }
+  return null;
+}
+
+function parseLastJson(raw: string): unknown | null {
+  const lines = raw.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const t = lines[i].trim();
+    if (!t) continue;
+    try { return JSON.parse(t); } catch { /* try previous line */ }
+  }
+  return null;
 }
 
 function extractStopReason(lastLine: unknown): string | null {
@@ -232,7 +277,9 @@ function extractTimestamp(lastLine: unknown): Date | null {
 // closing stop_reason rewritten. Matching is anchored on both ends to avoid
 // false positives if Claude Code ever ships an unrelated message that
 // starts with the same prefix.
-const INTERRUPT_MARKER_RE = /^\[Request interrupted by user[^\]]*\]$/;
+// `[^[]*` rather than `[^\]]*` so a hypothetical future variant whose
+// reason text contains a `]` (but no `[`) would still match.
+const INTERRUPT_MARKER_RE = /^\[Request interrupted by user[^[]*\]$/;
 
 function wasInterruptedByUser(lastLine: unknown): boolean {
   if (!lastLine || typeof lastLine !== 'object') return false;
@@ -249,8 +296,8 @@ function wasInterruptedByUser(lastLine: unknown): boolean {
   return false;
 }
 
-async function readAgentDetails(c: AgentCandidate): Promise<AgentEntry | null> {
-  const { first, last } = await readBoundaryJsonLines(c.jsonlFile);
+async function readAgentDetails(c: AgentCandidate): Promise<AgentEntry> {
+  const { first, last } = await readBoundaryJsonLines(c.jsonlFile, c.size);
   const stopReason = extractStopReason(last);
   const interrupted = wasInterruptedByUser(last);
 
@@ -286,9 +333,15 @@ async function readAgentDetails(c: AgentCandidate): Promise<AgentEntry | null> {
  * MAX_AGENTS most recent files in `candidates`. Sorts oldest → newest by
  * file mtime; the survivors of `slice(-MAX_AGENTS)` are read.
  *
- * `mtime` is the on-disk last-write timestamp, not the subagent's logical
- * "last activity" — those are usually the same but can drift when the OS
- * journal flushes well after the write.
+ * `mtime` is the on-disk last-write timestamp, not the agent's logical
+ * "last activity". The two usually coincide, but on a slow filesystem an
+ * agent dispatched recently may have a stale mtime (its first write
+ * hasn't been journaled yet) while an older agent's file gets touched by
+ * an unrelated journal flush. The downstream `startTime` is read from
+ * the JSONL line's embedded `timestamp` field — so the sort order may
+ * not match `startTime` order exactly. Acceptable for the statusline's
+ * "newest N" picker; flagged here so a future caller doesn't assume the
+ * two orderings are identical.
  *
  * Exported so callers that already ran `scanSubagentsDir` (e.g. the
  * transcript parser, which uses the same scan to build its cache key) can
@@ -299,8 +352,7 @@ export async function readSubagentDetails(candidates: AgentCandidate[]): Promise
   const top = sorted.slice(-MAX_AGENTS);
   const agents: AgentEntry[] = [];
   for (const c of top) {
-    const a = await readAgentDetails(c);
-    if (a) agents.push(a);
+    agents.push(await readAgentDetails(c));
   }
   return agents;
 }

--- a/src/parsers/subagents.ts
+++ b/src/parsers/subagents.ts
@@ -28,8 +28,9 @@ const MAX_AGENTS = 10;
 // Generic dispatch types Claude Code attaches to anonymous Agent calls. The
 // list is hard-coded today; extend it when Claude Code adds new generic
 // types so the statusline doesn't accidentally surface their names as if
-// they were user-named subagents. Exported so tests can assert membership
-// directly without re-encoding the values.
+// they were user-named subagents. Exported as part of the public API;
+// callers should prefer `isNamedAgentType` for membership checks rather
+// than reaching into the set directly.
 export const GENERIC_AGENT_TYPES: ReadonlySet<string> = new Set(['general-purpose', 'unknown']);
 
 /**
@@ -214,14 +215,16 @@ async function readBoundaryJsonLines(filePath: string, fileSize: number): Promis
   let fd;
   try { fd = await open(filePath, 'r'); } catch { return { first: null, last: null }; }
   try {
-    const headSize = Math.min(BOUNDARY_CHUNK_SIZE, fileSize);
-    const headBuf = Buffer.alloc(headSize);
-    await fd.read(headBuf, 0, headSize, 0);
+    // We're on the chunked path, so fileSize > LARGE_FILE_THRESHOLD >
+    // BOUNDARY_CHUNK_SIZE — head and tail windows are always exactly
+    // BOUNDARY_CHUNK_SIZE bytes, never clamped by file size.
+    const chunkSize = BOUNDARY_CHUNK_SIZE;
+    const headBuf = Buffer.alloc(chunkSize);
+    await fd.read(headBuf, 0, chunkSize, 0);
     const head = headBuf.toString('utf8');
 
-    const tailSize = Math.min(BOUNDARY_CHUNK_SIZE, fileSize);
-    const tailBuf = Buffer.alloc(tailSize);
-    await fd.read(tailBuf, 0, tailSize, fileSize - tailSize);
+    const tailBuf = Buffer.alloc(chunkSize);
+    await fd.read(tailBuf, 0, chunkSize, fileSize - chunkSize);
     const tail = tailBuf.toString('utf8');
 
     // The tail window starts at an arbitrary byte offset; if that byte
@@ -234,12 +237,13 @@ async function readBoundaryJsonLines(filePath: string, fileSize: number): Promis
     const first = parseFirstJson(head);
     const last = parseLastJson(tailFromBoundary);
     if (log.enabled) {
-      // When a single first/last line exceeds the boundary chunk size,
-      // JSON.parse fails silently and we fall back to mtime / "running".
-      // Surface that in debug logs so users tracking down a stuck agent
-      // can spot it.
-      if (first === null) log('warn — first-line parse missed (likely >', BOUNDARY_CHUNK_SIZE, 'bytes):', filePath);
-      if (last === null) log('warn — last-line parse missed (likely >', BOUNDARY_CHUNK_SIZE, 'bytes):', filePath);
+      // When a single first/last line is bigger than the chunk window,
+      // JSON.parse fails on every fragment we see and we fall back to
+      // mtime / "running". A fully corrupt file produces the same
+      // signal — the suffix "(no valid JSON in head/tail window)"
+      // covers both interpretations without overcommitting to either.
+      if (first === null) log('warn — first-line parse missed (no valid JSON in head window):', filePath);
+      if (last === null) log('warn — last-line parse missed (no valid JSON in tail window):', filePath);
     }
     return { first, last };
   } catch { return { first: null, last: null }; }

--- a/src/parsers/subagents.ts
+++ b/src/parsers/subagents.ts
@@ -1,0 +1,139 @@
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { existsSync, realpathSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join, dirname, basename, resolve } from 'node:path';
+import type { AgentEntry, ToolStatus } from '../types.js';
+import { isUnderAllowedRoot } from '../utils/path.js';
+import { sanitizeTermString } from '../normalize.js';
+import { debug } from '../utils/debug.js';
+
+const log = debug('subagents');
+
+// Claude Code stores per-subagent transcripts at
+//   ~/.claude/projects/<slug>/<session-id>/subagents/agent-<id>.jsonl
+// alongside an agent-<id>.meta.json sidecar carrying {agentType, description}.
+// This is an undocumented implementation detail of Claude Code (verified against
+// 2.1.x). When the layout changes, this module degrades to an empty result and
+// the main-JSONL parser remains the source of truth.
+const AGENT_FILE_RE = /^agent-([A-Za-z0-9_-]+)\.jsonl$/;
+
+// Subagent JSONLs without `stop_reason: "end_turn"` AND without disk activity
+// for this many seconds are treated as completed (likely crashed/aborted).
+// Prevents indefinite "running" indicators when an agent dies without writing
+// its closing line.
+export const STALE_GRACE_SECONDS = 60;
+
+function realpathSafe(p: string): string {
+  try { return realpathSync(p); } catch { return resolve(p); }
+}
+const ALLOWED_ROOTS: readonly string[] = [
+  ...new Set([resolve(homedir()), resolve(tmpdir()), realpathSafe(homedir()), realpathSafe(tmpdir())]),
+];
+
+export function deriveSubagentsDir(jsonlPath: string): string {
+  const dir = dirname(jsonlPath);
+  const base = basename(jsonlPath).replace(/\.jsonl$/i, '');
+  return join(dir, base, 'subagents');
+}
+
+interface MetaSidecar {
+  agentType?: string;
+  description?: string;
+}
+
+async function readMeta(metaPath: string): Promise<MetaSidecar | null> {
+  try {
+    const raw = await readFile(metaPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') return parsed as MetaSidecar;
+  } catch { /* meta is best-effort */ }
+  return null;
+}
+
+async function readLastJsonLine(filePath: string): Promise<unknown | null> {
+  try {
+    const raw = await readFile(filePath, 'utf8');
+    const lines = raw.split('\n');
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i].trim();
+      if (!line) continue;
+      try { return JSON.parse(line); } catch { /* try previous line */ }
+    }
+  } catch { /* unreadable */ }
+  return null;
+}
+
+function extractStopReason(lastLine: unknown): string | null {
+  if (!lastLine || typeof lastLine !== 'object') return null;
+  const msg = (lastLine as { message?: unknown }).message;
+  if (!msg || typeof msg !== 'object') return null;
+  const sr = (msg as { stop_reason?: unknown }).stop_reason;
+  return typeof sr === 'string' ? sr : null;
+}
+
+export async function parseSubagentsDir(jsonlPath: string, now: number = Date.now()): Promise<AgentEntry[]> {
+  if (!jsonlPath) return [];
+  const subagentsDir = deriveSubagentsDir(jsonlPath);
+  if (!existsSync(subagentsDir)) return [];
+  const resolved = resolve(subagentsDir);
+  if (!isUnderAllowedRoot(resolved, ALLOWED_ROOTS)) {
+    log('skip — subagents dir outside allowed roots:', resolved);
+    return [];
+  }
+
+  let entries: string[];
+  try {
+    entries = await readdir(resolved);
+  } catch (err) {
+    log('readdir failed:', resolved, err);
+    return [];
+  }
+
+  const collected: { agent: AgentEntry; mtimeMs: number }[] = [];
+  for (const file of entries) {
+    const m = file.match(AGENT_FILE_RE);
+    if (!m) continue;
+    const id = m[1];
+    const jsonlFile = join(resolved, file);
+
+    let st;
+    try { st = await stat(jsonlFile); } catch { continue; }
+    if (!st.isFile()) continue;
+
+    const lastLine = await readLastJsonLine(jsonlFile);
+    const stopReason = extractStopReason(lastLine);
+
+    const meta = await readMeta(join(resolved, `agent-${id}.meta.json`));
+    const agentType = sanitizeTermString(meta?.agentType ?? 'unknown');
+    const description = typeof meta?.description === 'string' ? sanitizeTermString(meta.description) : undefined;
+
+    const ageMs = now - st.mtimeMs;
+    const isStale = ageMs > STALE_GRACE_SECONDS * 1000;
+    let status: ToolStatus;
+    if (stopReason === 'end_turn') status = 'completed';
+    else if (isStale) status = 'completed';
+    else status = 'running';
+
+    const startTimeMs = (st.birthtimeMs && st.birthtimeMs > 0) ? st.birthtimeMs : st.mtimeMs;
+    const agent: AgentEntry = {
+      id,
+      type: agentType,
+      status,
+      startTime: new Date(startTimeMs),
+    };
+    if (description) agent.description = description;
+    if (status === 'completed') agent.endTime = new Date(st.mtimeMs);
+    collected.push({ agent, mtimeMs: st.mtimeMs });
+  }
+
+  // Sort oldest → newest by last-activity so the most recent N survive the
+  // cap below. We use mtime rather than birthtime because birthtime is
+  // unreliable across filesystems (often unset, can't be updated by tests).
+  collected.sort((a, b) => a.mtimeMs - b.mtimeMs);
+  return collected.slice(-MAX_AGENTS).map(c => c.agent);
+}
+
+// Long-running sessions accumulate dozens of agent files; the statusline only
+// surfaces a handful. Match the cap used by the main JSONL agent slice (in
+// transcript.ts: `agentMap.values()).slice(-10)`).
+const MAX_AGENTS = 10;

--- a/src/parsers/subagents.ts
+++ b/src/parsers/subagents.ts
@@ -1,9 +1,12 @@
+// Mixed sync/async fs imports are deliberate: `stat` and `readFile` are async
+// I/O on the hot path; the only sync call is the canonicalisation helper from
+// `utils/path.ts`. We do not gate any I/O behind `existsSync` here — the
+// async readdir/stat calls have try/catch fallbacks, which avoids the
+// existsSync→readdir TOCTOU window.
 import { readdir, readFile, stat } from 'node:fs/promises';
-import { existsSync, realpathSync } from 'node:fs';
-import { homedir, tmpdir } from 'node:os';
 import { join, dirname, basename, resolve } from 'node:path';
 import type { AgentEntry, ToolStatus } from '../types.js';
-import { isUnderAllowedRoot } from '../utils/path.js';
+import { isUnderAllowedRoot, LUMIRA_ALLOWED_ROOTS } from '../utils/path.js';
 import { sanitizeTermString } from '../normalize.js';
 import { debug } from '../utils/debug.js';
 
@@ -12,10 +15,31 @@ const log = debug('subagents');
 // Claude Code stores per-subagent transcripts at
 //   ~/.claude/projects/<slug>/<session-id>/subagents/agent-<id>.jsonl
 // alongside an agent-<id>.meta.json sidecar carrying {agentType, description}.
-// This is an undocumented implementation detail of Claude Code (verified against
-// 2.1.x). When the layout changes, this module degrades to an empty result and
-// the main-JSONL parser remains the source of truth.
+// This is an undocumented implementation detail of Claude Code (verified
+// against 2.1.x). When the layout changes, this module degrades to an empty
+// result and the main-JSONL parser remains the source of truth.
 const AGENT_FILE_RE = /^agent-([A-Za-z0-9_-]+)\.jsonl$/;
+
+// Long-running sessions accumulate dozens of agent files; the statusline only
+// surfaces a handful. Match the cap used by the main-JSONL agent slice (in
+// `transcript.ts: agentMap.values()).slice(-10)`).
+const MAX_AGENTS = 10;
+
+// Generic dispatch types Claude Code attaches to anonymous Agent calls. The
+// list is hard-coded today; extend it when Claude Code adds new generic
+// types so the statusline doesn't accidentally surface their names as if
+// they were user-named subagents.
+const GENERIC_AGENT_TYPES: ReadonlySet<string> = new Set(['general-purpose', 'unknown']);
+
+/**
+ * Returns true when `type` identifies a *named* subagent — i.e. one defined
+ * by the user (e.g. `pepito`, `feature-dev:code-reviewer`) rather than an
+ * anonymous dispatch via the generic Agent tool. Render layers use this to
+ * decide whether to surface the type in the cubes-icon widget.
+ */
+export function isNamedAgentType(type: string | undefined | null): boolean {
+  return typeof type === 'string' && type.length > 0 && !GENERIC_AGENT_TYPES.has(type);
+}
 
 // Only `stop_reason: "end_turn"` definitively marks a subagent as finished.
 // Other terminal markers like `tool_use` are emitted whenever the subagent
@@ -26,12 +50,22 @@ const AGENT_FILE_RE = /^agent-([A-Za-z0-9_-]+)\.jsonl$/;
 // linger as "running" until the session closes. That's rare; false negatives
 // on long-tool agents were the more common bug.
 
-function realpathSafe(p: string): string {
-  try { return realpathSync(p); } catch { return resolve(p); }
+// SECURITY: like `transcript.ts`, this module performs *string-level*
+// allow-list checks via `isUnderAllowedRoot`. Symlinks are not followed at
+// check time. A symlinked subagents dir whose target lies outside the
+// allow-list is treated as legal as long as its own path string sits under a
+// permitted root. The threat is bounded because (a) the path is derived
+// mechanically from the parent JSONL path which `transcript.ts` already
+// validated, and (b) Claude Code itself owns the layout. Callers protecting
+// against symlink traversal should pre-canonicalise via `realpathSafe`.
+
+// Internal type — shape of the agent-<id>.meta.json sidecar Claude Code writes.
+// All fields are validated at use site since the file is parsed via
+// `JSON.parse` and the cast is unchecked.
+interface MetaSidecar {
+  agentType?: unknown;
+  description?: unknown;
 }
-const ALLOWED_ROOTS: readonly string[] = [
-  ...new Set([resolve(homedir()), resolve(tmpdir()), realpathSafe(homedir()), realpathSafe(tmpdir())]),
-];
 
 export function deriveSubagentsDir(jsonlPath: string): string {
   const dir = dirname(jsonlPath);
@@ -39,9 +73,53 @@ export function deriveSubagentsDir(jsonlPath: string): string {
   return join(dir, base, 'subagents');
 }
 
-interface MetaSidecar {
-  agentType?: string;
-  description?: string;
+/**
+ * Cheap filesystem fingerprint of a session's subagents dir, suitable for
+ * folding into a transcript-level cache key. Returns the directory mtime plus
+ * the count and aggregate mtime/size of agent JSONL files inside. A change to
+ * any agent file flips at least one of these values.
+ *
+ * Intentionally O(N) on dir size: the dir is small (≤ MAX_AGENTS handful)
+ * and `stat` is fast. Returns null when the dir doesn't exist or isn't
+ * accessible — the caller should treat that as "no fingerprint, no cached
+ * subagent state".
+ */
+export interface SubagentsDirState {
+  count: number;
+  totalMtimeMs: number;
+  totalSize: number;
+}
+
+export async function getSubagentsDirState(jsonlPath: string): Promise<SubagentsDirState | null> {
+  if (!jsonlPath) return null;
+  const dir = deriveSubagentsDir(jsonlPath);
+  if (!isUnderAllowedRoot(resolve(dir), LUMIRA_ALLOWED_ROOTS)) return null;
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return null;
+  }
+  let count = 0;
+  let totalMtimeMs = 0;
+  let totalSize = 0;
+  for (const file of entries) {
+    if (!AGENT_FILE_RE.test(file)) continue;
+    try {
+      const st = await stat(join(dir, file));
+      if (!st.isFile()) continue;
+      count += 1;
+      totalMtimeMs += st.mtimeMs;
+      totalSize += st.size;
+    } catch { /* file disappeared mid-scan — skip */ }
+  }
+  return { count, totalMtimeMs, totalSize };
+}
+
+export function subagentsDirStateEqual(a: SubagentsDirState | null, b: SubagentsDirState | null): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.count === b.count && a.totalMtimeMs === b.totalMtimeMs && a.totalSize === b.totalSize;
 }
 
 async function readMeta(metaPath: string): Promise<MetaSidecar | null> {
@@ -53,7 +131,7 @@ async function readMeta(metaPath: string): Promise<MetaSidecar | null> {
   return null;
 }
 
-async function readLastJsonLine(filePath: string): Promise<unknown | null> {
+async function readLastJsonLine(filePath: string): Promise<unknown> {
   try {
     const raw = await readFile(filePath, 'utf8');
     const lines = raw.split('\n');
@@ -72,6 +150,17 @@ function extractStopReason(lastLine: unknown): string | null {
   if (!msg || typeof msg !== 'object') return null;
   const sr = (msg as { stop_reason?: unknown }).stop_reason;
   return typeof sr === 'string' ? sr : null;
+}
+
+// JSONL lines carry an ISO `timestamp` field. Prefer it for endTime over the
+// file's mtime: mtime can drift due to OS-level flush buffering, especially
+// for short-lived agents that finish faster than the journal commit window.
+function extractTimestamp(lastLine: unknown): Date | null {
+  if (!lastLine || typeof lastLine !== 'object') return null;
+  const ts = (lastLine as { timestamp?: unknown }).timestamp;
+  if (typeof ts !== 'string') return null;
+  const d = new Date(ts);
+  return Number.isFinite(d.getTime()) ? d : null;
 }
 
 // When the user stops a running subagent, Claude Code appends a synthetic
@@ -93,16 +182,58 @@ function wasInterruptedByUser(lastLine: unknown): boolean {
   return false;
 }
 
+// Phase 1 entry: stat-only metadata for ranking. Phase 2 (`readAgentDetails`)
+// reads JSONL + meta only for files that survive the MAX_AGENTS slice — this
+// avoids opening the entire dir on every statusline tick when a session has
+// accumulated dozens of historical agent files.
+interface AgentCandidate {
+  id: string;
+  jsonlFile: string;
+  metaFile: string;
+  mtimeMs: number;
+  size: number;
+}
+
+async function readAgentDetails(c: AgentCandidate): Promise<AgentEntry | null> {
+  const lastLine = await readLastJsonLine(c.jsonlFile);
+  const stopReason = extractStopReason(lastLine);
+  const interrupted = wasInterruptedByUser(lastLine);
+
+  const meta = await readMeta(c.metaFile);
+  const agentType = sanitizeTermString(typeof meta?.agentType === 'string' ? meta.agentType : 'unknown');
+  const description = typeof meta?.description === 'string' ? sanitizeTermString(meta.description) : undefined;
+
+  const status: ToolStatus = (stopReason === 'end_turn' || interrupted) ? 'completed' : 'running';
+
+  // birthtimeMs is unreliable across filesystems (often 0/unset, can't be
+  // updated by tests via utimes). Fall back to mtimeMs whenever it's missing.
+  const startTimeMs = c.mtimeMs;
+  const agent: AgentEntry = {
+    id: c.id,
+    type: agentType,
+    status,
+    startTime: new Date(startTimeMs),
+  };
+  if (description) agent.description = description;
+  if (status === 'completed') {
+    const tsFromLine = extractTimestamp(lastLine);
+    agent.endTime = tsFromLine ?? new Date(c.mtimeMs);
+  }
+  return agent;
+}
+
 export async function parseSubagentsDir(jsonlPath: string): Promise<AgentEntry[]> {
   if (!jsonlPath) return [];
   const subagentsDir = deriveSubagentsDir(jsonlPath);
-  if (!existsSync(subagentsDir)) return [];
   const resolved = resolve(subagentsDir);
-  if (!isUnderAllowedRoot(resolved, ALLOWED_ROOTS)) {
+  if (!isUnderAllowedRoot(resolved, LUMIRA_ALLOWED_ROOTS)) {
     log('skip — subagents dir outside allowed roots:', resolved);
     return [];
   }
 
+  // No `existsSync` guard: the readdir below already returns ENOENT on a
+  // missing dir, and skipping the sync stat removes the TOCTOU window where
+  // the dir could be deleted between check and use.
   let entries: string[];
   try {
     entries = await readdir(resolved);
@@ -111,47 +242,39 @@ export async function parseSubagentsDir(jsonlPath: string): Promise<AgentEntry[]
     return [];
   }
 
-  const collected: { agent: AgentEntry; mtimeMs: number }[] = [];
+  // Phase 1 — stat all candidate files. `stat` is cheap; reading the JSONL
+  // bodies is what we want to keep bounded.
+  const candidates: AgentCandidate[] = [];
   for (const file of entries) {
     const m = file.match(AGENT_FILE_RE);
     if (!m) continue;
     const id = m[1];
     const jsonlFile = join(resolved, file);
-
-    let st;
-    try { st = await stat(jsonlFile); } catch { continue; }
-    if (!st.isFile()) continue;
-
-    const lastLine = await readLastJsonLine(jsonlFile);
-    const stopReason = extractStopReason(lastLine);
-    const interrupted = wasInterruptedByUser(lastLine);
-
-    const meta = await readMeta(join(resolved, `agent-${id}.meta.json`));
-    const agentType = sanitizeTermString(meta?.agentType ?? 'unknown');
-    const description = typeof meta?.description === 'string' ? sanitizeTermString(meta.description) : undefined;
-
-    const status: ToolStatus = (stopReason === 'end_turn' || interrupted) ? 'completed' : 'running';
-
-    const startTimeMs = (st.birthtimeMs && st.birthtimeMs > 0) ? st.birthtimeMs : st.mtimeMs;
-    const agent: AgentEntry = {
-      id,
-      type: agentType,
-      status,
-      startTime: new Date(startTimeMs),
-    };
-    if (description) agent.description = description;
-    if (status === 'completed') agent.endTime = new Date(st.mtimeMs);
-    collected.push({ agent, mtimeMs: st.mtimeMs });
+    try {
+      const st = await stat(jsonlFile);
+      if (!st.isFile()) continue;
+      candidates.push({
+        id,
+        jsonlFile,
+        metaFile: join(resolved, `agent-${id}.meta.json`),
+        mtimeMs: st.mtimeMs,
+        size: st.size,
+      });
+    } catch { /* race with deletion — skip */ }
   }
 
-  // Sort oldest → newest by last-activity so the most recent N survive the
-  // cap below. We use mtime rather than birthtime because birthtime is
-  // unreliable across filesystems (often unset, can't be updated by tests).
-  collected.sort((a, b) => a.mtimeMs - b.mtimeMs);
-  return collected.slice(-MAX_AGENTS).map(c => c.agent);
-}
+  // Sort oldest → newest by file mtime, then keep only the most recent
+  // MAX_AGENTS. mtime is the on-disk last-write timestamp, not the
+  // subagent's logical "last activity" — those are usually the same but can
+  // drift when the OS journal flushes well after the write.
+  candidates.sort((a, b) => a.mtimeMs - b.mtimeMs);
+  const top = candidates.slice(-MAX_AGENTS);
 
-// Long-running sessions accumulate dozens of agent files; the statusline only
-// surfaces a handful. Match the cap used by the main JSONL agent slice (in
-// transcript.ts: `agentMap.values()).slice(-10)`).
-const MAX_AGENTS = 10;
+  // Phase 2 — read JSONL bodies + meta sidecars only for the survivors.
+  const agents: AgentEntry[] = [];
+  for (const c of top) {
+    const a = await readAgentDetails(c);
+    if (a) agents.push(a);
+  }
+  return agents;
+}

--- a/src/parsers/subagents.ts
+++ b/src/parsers/subagents.ts
@@ -17,11 +17,14 @@ const log = debug('subagents');
 // the main-JSONL parser remains the source of truth.
 const AGENT_FILE_RE = /^agent-([A-Za-z0-9_-]+)\.jsonl$/;
 
-// Subagent JSONLs without `stop_reason: "end_turn"` AND without disk activity
-// for this many seconds are treated as completed (likely crashed/aborted).
-// Prevents indefinite "running" indicators when an agent dies without writing
-// its closing line.
-export const STALE_GRACE_SECONDS = 60;
+// Only `stop_reason: "end_turn"` definitively marks a subagent as finished.
+// Other terminal markers like `tool_use` are emitted whenever the subagent
+// yields to a long-running tool (e.g. a 5-minute bash heartbeat) and cannot
+// be treated as completion — the JSONL goes silent until the tool returns,
+// so any mtime-based grace window incorrectly flips live agents to completed.
+// Trade-off: a subagent that crashes without writing its closing line will
+// linger as "running" until the session closes. That's rare; false negatives
+// on long-tool agents were the more common bug.
 
 function realpathSafe(p: string): string {
   try { return realpathSync(p); } catch { return resolve(p); }
@@ -71,7 +74,26 @@ function extractStopReason(lastLine: unknown): string | null {
   return typeof sr === 'string' ? sr : null;
 }
 
-export async function parseSubagentsDir(jsonlPath: string, now: number = Date.now()): Promise<AgentEntry[]> {
+// When the user stops a running subagent, Claude Code appends a synthetic
+// user-role message whose text marker is "[Request interrupted by user…]".
+// That's the only on-disk signal of a kill — the assistant message that
+// preceded it never gets its closing stop_reason rewritten.
+function wasInterruptedByUser(lastLine: unknown): boolean {
+  if (!lastLine || typeof lastLine !== 'object') return false;
+  const d = lastLine as { type?: unknown; message?: { role?: unknown; content?: unknown } };
+  if (d.type !== 'user') return false;
+  const content = d.message?.content;
+  if (!Array.isArray(content)) return false;
+  for (const block of content) {
+    if (block && typeof block === 'object') {
+      const text = (block as { text?: unknown }).text;
+      if (typeof text === 'string' && text.startsWith('[Request interrupted by user')) return true;
+    }
+  }
+  return false;
+}
+
+export async function parseSubagentsDir(jsonlPath: string): Promise<AgentEntry[]> {
   if (!jsonlPath) return [];
   const subagentsDir = deriveSubagentsDir(jsonlPath);
   if (!existsSync(subagentsDir)) return [];
@@ -102,17 +124,13 @@ export async function parseSubagentsDir(jsonlPath: string, now: number = Date.no
 
     const lastLine = await readLastJsonLine(jsonlFile);
     const stopReason = extractStopReason(lastLine);
+    const interrupted = wasInterruptedByUser(lastLine);
 
     const meta = await readMeta(join(resolved, `agent-${id}.meta.json`));
     const agentType = sanitizeTermString(meta?.agentType ?? 'unknown');
     const description = typeof meta?.description === 'string' ? sanitizeTermString(meta.description) : undefined;
 
-    const ageMs = now - st.mtimeMs;
-    const isStale = ageMs > STALE_GRACE_SECONDS * 1000;
-    let status: ToolStatus;
-    if (stopReason === 'end_turn') status = 'completed';
-    else if (isStale) status = 'completed';
-    else status = 'running';
+    const status: ToolStatus = (stopReason === 'end_turn' || interrupted) ? 'completed' : 'running';
 
     const startTimeMs = (st.birthtimeMs && st.birthtimeMs > 0) ? st.birthtimeMs : st.mtimeMs;
     const agent: AgentEntry = {

--- a/src/parsers/transcript.ts
+++ b/src/parsers/transcript.ts
@@ -7,7 +7,7 @@ import { isMtimeFresh, getMtimeState, type MtimeState } from '../utils/cache.js'
 import { sanitizeTermString } from '../normalize.js';
 import { isUnderAllowedRoot, LUMIRA_ALLOWED_ROOTS } from '../utils/path.js';
 import { debug } from '../utils/debug.js';
-import { parseSubagentsDir, getSubagentsDirState, subagentsDirStateEqual, type SubagentsDirState } from './subagents.js';
+import { scanSubagentsDir, readSubagentDetails, subagentsDirStateEqual, type SubagentsDirState } from './subagents.js';
 
 const log = debug('transcript');
 
@@ -137,6 +137,9 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
     return result;
   }
 
+  // path.resolve, NOT realpathSafe — symlink resolution is deliberately not
+  // done here (and not in subagents.ts either). See `src/utils/path.ts`
+  // header for the string-level threat model rationale.
   const resolved = resolve(transcriptPath);
   if (!isUnderAllowedRoot(resolved, LUMIRA_ALLOWED_ROOTS)) {
     log('skip — path outside allowed roots:', resolved);
@@ -147,10 +150,12 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   const currentMtime = getMtimeState(resolved);
   // The subagents/ dir lives outside the main JSONL's stat scope, so a quiet
   // subagent's progress (or a `stop_reason: end_turn` flush) wouldn't change
-  // anything the cache can see. Fold a cheap fingerprint of the dir into the
-  // cache key so updates there force a re-parse even when the parent JSONL
-  // is unchanged.
-  const currentSubagentsState = await getSubagentsDirState(resolved);
+  // anything the cache can see. A single `scanSubagentsDir` produces both
+  // the cache fingerprint AND the per-file candidates we'll feed to
+  // `readSubagentDetails` on a miss — eliminates the double readdir+stat
+  // pass that an independent fingerprint call would force.
+  const subagentsScan = await scanSubagentsDir(resolved);
+  const currentSubagentsState = subagentsScan.state;
   const cached = transcriptCache.get(resolved);
   if (
     currentMtime && cached && isMtimeFresh(resolved, cached.mtime)
@@ -298,7 +303,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   // marker via stop_reason. When present, prefer it over the main-JSONL
   // pairing heuristic. When absent (older Claude Code, layout change), fall
   // back to whatever main-JSONL parsing produced.
-  const subagentDirAgents = await parseSubagentsDir(resolved);
+  const subagentDirAgents = await readSubagentDetails(subagentsScan.candidates);
   if (subagentDirAgents.length > 0) {
     if (log.enabled) log('subagents-dir override:', subagentDirAgents.length, 'agents replace', result.agents.length, 'from main JSONL');
     result.agents = subagentDirAgents;

--- a/src/parsers/transcript.ts
+++ b/src/parsers/transcript.ts
@@ -1,14 +1,13 @@
-import { createReadStream, existsSync, realpathSync } from 'node:fs';
+import { createReadStream, existsSync } from 'node:fs';
 import { createInterface } from 'node:readline';
 import { resolve } from 'node:path';
-import { homedir, tmpdir } from 'node:os';
 import type { TranscriptData, ToolEntry, AgentEntry, TodoEntry, TodoStatus, ThinkingEffort } from '../types.js';
 import { EMPTY_TRANSCRIPT } from '../types.js';
 import { isMtimeFresh, getMtimeState, type MtimeState } from '../utils/cache.js';
 import { sanitizeTermString } from '../normalize.js';
-import { isUnderAllowedRoot } from '../utils/path.js';
+import { isUnderAllowedRoot, LUMIRA_ALLOWED_ROOTS } from '../utils/path.js';
 import { debug } from '../utils/debug.js';
-import { parseSubagentsDir } from './subagents.js';
+import { parseSubagentsDir, getSubagentsDirState, subagentsDirStateEqual, type SubagentsDirState } from './subagents.js';
 
 const log = debug('transcript');
 
@@ -25,7 +24,7 @@ const log = debug('transcript');
 // iteration order is insertion order, which gives us a free LRU: re-insert
 // on hit to refresh recency, drop the first key when size > cap.
 export const TRANSCRIPT_CACHE_CAP = 10;
-type TranscriptCacheEntry = { result: TranscriptData; mtime: MtimeState };
+type TranscriptCacheEntry = { result: TranscriptData; mtime: MtimeState; subagentsDir: SubagentsDirState | null };
 const transcriptCache = new Map<string, TranscriptCacheEntry>();
 
 // Shallow clone of TranscriptData so callers can't mutate the cached arrays.
@@ -123,17 +122,10 @@ export function extractToolTarget(toolName: string, input: Record<string, unknow
 // under an allowed root pointing at /etc/passwd) is tracked separately;
 // the threat is narrow because `transcript_path` arrives from Claude Code
 // itself, not arbitrary external input.
-function realpathSafe(p: string): string {
-  try { return realpathSync(p); } catch { return resolve(p); }
-}
-const ALLOWED_ROOTS: readonly string[] = [
-  ...new Set([
-    resolve(homedir()),
-    resolve(tmpdir()),
-    realpathSafe(homedir()),
-    realpathSafe(tmpdir()),
-  ]),
-];
+// `realpathSafe` and `LUMIRA_ALLOWED_ROOTS` previously lived here; both are
+// now in `src/utils/path.ts` so other parsers (e.g. `subagents.ts`) share the
+// same canonicalisation and allow-list semantics. See `path.ts` for caveats
+// about the string-level (non-symlink-following) nature of the check.
 
 export async function parseTranscript(transcriptPath: string): Promise<TranscriptData> {
   const result: TranscriptData = { ...EMPTY_TRANSCRIPT, tools: [], agents: [], todos: [] };
@@ -146,15 +138,24 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   }
 
   const resolved = resolve(transcriptPath);
-  if (!isUnderAllowedRoot(resolved, ALLOWED_ROOTS)) {
+  if (!isUnderAllowedRoot(resolved, LUMIRA_ALLOWED_ROOTS)) {
     log('skip — path outside allowed roots:', resolved);
     transcriptCache.delete(resolved);
     return result;
   }
 
   const currentMtime = getMtimeState(resolved);
+  // The subagents/ dir lives outside the main JSONL's stat scope, so a quiet
+  // subagent's progress (or a `stop_reason: end_turn` flush) wouldn't change
+  // anything the cache can see. Fold a cheap fingerprint of the dir into the
+  // cache key so updates there force a re-parse even when the parent JSONL
+  // is unchanged.
+  const currentSubagentsState = await getSubagentsDirState(resolved);
   const cached = transcriptCache.get(resolved);
-  if (currentMtime && cached && isMtimeFresh(resolved, cached.mtime)) {
+  if (
+    currentMtime && cached && isMtimeFresh(resolved, cached.mtime)
+    && subagentsDirStateEqual(cached.subagentsDir, currentSubagentsState)
+  ) {
     log('cache hit:', resolved);
     touchCache(resolved, cached);
     return cloneShallow(cached.result);
@@ -298,10 +299,13 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   // pairing heuristic. When absent (older Claude Code, layout change), fall
   // back to whatever main-JSONL parsing produced.
   const subagentDirAgents = await parseSubagentsDir(resolved);
-  if (subagentDirAgents.length > 0) result.agents = subagentDirAgents;
+  if (subagentDirAgents.length > 0) {
+    if (log.enabled) log('subagents-dir override:', subagentDirAgents.length, 'agents replace', result.agents.length, 'from main JSONL');
+    result.agents = subagentDirAgents;
+  }
 
   if (currentMtime) {
-    touchCache(resolved, { result, mtime: currentMtime });
+    touchCache(resolved, { result, mtime: currentMtime, subagentsDir: currentSubagentsState });
   }
   if (log.enabled) {
     log('parsed', resolved, {

--- a/src/parsers/transcript.ts
+++ b/src/parsers/transcript.ts
@@ -202,22 +202,32 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
 
         for (const block of content) {
           if (block.type === 'tool_use' && block.id && block.name) {
-            toolMap.set(block.id, { id: block.id, name: sanitizeTermString(block.name), target: extractToolTarget(block.name, block.input), status: 'running', startTime: timestamp });
+            // Claude Code occasionally re-emits a tool_use after its tool_result
+            // has already landed (observed when a subagent dispatch fails with
+            // "Agent type not found"). Treat the first completion as final —
+            // never downgrade completed/error back to running on re-registration.
+            const existingTool = toolMap.get(block.id);
+            if (!existingTool || existingTool.status === 'running') {
+              toolMap.set(block.id, { id: block.id, name: sanitizeTermString(block.name), target: extractToolTarget(block.name, block.input), status: 'running', startTime: timestamp });
+            }
 
             // Claude Code ≥ 2.1.x renamed the subagent dispatch tool from
             // `Task` to `Agent`. Both shapes carry the same fields
             // (subagent_type, description, model, prompt). Accept either so the
             // live agent count widget works on both versions.
             if (block.name === 'Task' || block.name === 'Agent') {
-              const inp = block.input || {};
-              agentMap.set(block.id, {
-                id: block.id,
-                type: sanitizeTermString(inp.subagent_type || 'unknown'),
-                model: typeof inp.model === 'string' ? sanitizeTermString(inp.model) : inp.model,
-                description: typeof inp.description === 'string' ? sanitizeTermString(inp.description) : inp.description,
-                status: 'running',
-                startTime: timestamp,
-              });
+              const existingAgent = agentMap.get(block.id);
+              if (!existingAgent || existingAgent.status === 'running') {
+                const inp = block.input || {};
+                agentMap.set(block.id, {
+                  id: block.id,
+                  type: sanitizeTermString(inp.subagent_type || 'unknown'),
+                  model: typeof inp.model === 'string' ? sanitizeTermString(inp.model) : inp.model,
+                  description: typeof inp.description === 'string' ? sanitizeTermString(inp.description) : inp.description,
+                  status: 'running',
+                  startTime: timestamp,
+                });
+              }
             }
 
             if (block.name === 'TodoWrite' && block.input?.todos && Array.isArray(block.input.todos)) {

--- a/src/parsers/transcript.ts
+++ b/src/parsers/transcript.ts
@@ -8,6 +8,7 @@ import { isMtimeFresh, getMtimeState, type MtimeState } from '../utils/cache.js'
 import { sanitizeTermString } from '../normalize.js';
 import { isUnderAllowedRoot } from '../utils/path.js';
 import { debug } from '../utils/debug.js';
+import { parseSubagentsDir } from './subagents.js';
 
 const log = debug('transcript');
 
@@ -288,6 +289,17 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   result.agents = Array.from(agentMap.values()).slice(-10);
   result.todos = todos;
   result.thinkingEffort = thinkingEffort;
+
+  // The subagents/ dir alongside the main JSONL is Claude Code's own
+  // per-subagent transcript store. It records every agent that ran in this
+  // session — including quiet/background ones whose tool_use entry stays
+  // buffered in the parent JSONL — and exposes a definitive completion
+  // marker via stop_reason. When present, prefer it over the main-JSONL
+  // pairing heuristic. When absent (older Claude Code, layout change), fall
+  // back to whatever main-JSONL parsing produced.
+  const subagentDirAgents = await parseSubagentsDir(resolved);
+  if (subagentDirAgents.length > 0) result.agents = subagentDirAgents;
+
   if (currentMtime) {
     touchCache(resolved, { result, mtime: currentMtime });
   }

--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -4,6 +4,7 @@ import { fitSegments, truncField } from './text.js';
 import { formatGitChanges, getActiveTodo, SEP } from './shared.js';
 import { hyperlink } from './hyperlink.js';
 import { formatDuration } from '../utils/format.js';
+import { isNamedAgentType } from '../parsers/subagents.js';
 import type { Colors } from './colors.js';
 import type { RenderContext } from '../types.js';
 
@@ -92,9 +93,7 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
     //      under the live ⚡N agents widget on line 3 to avoid noise.
     let agentName = input.agentName;
     if (!agentName) {
-      const named = transcript.agents.filter(a =>
-        a.status === 'running' && a.type && a.type !== 'general-purpose' && a.type !== 'unknown'
-      );
+      const named = transcript.agents.filter(a => a.status === 'running' && isNamedAgentType(a.type));
       if (named.length === 1) agentName = named[0].type;
     }
     if (agentName) {

--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -83,8 +83,23 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
     right.push(c.gray(`${icons.tree} ${truncField(input.worktreeName, 15)}`));
   }
 
-  if (display.agent && input.agentName) {
-    right.push(c.gray(`${icons.cubes} ${truncField(input.agentName, 15)}`));
+  if (display.agent) {
+    // Show the cubes-icon agent name when:
+    //   1) the statusline is rendering inside a subagent session (input.agentName
+    //      comes from Claude Code's stdin payload), or
+    //   2) the parent session has exactly one *named* subagent currently
+    //      running. Anonymous (general-purpose / unknown) agents stay collapsed
+    //      under the live ⚡N agents widget on line 3 to avoid noise.
+    let agentName = input.agentName;
+    if (!agentName) {
+      const named = transcript.agents.filter(a =>
+        a.status === 'running' && a.type && a.type !== 'general-purpose' && a.type !== 'unknown'
+      );
+      if (named.length === 1) agentName = named[0].type;
+    }
+    if (agentName) {
+      right.push(c.gray(`${icons.cubes} ${truncField(agentName, 15)}`));
+    }
   }
 
   if (display.sessionName && input.sessionName) {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,3 +1,5 @@
+import { realpathSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { resolve, relative, isAbsolute } from 'node:path';
 
 /**
@@ -15,6 +17,30 @@ import { resolve, relative, isAbsolute } from 'node:path';
  * Empty-string entries in `roots` are skipped (otherwise `resolve('')` would
  * silently expand to `process.cwd()` and widen the allowlist).
  */
+/**
+ * Resolves a path through symlinks, falling back to plain `resolve()` if the
+ * path doesn't exist or canonicalisation fails. Used to harden allow-list
+ * checks across modules that read user-controlled paths.
+ */
+export function realpathSafe(p: string): string {
+  try { return realpathSync(p); } catch { return resolve(p); }
+}
+
+/**
+ * The default set of root directories Lumira parsers are allowed to read from.
+ * Includes both the canonical and the symlink-resolved forms of $HOME and
+ * $TMPDIR so paths under either spelling are accepted.
+ *
+ * IMPORTANT: this allow-list is a *string-level* defence. `isUnderAllowedRoot`
+ * does not follow symlinks at check time — callers protecting against symlink
+ * traversal should canonicalise the candidate path with `realpathSafe` before
+ * the comparison, or accept that a symlink whose target lies outside the
+ * allow-list is treated as legal as long as its own *path* sits under one.
+ */
+export const LUMIRA_ALLOWED_ROOTS: readonly string[] = [
+  ...new Set([resolve(homedir()), resolve(tmpdir()), realpathSafe(homedir()), realpathSafe(tmpdir())]),
+];
+
 export function isUnderAllowedRoot(candidate: string, roots: readonly string[]): boolean {
   if (roots.length === 0) return false;
   const normalizedCandidate = resolve(candidate);

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -3,21 +3,6 @@ import { homedir, tmpdir } from 'node:os';
 import { resolve, relative, isAbsolute } from 'node:path';
 
 /**
- * Returns true if `candidate` is the same as, or a descendant of, any of the
- * `roots`. Uses `path.relative` to avoid the classic `startsWith` bypass where
- * a sibling like `/tmpattacker` would pass `'/tmp'.startsWith()`.
- *
- * Both `candidate` and each entry in `roots` are normalized via `path.resolve`
- * internally, so callers don't have to pre-resolve.
- *
- * IMPORTANT: this performs string-level path comparison only. It does **not**
- * follow symlinks. Callers protecting against symlink-based traversal should
- * pass paths that have already been canonicalized via `fs.realpathSync`.
- *
- * Empty-string entries in `roots` are skipped (otherwise `resolve('')` would
- * silently expand to `process.cwd()` and widen the allowlist).
- */
-/**
  * Resolves a path through symlinks, falling back to plain `resolve()` if the
  * path doesn't exist or canonicalisation fails. Used to harden allow-list
  * checks across modules that read user-controlled paths.
@@ -41,6 +26,21 @@ export const LUMIRA_ALLOWED_ROOTS: readonly string[] = [
   ...new Set([resolve(homedir()), resolve(tmpdir()), realpathSafe(homedir()), realpathSafe(tmpdir())]),
 ];
 
+/**
+ * Returns true if `candidate` is the same as, or a descendant of, any of the
+ * `roots`. Uses `path.relative` to avoid the classic `startsWith` bypass where
+ * a sibling like `/tmpattacker` would pass `'/tmp'.startsWith()`.
+ *
+ * Both `candidate` and each entry in `roots` are normalized via `path.resolve`
+ * internally, so callers don't have to pre-resolve.
+ *
+ * IMPORTANT: this performs string-level path comparison only. It does **not**
+ * follow symlinks. Callers protecting against symlink-based traversal should
+ * pass paths that have already been canonicalized via `fs.realpathSync`.
+ *
+ * Empty-string entries in `roots` are skipped (otherwise `resolve('')` would
+ * silently expand to `process.cwd()` and widen the allowlist).
+ */
 export function isUnderAllowedRoot(candidate: string, roots: readonly string[]): boolean {
   if (roots.length === 0) return false;
   const normalizedCandidate = resolve(candidate);

--- a/tests/fixtures/transcript-agent-zombie.jsonl
+++ b/tests/fixtures/transcript-agent-zombie.jsonl
@@ -1,0 +1,3 @@
+{"timestamp":"2026-05-07T18:00:00Z","message":{"content":[{"type":"tool_use","id":"z1","name":"Agent","input":{"subagent_type":"pepito","description":"first try"}}]}}
+{"timestamp":"2026-05-07T18:00:01Z","message":{"content":[{"type":"tool_result","tool_use_id":"z1","content":"Agent type 'pepito' not found"}]}}
+{"timestamp":"2026-05-07T18:00:02Z","message":{"content":[{"type":"tool_use","id":"z1","name":"Agent","input":{"subagent_type":"pepito","description":"first try"}}]}}

--- a/tests/parsers/subagents.test.ts
+++ b/tests/parsers/subagents.test.ts
@@ -58,6 +58,12 @@ describe('deriveSubagentsDir', () => {
     expect(deriveSubagentsDir('/home/u/.claude/projects/proj/abc.jsonl'))
       .toBe('/home/u/.claude/projects/proj/abc/subagents');
   });
+  it('strips uppercase .JSONL extensions case-insensitively', () => {
+    expect(deriveSubagentsDir('/home/u/proj/abc.JSONL'))
+      .toBe('/home/u/proj/abc/subagents');
+    expect(deriveSubagentsDir('/home/u/proj/abc.Jsonl'))
+      .toBe('/home/u/proj/abc/subagents');
+  });
 });
 
 describe('parseSubagentsDir', () => {
@@ -244,6 +250,56 @@ describe('parseSubagentsDir', () => {
     // endTime is still a valid Date (file mtime) — never NaN.
     expect(agents[0].endTime).toBeInstanceOf(Date);
     expect(Number.isFinite(agents[0].endTime!.getTime())).toBe(true);
+  });
+
+  it('falls back to file mtime for startTime when first JSONL line has no timestamp field', async () => {
+    const { jsonlPath, subagentsDir } = makeSession();
+    writeAgent(subagentsDir, 'no-ts',
+      // No `timestamp` field — extractTimestamp returns null and mtime is used.
+      { agentId: 'no-ts', message: { role: 'assistant', stop_reason: 'end_turn' } },
+    );
+    const agents = await parseSubagentsDir(jsonlPath);
+    expect(agents[0].startTime).toBeInstanceOf(Date);
+    expect(Number.isFinite(agents[0].startTime.getTime())).toBe(true);
+  });
+
+  it('ignores non-text content blocks when checking for the interrupt marker', async () => {
+    // A mixed content array (e.g. image + text) must still trigger the
+    // marker check on the text block. Documents the safety of the
+    // `typeof text === 'string'` guard against non-text blocks.
+    const { jsonlPath, subagentsDir } = makeSession();
+    writeAgent(subagentsDir, 'mix1', {
+      type: 'user',
+      message: { role: 'user', content: [
+        { type: 'image', source: { data: 'fake' } },
+        { type: 'text', text: '[Request interrupted by user]' },
+      ] },
+    });
+    const agents = await parseSubagentsDir(jsonlPath);
+    expect(agents[0].status).toBe('completed');
+  });
+
+  it('handles a large JSONL via head/tail chunked reads (>64 KB threshold)', async () => {
+    // Subagent transcripts can grow into the megabytes when the agent
+    // runs many tool calls. The boundary reader streams via head/tail
+    // chunks instead of slurping. This test fabricates a >64 KB file
+    // with a recognisable first and last line and verifies both
+    // start/end timestamps + completion status survive the chunked path.
+    const { jsonlPath, subagentsDir } = makeSession();
+    const startTs = '2026-05-07T18:00:00.000Z';
+    const endTs = '2026-05-07T18:10:00.000Z';
+    const first = JSON.stringify({ agentId: 'big', timestamp: startTs, type: 'user', message: { role: 'user', content: [{ type: 'text', text: 'go' }] } });
+    const last = JSON.stringify({ agentId: 'big', timestamp: endTs, type: 'assistant', message: { role: 'assistant', stop_reason: 'end_turn' } });
+    // Pad the middle with ~80 KB of junk lines that don't parse as JSON
+    // (they should be skipped by parseFirstJson/parseLastJson).
+    const junk = Array.from({ length: 4000 }, (_, i) => `noise line ${i} `.repeat(8)).join('\n');
+    writeRawAgent(subagentsDir, 'big', `${first}\n${junk}\n${last}\n`);
+    const agents = await parseSubagentsDir(jsonlPath);
+    expect(agents).toHaveLength(1);
+    expect(agents[0].id).toBe('big');
+    expect(agents[0].status).toBe('completed');
+    expect(agents[0].startTime.toISOString()).toBe(startTs);
+    expect(agents[0].endTime?.toISOString()).toBe(endTs);
   });
 
   it('uses the first JSONL line timestamp for startTime, not the file mtime', async () => {

--- a/tests/parsers/subagents.test.ts
+++ b/tests/parsers/subagents.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { parseSubagentsDir, deriveSubagentsDir, STALE_GRACE_SECONDS } from '../../src/parsers/subagents.js';
+import { parseSubagentsDir, deriveSubagentsDir } from '../../src/parsers/subagents.js';
 
 let workDir: string;
 
@@ -81,14 +81,28 @@ describe('parseSubagentsDir', () => {
     expect(agents[0].status).toBe('running');
   });
 
-  it('marks a stale agent (no end_turn, no recent activity) as completed via grace window', async () => {
+  it('marks an agent as completed when last line is "[Request interrupted by user…]"', async () => {
     const { jsonlPath, subagentsDir } = makeSession();
-    writeAgent(subagentsDir, 's1',
-      { agentId: 's1', message: { role: 'assistant', stop_reason: null } },
-      STALE_GRACE_SECONDS + 5,
+    writeAgent(subagentsDir, 'k1',
+      { type: 'user', message: { role: 'user', content: [{ type: 'text', text: '[Request interrupted by user for tool use]' }] } },
     );
     const agents = await parseSubagentsDir(jsonlPath);
     expect(agents[0].status).toBe('completed');
+  });
+
+  it('keeps an agent as running when stop_reason is "tool_use" (waiting for a long tool)', async () => {
+    // A subagent that yields to a long-running tool (e.g. a 5-minute heartbeat
+    // bash) writes its last JSONL line with stop_reason: "tool_use" and goes
+    // silent until the tool returns. Earlier versions used an mtime-based
+    // grace window that would flip these to "completed" — this test guards
+    // against that regression.
+    const { jsonlPath, subagentsDir } = makeSession();
+    writeAgent(subagentsDir, 't1',
+      { agentId: 't1', message: { role: 'assistant', stop_reason: 'tool_use' } },
+      300,
+    );
+    const agents = await parseSubagentsDir(jsonlPath);
+    expect(agents[0].status).toBe('running');
   });
 
   it('falls back to type "unknown" when meta sidecar is missing', async () => {

--- a/tests/parsers/subagents.test.ts
+++ b/tests/parsers/subagents.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { parseSubagentsDir, deriveSubagentsDir, STALE_GRACE_SECONDS } from '../../src/parsers/subagents.js';
+
+let workDir: string;
+
+function makeSession(): { jsonlPath: string; subagentsDir: string } {
+  // Lay out: <workDir>/<session-id>.jsonl + <workDir>/<session-id>/subagents/
+  const sessionId = 'sess-test';
+  const jsonlPath = join(workDir, `${sessionId}.jsonl`);
+  writeFileSync(jsonlPath, '{}\n');
+  const subagentsDir = join(workDir, sessionId, 'subagents');
+  mkdirSync(subagentsDir, { recursive: true });
+  return { jsonlPath, subagentsDir };
+}
+
+function writeAgent(dir: string, id: string, lastLine: object, mtimeSecondsAgo = 0, meta?: object): string {
+  const jsonlPath = join(dir, `agent-${id}.jsonl`);
+  writeFileSync(jsonlPath, JSON.stringify(lastLine) + '\n');
+  if (meta) writeFileSync(join(dir, `agent-${id}.meta.json`), JSON.stringify(meta));
+  if (mtimeSecondsAgo > 0) {
+    const t = (Date.now() - mtimeSecondsAgo * 1000) / 1000;
+    utimesSync(jsonlPath, t, t);
+  }
+  return jsonlPath;
+}
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'lumira-subagents-'));
+});
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe('deriveSubagentsDir', () => {
+  it('maps <session>.jsonl → <session>/subagents/', () => {
+    expect(deriveSubagentsDir('/home/u/.claude/projects/proj/abc.jsonl'))
+      .toBe('/home/u/.claude/projects/proj/abc/subagents');
+  });
+});
+
+describe('parseSubagentsDir', () => {
+  it('returns empty when subagents dir does not exist', async () => {
+    const jsonlPath = join(workDir, 'no-session.jsonl');
+    writeFileSync(jsonlPath, '{}\n');
+    expect(await parseSubagentsDir(jsonlPath)).toEqual([]);
+  });
+
+  it('returns empty when jsonlPath is falsy', async () => {
+    expect(await parseSubagentsDir('')).toEqual([]);
+  });
+
+  it('refuses dirs outside allowed roots (homedir, tmpdir)', async () => {
+    expect(await parseSubagentsDir('/etc/passwd.jsonl')).toEqual([]);
+  });
+
+  it('marks an agent as completed when last line has stop_reason=end_turn', async () => {
+    const { jsonlPath, subagentsDir } = makeSession();
+    writeAgent(subagentsDir, 'a1',
+      { agentId: 'a1', message: { role: 'assistant', stop_reason: 'end_turn' } },
+      0,
+      { agentType: 'pepito', description: 'test agent' },
+    );
+    const agents = await parseSubagentsDir(jsonlPath);
+    expect(agents).toHaveLength(1);
+    expect(agents[0].id).toBe('a1');
+    expect(agents[0].status).toBe('completed');
+    expect(agents[0].type).toBe('pepito');
+    expect(agents[0].description).toBe('test agent');
+  });
+
+  it('marks an agent as running when no stop_reason and mtime is fresh', async () => {
+    const { jsonlPath, subagentsDir } = makeSession();
+    writeAgent(subagentsDir, 'r1',
+      { agentId: 'r1', message: { role: 'assistant', stop_reason: null } },
+    );
+    const agents = await parseSubagentsDir(jsonlPath);
+    expect(agents).toHaveLength(1);
+    expect(agents[0].status).toBe('running');
+  });
+
+  it('marks a stale agent (no end_turn, no recent activity) as completed via grace window', async () => {
+    const { jsonlPath, subagentsDir } = makeSession();
+    writeAgent(subagentsDir, 's1',
+      { agentId: 's1', message: { role: 'assistant', stop_reason: null } },
+      STALE_GRACE_SECONDS + 5,
+    );
+    const agents = await parseSubagentsDir(jsonlPath);
+    expect(agents[0].status).toBe('completed');
+  });
+
+  it('falls back to type "unknown" when meta sidecar is missing', async () => {
+    const { jsonlPath, subagentsDir } = makeSession();
+    writeAgent(subagentsDir, 'm1',
+      { agentId: 'm1', message: { role: 'assistant', stop_reason: 'end_turn' } },
+    );
+    const agents = await parseSubagentsDir(jsonlPath);
+    expect(agents[0].type).toBe('unknown');
+    expect(agents[0].description).toBeUndefined();
+  });
+
+  it('ignores files that do not match agent-<id>.jsonl', async () => {
+    const { jsonlPath, subagentsDir } = makeSession();
+    writeFileSync(join(subagentsDir, 'random.txt'), 'noise');
+    writeFileSync(join(subagentsDir, 'agent-x.meta.json'), '{}');
+    expect(await parseSubagentsDir(jsonlPath)).toEqual([]);
+  });
+
+  it('returns multiple agents in oldest-first order', async () => {
+    const { jsonlPath, subagentsDir } = makeSession();
+    writeAgent(subagentsDir, 'old',
+      { agentId: 'old', message: { role: 'assistant', stop_reason: 'end_turn' } },
+      120,
+    );
+    writeAgent(subagentsDir, 'new',
+      { agentId: 'new', message: { role: 'assistant', stop_reason: 'end_turn' } },
+      0,
+    );
+    const agents = await parseSubagentsDir(jsonlPath);
+    expect(agents.map(a => a.id)).toEqual(['old', 'new']);
+  });
+});

--- a/tests/parsers/subagents.test.ts
+++ b/tests/parsers/subagents.test.ts
@@ -234,6 +234,34 @@ describe('parseSubagentsDir', () => {
     const agents = await parseSubagentsDir(jsonlPath);
     expect(agents[0].endTime?.toISOString()).toBe(ts);
   });
+
+  it('falls back to file mtime when the JSONL timestamp is malformed', async () => {
+    const { jsonlPath, subagentsDir } = makeSession();
+    writeAgent(subagentsDir, 'badts',
+      { agentId: 'badts', timestamp: 'not-a-date', message: { role: 'assistant', stop_reason: 'end_turn' } },
+    );
+    const agents = await parseSubagentsDir(jsonlPath);
+    // endTime is still a valid Date (file mtime) — never NaN.
+    expect(agents[0].endTime).toBeInstanceOf(Date);
+    expect(Number.isFinite(agents[0].endTime!.getTime())).toBe(true);
+  });
+
+  it('uses the first JSONL line timestamp for startTime, not the file mtime', async () => {
+    // For a long-running agent, file mtime points at the close-out (end_turn
+    // write), which is wrong as a "started at" value. The first line's
+    // dispatch timestamp is the correct source.
+    const { jsonlPath, subagentsDir } = makeSession();
+    const startTs = '2026-05-07T18:00:00.000Z';
+    const endTs = '2026-05-07T18:05:00.000Z';
+    const lines = [
+      JSON.stringify({ agentId: 'long', timestamp: startTs, type: 'user', message: { role: 'user', content: [{ type: 'text', text: 'go' }] } }),
+      JSON.stringify({ agentId: 'long', timestamp: endTs, type: 'assistant', message: { role: 'assistant', stop_reason: 'end_turn' } }),
+    ].join('\n') + '\n';
+    writeRawAgent(subagentsDir, 'long', lines);
+    const agents = await parseSubagentsDir(jsonlPath);
+    expect(agents[0].startTime.toISOString()).toBe(startTs);
+    expect(agents[0].endTime?.toISOString()).toBe(endTs);
+  });
 });
 
 describe('isNamedAgentType', () => {
@@ -249,6 +277,14 @@ describe('isNamedAgentType', () => {
     expect(isNamedAgentType('')).toBe(false);
     expect(isNamedAgentType(undefined)).toBe(false);
     expect(isNamedAgentType(null)).toBe(false);
+  });
+  it('matches case-sensitively (treats different casing as named)', () => {
+    // Documents the case-sensitive contract: if Claude Code emits
+    // "General-Purpose" or "UNKNOWN", we treat them as user-defined names.
+    // If the upstream type-string casing ever drifts, this test will fail
+    // and the GENERIC_AGENT_TYPES set should be updated.
+    expect(isNamedAgentType('General-Purpose')).toBe(true);
+    expect(isNamedAgentType('UNKNOWN')).toBe(true);
   });
 });
 
@@ -284,9 +320,53 @@ describe('getSubagentsDirState + subagentsDirStateEqual', () => {
     expect(subagentsDirStateEqual(state1, state2)).toBe(false);
   });
 
+  it('returns a zero-count state (not null) when the dir exists but has no agent files', async () => {
+    // A dir with only sidecars or unrelated files should still be detected
+    // as "exists but empty" — count=0, totals=0 — distinct from null which
+    // means "no dir at all". The cache check distinguishes these so an
+    // empty dir doesn't masquerade as a missing one.
+    const { jsonlPath, subagentsDir } = makeSession();
+    writeFileSync(join(subagentsDir, 'noise.txt'), 'irrelevant');
+    writeFileSync(join(subagentsDir, 'agent-x.meta.json'), '{}');
+    const state = await getSubagentsDirState(jsonlPath);
+    expect(state).not.toBeNull();
+    expect(state?.count).toBe(0);
+    expect(state?.maxMtimeMs).toBe(0);
+    expect(state?.totalSize).toBe(0);
+  });
+
+  it('returns null when the path resolves to a regular file instead of a directory', async () => {
+    // If something has stuffed a file where the subagents dir would live,
+    // readdir throws ENOTDIR. The fingerprint should treat that the same
+    // as a missing dir.
+    const sessionId = 'sess-file-not-dir';
+    const jsonlPath = join(workDir, `${sessionId}.jsonl`);
+    writeFileSync(jsonlPath, '{}\n');
+    mkdirSync(join(workDir, sessionId), { recursive: true });
+    writeFileSync(join(workDir, sessionId, 'subagents'), 'this is a file, not a dir');
+    expect(await getSubagentsDirState(jsonlPath)).toBeNull();
+  });
+
+  it('changes maxMtimeMs (not just totalSize) when an existing file is modified in place at a later mtime', async () => {
+    const { jsonlPath, subagentsDir } = makeSession();
+    writeAgent(subagentsDir, 'm1',
+      { agentId: 'm1', message: { role: 'assistant', stop_reason: 'tool_use' } },
+      10,
+    );
+    const before = await getSubagentsDirState(jsonlPath);
+
+    // Same id, fresh mtime, different (longer) body
+    writeAgent(subagentsDir, 'm1',
+      { agentId: 'm1', message: { role: 'assistant', stop_reason: 'end_turn', text: 'much longer body to widen totalSize' } },
+    );
+    const after = await getSubagentsDirState(jsonlPath);
+    expect(after?.count).toBe(before?.count);
+    expect(after?.maxMtimeMs).toBeGreaterThan(before?.maxMtimeMs ?? 0);
+  });
+
   it('subagentsDirStateEqual treats two nulls as equal but null vs state as not equal', () => {
     expect(subagentsDirStateEqual(null, null)).toBe(true);
-    expect(subagentsDirStateEqual(null, { count: 0, totalMtimeMs: 0, totalSize: 0 })).toBe(false);
-    expect(subagentsDirStateEqual({ count: 1, totalMtimeMs: 100, totalSize: 50 }, { count: 1, totalMtimeMs: 100, totalSize: 50 })).toBe(true);
+    expect(subagentsDirStateEqual(null, { count: 0, maxMtimeMs: 0, totalSize: 0 })).toBe(false);
+    expect(subagentsDirStateEqual({ count: 1, maxMtimeMs: 100, totalSize: 50 }, { count: 1, maxMtimeMs: 100, totalSize: 50 })).toBe(true);
   });
 });

--- a/tests/parsers/subagents.test.ts
+++ b/tests/parsers/subagents.test.ts
@@ -8,6 +8,7 @@ import {
   isNamedAgentType,
   getSubagentsDirState,
   subagentsDirStateEqual,
+  GENERIC_AGENT_TYPES,
 } from '../../src/parsers/subagents.js';
 
 let workDir: string;
@@ -379,6 +380,18 @@ describe('isNamedAgentType', () => {
     // and the GENERIC_AGENT_TYPES set should be updated.
     expect(isNamedAgentType('General-Purpose')).toBe(true);
     expect(isNamedAgentType('UNKNOWN')).toBe(true);
+  });
+});
+
+describe('GENERIC_AGENT_TYPES', () => {
+  it('contains the canonical anonymous dispatch types', () => {
+    // Pinning the exported contract so a future addition to the set
+    // doesn't silently change behaviour without updating this test.
+    expect(GENERIC_AGENT_TYPES.has('general-purpose')).toBe(true);
+    expect(GENERIC_AGENT_TYPES.has('unknown')).toBe(true);
+  });
+  it('is in agreement with isNamedAgentType for every member', () => {
+    for (const t of GENERIC_AGENT_TYPES) expect(isNamedAgentType(t)).toBe(false);
   });
 });
 

--- a/tests/parsers/subagents.test.ts
+++ b/tests/parsers/subagents.test.ts
@@ -290,16 +290,54 @@ describe('parseSubagentsDir', () => {
     const endTs = '2026-05-07T18:10:00.000Z';
     const first = JSON.stringify({ agentId: 'big', timestamp: startTs, type: 'user', message: { role: 'user', content: [{ type: 'text', text: 'go' }] } });
     const last = JSON.stringify({ agentId: 'big', timestamp: endTs, type: 'assistant', message: { role: 'assistant', stop_reason: 'end_turn' } });
-    // Pad the middle with ~80 KB of junk lines that don't parse as JSON
-    // (they should be skipped by parseFirstJson/parseLastJson).
-    const junk = Array.from({ length: 4000 }, (_, i) => `noise line ${i} `.repeat(8)).join('\n');
-    writeRawAgent(subagentsDir, 'big', `${first}\n${junk}\n${last}\n`);
+    // Pad the middle with ~80 KB of junk lines.
+    const junkLines = Array.from({ length: 4000 }, (_, i) => `noise line ${i} `.repeat(8));
+    // Sanity-check the assumption: junk lines must NOT be valid JSON,
+    // otherwise the test passes for the wrong reason (parser would lock
+    // onto the first junk line instead of falling through to `first`).
+    expect(() => JSON.parse(junkLines[0])).toThrow();
+    writeRawAgent(subagentsDir, 'big', `${first}\n${junkLines.join('\n')}\n${last}\n`);
     const agents = await parseSubagentsDir(jsonlPath);
     expect(agents).toHaveLength(1);
     expect(agents[0].id).toBe('big');
     expect(agents[0].status).toBe('completed');
     expect(agents[0].startTime.toISOString()).toBe(startTs);
     expect(agents[0].endTime?.toISOString()).toBe(endTs);
+  });
+
+  it('falls back gracefully when the FIRST JSONL line exceeds the head chunk window (>16 KB)', async () => {
+    // A first line larger than the 16 KB head buffer can't be JSON.parse'd
+    // by parseFirstJson — extractTimestamp returns null and startTime
+    // falls back to mtime. The last line (small) is still parseable so
+    // status detection still works.
+    const { jsonlPath, subagentsDir } = makeSession();
+    const endTs = '2026-05-07T18:10:00.000Z';
+    const huge = JSON.stringify({ agentId: 'fat-first', timestamp: '2026-05-07T18:00:00.000Z', message: { content: 'x'.repeat(20_000) } });
+    const last = JSON.stringify({ agentId: 'fat-first', timestamp: endTs, message: { role: 'assistant', stop_reason: 'end_turn' } });
+    const pad = 'p'.repeat(50_000);
+    writeRawAgent(subagentsDir, 'fat-first', `${huge}\n${pad}\n${last}\n`);
+    const agents = await parseSubagentsDir(jsonlPath);
+    expect(agents[0].status).toBe('completed');
+    expect(agents[0].endTime?.toISOString()).toBe(endTs);
+    // startTime fell back to mtime — Date is finite, never NaN.
+    expect(Number.isFinite(agents[0].startTime.getTime())).toBe(true);
+  });
+
+  it('marks a completed agent as running when the LAST JSONL line exceeds the tail chunk window (>16 KB)', async () => {
+    // Documents the only known semantic regression of the chunked-read
+    // path: a closing assistant message bigger than 16 KB hides its
+    // stop_reason from the tail-window parser, so the agent appears
+    // permanently "running". If this assumption ever breaks (Claude Code
+    // routinely emits huge close-out messages), this test fails and we
+    // revisit the chunk size or restore full-read with a streaming parser.
+    const { jsonlPath, subagentsDir } = makeSession();
+    const first = JSON.stringify({ agentId: 'fat-last', timestamp: '2026-05-07T18:00:00.000Z', message: { role: 'user', content: [{ type: 'text', text: 'go' }] } });
+    const huge = JSON.stringify({ agentId: 'fat-last', timestamp: '2026-05-07T18:10:00.000Z', message: { role: 'assistant', stop_reason: 'end_turn', text: 'x'.repeat(30_000) } });
+    const pad = 'p'.repeat(50_000);
+    writeRawAgent(subagentsDir, 'fat-last', `${first}\n${pad}\n${huge}\n`);
+    const agents = await parseSubagentsDir(jsonlPath);
+    // stop_reason is unreachable → status sticks to running.
+    expect(agents[0].status).toBe('running');
   });
 
   it('uses the first JSONL line timestamp for startTime, not the file mtime', async () => {

--- a/tests/parsers/subagents.test.ts
+++ b/tests/parsers/subagents.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { parseSubagentsDir, deriveSubagentsDir } from '../../src/parsers/subagents.js';
+import {
+  parseSubagentsDir,
+  deriveSubagentsDir,
+  isNamedAgentType,
+  getSubagentsDirState,
+  subagentsDirStateEqual,
+} from '../../src/parsers/subagents.js';
 
 let workDir: string;
 
@@ -16,7 +22,13 @@ function makeSession(): { jsonlPath: string; subagentsDir: string } {
   return { jsonlPath, subagentsDir };
 }
 
-function writeAgent(dir: string, id: string, lastLine: object, mtimeSecondsAgo = 0, meta?: object): string {
+function writeAgent(
+  dir: string,
+  id: string,
+  lastLine: Record<string, unknown>,
+  mtimeSecondsAgo = 0,
+  meta?: Record<string, unknown>,
+): string {
   const jsonlPath = join(dir, `agent-${id}.jsonl`);
   writeFileSync(jsonlPath, JSON.stringify(lastLine) + '\n');
   if (meta) writeFileSync(join(dir, `agent-${id}.meta.json`), JSON.stringify(meta));
@@ -24,6 +36,13 @@ function writeAgent(dir: string, id: string, lastLine: object, mtimeSecondsAgo =
     const t = (Date.now() - mtimeSecondsAgo * 1000) / 1000;
     utimesSync(jsonlPath, t, t);
   }
+  return jsonlPath;
+}
+
+function writeRawAgent(dir: string, id: string, body: string, meta?: Record<string, unknown>): string {
+  const jsonlPath = join(dir, `agent-${id}.jsonl`);
+  writeFileSync(jsonlPath, body);
+  if (meta) writeFileSync(join(dir, `agent-${id}.meta.json`), JSON.stringify(meta));
   return jsonlPath;
 }
 
@@ -134,5 +153,140 @@ describe('parseSubagentsDir', () => {
     );
     const agents = await parseSubagentsDir(jsonlPath);
     expect(agents.map(a => a.id)).toEqual(['old', 'new']);
+  });
+
+  it('caps the result at MAX_AGENTS, keeping the most recently active', async () => {
+    // Long-running sessions accumulate dozens of agent files. The slice cap
+    // (MAX_AGENTS = 10) must keep the freshest mtimes — a 12-agent session
+    // should drop the two oldest, never the newest two.
+    const { jsonlPath, subagentsDir } = makeSession();
+    for (let i = 0; i < 12; i++) {
+      writeAgent(subagentsDir, `id${i}`,
+        { agentId: `id${i}`, message: { role: 'assistant', stop_reason: 'end_turn' } },
+        12 - i, // oldest first (mtime longest-ago), newest last
+      );
+    }
+    const agents = await parseSubagentsDir(jsonlPath);
+    expect(agents).toHaveLength(10);
+    // The 10 newest are id2..id11; id0 and id1 must have been dropped.
+    const returnedIds = agents.map(a => a.id);
+    expect(returnedIds).not.toContain('id0');
+    expect(returnedIds).not.toContain('id1');
+    expect(returnedIds).toContain('id11');
+  });
+
+  it('treats an empty JSONL file as running (no end_turn marker)', async () => {
+    const { jsonlPath, subagentsDir } = makeSession();
+    writeRawAgent(subagentsDir, 'e1', '');
+    const agents = await parseSubagentsDir(jsonlPath);
+    expect(agents).toHaveLength(1);
+    expect(agents[0].status).toBe('running');
+  });
+
+  it('treats a whitespace-only JSONL file as running and does not throw', async () => {
+    const { jsonlPath, subagentsDir } = makeSession();
+    writeRawAgent(subagentsDir, 'w1', '   \n\n   \n');
+    const agents = await parseSubagentsDir(jsonlPath);
+    expect(agents[0].status).toBe('running');
+  });
+
+  it('does NOT mark interrupted when the marker is on an earlier line and a different line follows', async () => {
+    // Robustness: `wasInterruptedByUser` only inspects the last non-empty
+    // line. A historical interrupt followed by a new assistant message must
+    // be evaluated against the new last line, not the old marker.
+    const { jsonlPath, subagentsDir } = makeSession();
+    const interruptLine = JSON.stringify({ type: 'user', message: { content: [{ type: 'text', text: '[Request interrupted by user]' }] } });
+    const newLine = JSON.stringify({ agentId: 'i1', type: 'assistant', message: { role: 'assistant', stop_reason: 'tool_use' } });
+    writeRawAgent(subagentsDir, 'i1', `${interruptLine}\n${newLine}\n`);
+    const agents = await parseSubagentsDir(jsonlPath);
+    expect(agents[0].status).toBe('running');
+  });
+
+  it('falls back to type "unknown" when meta sidecar contains invalid JSON', async () => {
+    const { jsonlPath, subagentsDir } = makeSession();
+    writeAgent(subagentsDir, 'b1',
+      { agentId: 'b1', message: { role: 'assistant', stop_reason: 'end_turn' } },
+    );
+    writeFileSync(join(subagentsDir, 'agent-b1.meta.json'), '{not json');
+    const agents = await parseSubagentsDir(jsonlPath);
+    expect(agents[0].type).toBe('unknown');
+    expect(agents[0].description).toBeUndefined();
+  });
+
+  it('falls back to type "unknown" when meta agentType is not a string', async () => {
+    const { jsonlPath, subagentsDir } = makeSession();
+    writeAgent(subagentsDir, 'b2',
+      { agentId: 'b2', message: { role: 'assistant', stop_reason: 'end_turn' } },
+      0,
+      { agentType: { evil: 'object' }, description: 42 } as unknown as Record<string, unknown>,
+    );
+    const agents = await parseSubagentsDir(jsonlPath);
+    expect(agents[0].type).toBe('unknown');
+    expect(agents[0].description).toBeUndefined();
+  });
+
+  it('uses the JSONL line timestamp for endTime when available', async () => {
+    const { jsonlPath, subagentsDir } = makeSession();
+    const ts = '2026-05-07T18:30:00.000Z';
+    writeAgent(subagentsDir, 'ts1',
+      { agentId: 'ts1', timestamp: ts, message: { role: 'assistant', stop_reason: 'end_turn' } },
+    );
+    const agents = await parseSubagentsDir(jsonlPath);
+    expect(agents[0].endTime?.toISOString()).toBe(ts);
+  });
+});
+
+describe('isNamedAgentType', () => {
+  it('returns true for user-defined types', () => {
+    expect(isNamedAgentType('pepito')).toBe(true);
+    expect(isNamedAgentType('feature-dev:code-reviewer')).toBe(true);
+  });
+  it('returns false for generic dispatches', () => {
+    expect(isNamedAgentType('general-purpose')).toBe(false);
+    expect(isNamedAgentType('unknown')).toBe(false);
+  });
+  it('returns false for empty / nullish input', () => {
+    expect(isNamedAgentType('')).toBe(false);
+    expect(isNamedAgentType(undefined)).toBe(false);
+    expect(isNamedAgentType(null)).toBe(false);
+  });
+});
+
+describe('getSubagentsDirState + subagentsDirStateEqual', () => {
+  it('returns null when the dir does not exist', async () => {
+    const jsonlPath = join(workDir, 'nope.jsonl');
+    writeFileSync(jsonlPath, '{}\n');
+    expect(await getSubagentsDirState(jsonlPath)).toBeNull();
+  });
+
+  it('returns null for falsy paths', async () => {
+    expect(await getSubagentsDirState('')).toBeNull();
+  });
+
+  it('returns null for paths outside allowed roots', async () => {
+    expect(await getSubagentsDirState('/etc/passwd.jsonl')).toBeNull();
+  });
+
+  it('reflects file count, total size and aggregate mtime', async () => {
+    const { jsonlPath, subagentsDir } = makeSession();
+    writeAgent(subagentsDir, 's1',
+      { agentId: 's1', message: { role: 'assistant', stop_reason: 'end_turn' } },
+    );
+    const state1 = await getSubagentsDirState(jsonlPath);
+    expect(state1?.count).toBe(1);
+    expect(state1?.totalSize).toBeGreaterThan(0);
+
+    writeAgent(subagentsDir, 's2',
+      { agentId: 's2', message: { role: 'assistant', stop_reason: 'end_turn' } },
+    );
+    const state2 = await getSubagentsDirState(jsonlPath);
+    expect(state2?.count).toBe(2);
+    expect(subagentsDirStateEqual(state1, state2)).toBe(false);
+  });
+
+  it('subagentsDirStateEqual treats two nulls as equal but null vs state as not equal', () => {
+    expect(subagentsDirStateEqual(null, null)).toBe(true);
+    expect(subagentsDirStateEqual(null, { count: 0, totalMtimeMs: 0, totalSize: 0 })).toBe(false);
+    expect(subagentsDirStateEqual({ count: 1, totalMtimeMs: 100, totalSize: 50 }, { count: 1, totalMtimeMs: 100, totalSize: 50 })).toBe(true);
   });
 });

--- a/tests/parsers/transcript.test.ts
+++ b/tests/parsers/transcript.test.ts
@@ -7,6 +7,12 @@ import { parseTranscript, extractToolTarget, normalizeTodoStatus, _clearTranscri
 const FIXTURES = join(import.meta.dirname, '..', 'fixtures');
 
 describe('parseTranscript', () => {
+  // Without this, fixtures with stable mtimes can cache-hit across cases —
+  // a previous test populates the cache, the next one runs `parseTranscript`
+  // on the same fixture, sees a fresh mtime and returns the cached result
+  // without exercising the parse path under test.
+  beforeEach(() => { _clearTranscriptCache(); });
+
   it('parses basic tool use and result', async () => {
     const result = await parseTranscript(join(FIXTURES, 'transcript-basic.jsonl'));
     expect(result.tools).toHaveLength(1);
@@ -88,9 +94,6 @@ describe('parseTranscript', () => {
     const line2 = JSON.stringify({ timestamp: '2026-04-08T10:00:01Z', message: { content: [{ type: 'tool_result', tool_use_id: 'tu1', content: 'ok' }] } });
     const line3 = JSON.stringify({ timestamp: '2026-04-08T10:00:02Z', message: { content: [{ type: 'tool_use', id: 'tu2', name: 'TodoWrite', input: { todos: [{ id: 'x', content: 'Renamed text', status: 'pending' }] } }] } });
     const line4 = JSON.stringify({ timestamp: '2026-04-08T10:00:03Z', message: { content: [{ type: 'tool_result', tool_use_id: 'tu2', content: 'ok' }] } });
-    const { writeFileSync, mkdtempSync, rmSync } = await import('node:fs');
-    const { join } = await import('node:path');
-    const { tmpdir } = await import('node:os');
     const dir = mkdtempSync(join(tmpdir(), 'lumira-test-'));
     const p = join(dir, 'test.jsonl');
     writeFileSync(p, [line1, line2, line3, line4].join('\n') + '\n');
@@ -188,6 +191,29 @@ describe('parseTranscript + subagents/ dir integration', () => {
     const result = await parseTranscript(mainPath);
     expect(result.agents).toHaveLength(1);
     expect(result.agents[0].type).toBe('general-purpose');
+  });
+
+  it('still invalidates the cache when the main JSONL changes and the subagent dir does not exist', async () => {
+    // Both cached and current dir state are null; the cache hit must be
+    // gated only by the main-JSONL mtime, never by `null === null` on the
+    // dir fingerprint accidentally short-circuiting the freshness check.
+    const mainPath = writeMain('sess-no-subdir', [
+      { timestamp: '2026-05-07T18:00:00Z', message: { content: [{ type: 'tool_use', id: 'tu0', name: 'Bash', input: { command: 'ls' } }] } },
+    ]);
+    const first = await parseTranscript(mainPath);
+    expect(first.tools).toHaveLength(1);
+
+    // Push the file mtime back, then rewrite — this gives a NEW mtime
+    // distinct from the cached entry.
+    const past = (Date.now() - 5000) / 1000;
+    utimesSync(mainPath, past, past);
+    writeFileSync(mainPath, [
+      JSON.stringify({ timestamp: '2026-05-07T18:00:00Z', message: { content: [{ type: 'tool_use', id: 'tu0', name: 'Bash', input: { command: 'ls' } }] } }),
+      JSON.stringify({ timestamp: '2026-05-07T18:00:01Z', message: { content: [{ type: 'tool_use', id: 'tuX', name: 'Read', input: { file_path: '/x' } }] } }),
+    ].join('\n') + '\n');
+
+    const second = await parseTranscript(mainPath);
+    expect(second.tools).toHaveLength(2);
   });
 
   it('invalidates the cache when only the subagent dir changes', async () => {

--- a/tests/parsers/transcript.test.ts
+++ b/tests/parsers/transcript.test.ts
@@ -35,6 +35,21 @@ describe('parseTranscript', () => {
     expect(running?.type).toBe('feature-dev:code-reviewer');
     expect(running?.model).toBe('opus');
   });
+
+  it('does not downgrade a completed agent to running on duplicate tool_use re-emission', async () => {
+    // Claude Code occasionally re-emits a tool_use entry after the matching
+    // tool_result has already landed (observed when a subagent dispatch fails
+    // with "Agent type not found" and is retried). The parser must treat the
+    // first completion as authoritative — re-emitted tool_use entries with the
+    // same id should not flip status back to "running", which would leave a
+    // zombie ⚡N agents widget.
+    const result = await parseTranscript(join(FIXTURES, 'transcript-agent-zombie.jsonl'));
+    expect(result.agents).toHaveLength(1);
+    expect(result.agents[0].id).toBe('z1');
+    expect(result.agents[0].status).toBe('completed');
+    expect(result.tools.find(t => t.id === 'z1')?.status).toBe('completed');
+  });
+
   it('parses TaskCreate and TaskUpdate', async () => {
     const result = await parseTranscript(join(FIXTURES, 'transcript-todos.jsonl'));
     expect(result.todos).toHaveLength(2);

--- a/tests/parsers/transcript.test.ts
+++ b/tests/parsers/transcript.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from 'node:fs';
 import { join } from 'node:path';
-import { parseTranscript, extractToolTarget, normalizeTodoStatus } from '../../src/parsers/transcript.js';
+import { tmpdir } from 'node:os';
+import { parseTranscript, extractToolTarget, normalizeTodoStatus, _clearTranscriptCache } from '../../src/parsers/transcript.js';
 
 const FIXTURES = join(import.meta.dirname, '..', 'fixtures');
 
@@ -132,4 +134,87 @@ describe('normalizeTodoStatus', () => {
   it('normalizes completed/done', () => { expect(normalizeTodoStatus('completed')).toBe('completed'); expect(normalizeTodoStatus('done')).toBe('completed'); });
   it('normalizes in_progress variants', () => { expect(normalizeTodoStatus('in_progress')).toBe('in_progress'); expect(normalizeTodoStatus('running')).toBe('in_progress'); });
   it('defaults to pending', () => { expect(normalizeTodoStatus('whatever')).toBe('pending'); expect(normalizeTodoStatus(undefined)).toBe('pending'); });
+});
+
+describe('parseTranscript + subagents/ dir integration', () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    _clearTranscriptCache();
+    workDir = mkdtempSync(join(tmpdir(), 'lumira-transcript-int-'));
+  });
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  function writeMain(name: string, lines: object[]): string {
+    const p = join(workDir, `${name}.jsonl`);
+    writeFileSync(p, lines.map(l => JSON.stringify(l)).join('\n') + '\n');
+    return p;
+  }
+  function writeSubagent(jsonlPath: string, id: string, lastLine: object, meta?: object) {
+    const sessionId = jsonlPath.replace(/\.jsonl$/, '').split('/').pop()!;
+    const dir = join(workDir, sessionId, 'subagents');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `agent-${id}.jsonl`), JSON.stringify(lastLine) + '\n');
+    if (meta) writeFileSync(join(dir, `agent-${id}.meta.json`), JSON.stringify(meta));
+  }
+
+  it('overrides main-JSONL agents with subagent-dir results when the dir is populated', async () => {
+    // Main JSONL has an Agent dispatch with subagent_type=general-purpose
+    // and a matching tool_result (so the main-JSONL parser would mark it
+    // completed). The subagents/ dir for the same session has a richer
+    // record with a named type ("pepito") — that must win.
+    const mainPath = writeMain('sess-int', [
+      { timestamp: '2026-05-07T18:00:00Z', message: { content: [{ type: 'tool_use', id: 'tu1', name: 'Agent', input: { subagent_type: 'general-purpose', description: 'd' } }] } },
+      { timestamp: '2026-05-07T18:00:30Z', message: { content: [{ type: 'tool_result', tool_use_id: 'tu1', content: 'ok' }] } },
+    ]);
+    writeSubagent(mainPath, 'real',
+      { agentId: 'real', message: { role: 'assistant', stop_reason: 'end_turn' } },
+      { agentType: 'pepito', description: 'real description' },
+    );
+    const result = await parseTranscript(mainPath);
+    expect(result.agents).toHaveLength(1);
+    expect(result.agents[0].id).toBe('real');
+    expect(result.agents[0].type).toBe('pepito');
+  });
+
+  it('falls back to main-JSONL agents when the subagent dir is empty', async () => {
+    const mainPath = writeMain('sess-fallback', [
+      { timestamp: '2026-05-07T18:00:00Z', message: { content: [{ type: 'tool_use', id: 'tu2', name: 'Agent', input: { subagent_type: 'general-purpose', description: 'fallback' } }] } },
+    ]);
+    // create empty subagents/ dir to confirm "empty == no override"
+    mkdirSync(join(workDir, 'sess-fallback', 'subagents'), { recursive: true });
+    const result = await parseTranscript(mainPath);
+    expect(result.agents).toHaveLength(1);
+    expect(result.agents[0].type).toBe('general-purpose');
+  });
+
+  it('invalidates the cache when only the subagent dir changes', async () => {
+    // Cache key must include the dir's fingerprint — otherwise a quiet
+    // subagent transitioning to end_turn would be invisible until the main
+    // JSONL is also touched.
+    const mainPath = writeMain('sess-cache', [
+      { timestamp: '2026-05-07T18:00:00Z', message: { content: [{ type: 'tool_use', id: 'tu3', name: 'Bash', input: { command: 'ls' } }] } },
+    ]);
+    writeSubagent(mainPath, 'a',
+      { agentId: 'a', message: { role: 'assistant', stop_reason: 'tool_use' } },
+      { agentType: 'pepito' },
+    );
+    // Push the agent file's mtime back so the next stat result differs after
+    // we rewrite it (filesystems with second-resolution mtimes otherwise see
+    // both writes as the same timestamp).
+    const agentJsonl = join(workDir, 'sess-cache', 'subagents', 'agent-a.jsonl');
+    const past = (Date.now() - 5000) / 1000;
+    utimesSync(agentJsonl, past, past);
+
+    const first = await parseTranscript(mainPath);
+    expect(first.agents[0].status).toBe('running');
+
+    // Mutate ONLY the subagent file. The main JSONL is unchanged.
+    writeFileSync(agentJsonl, JSON.stringify({ agentId: 'a', message: { role: 'assistant', stop_reason: 'end_turn' } }) + '\n');
+
+    const second = await parseTranscript(mainPath);
+    expect(second.agents[0].status).toBe('completed');
+  });
 });

--- a/tests/render/line1.test.ts
+++ b/tests/render/line1.test.ts
@@ -142,4 +142,60 @@ describe('renderLine1', () => {
     const out = stripAnsi(renderLine1(makeCtx({ tokenSpeed: 142, config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, tokenSpeed: false } } }), c));
     expect(out).not.toContain('tok/s');
   });
+
+  describe('cubes (agent name) widget', () => {
+    const cube = NERD_ICONS.cubes;
+
+    function withAgents(agents: { id: string; type: string; status: 'running' | 'completed' | 'error' }[]): RenderContext {
+      return makeCtx({
+        transcript: {
+          ...EMPTY_TRANSCRIPT,
+          agents: agents.map(a => ({ ...a, startTime: new Date() })),
+        },
+      });
+    }
+
+    it('shows input.agentName when present (subagent session via --agent flag)', () => {
+      const out = stripAnsi(renderLine1(makeCtx({}, { agent: { name: 'pepito' } } as Partial<ClaudeCodeInput>), c));
+      expect(out).toContain(`${cube} pepito`);
+    });
+
+    it('shows the running named subagent type when input.agentName is empty and exactly one named is running', () => {
+      const out = stripAnsi(renderLine1(withAgents([{ id: 'a1', type: 'pepito', status: 'running' }]), c));
+      expect(out).toContain(`${cube} pepito`);
+    });
+
+    it('does not show the cube when only generic agents (general-purpose) are running', () => {
+      const out = stripAnsi(renderLine1(withAgents([{ id: 'a1', type: 'general-purpose', status: 'running' }]), c));
+      expect(out).not.toContain(cube);
+    });
+
+    it('does not show the cube when zero agents are running', () => {
+      const out = stripAnsi(renderLine1(withAgents([{ id: 'a1', type: 'pepito', status: 'completed' }]), c));
+      expect(out).not.toContain(cube);
+    });
+
+    it('does not show the cube when more than one named agent is running (ambiguous)', () => {
+      const out = stripAnsi(renderLine1(withAgents([
+        { id: 'a1', type: 'pepito', status: 'running' },
+        { id: 'a2', type: 'feature-dev:code-reviewer', status: 'running' },
+      ]), c));
+      expect(out).not.toContain(cube);
+    });
+
+    it('input.agentName takes priority over a running named subagent', () => {
+      const ctx = withAgents([{ id: 'a1', type: 'pepito', status: 'running' }]);
+      ctx.input = { ...ctx.input, agentName: 'jarvis' };
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out).toContain(`${cube} jarvis`);
+      expect(out).not.toContain('pepito');
+    });
+
+    it('hides the cube when display.agent is false even if a named subagent is running', () => {
+      const ctx = withAgents([{ id: 'a1', type: 'pepito', status: 'running' }]);
+      ctx.config = { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, agent: false } };
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out).not.toContain(cube);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Read Claude Code's per-subagent JSONLs in `~/.claude/projects/<slug>/<session>/subagents/` as the primary source for the live `⚡N agents` widget — surfaces background subagents whose parent `tool_use` stays buffered in the main JSONL.
- Detect three terminal states cleanly: normal completion (`stop_reason: end_turn`), user interrupt (`[Request interrupted by user…]` marker on the trailing line), and "still running" (anything else, no mtime grace).
- Fix a longstanding zombie-agent bug where Claude Code re-emits a `tool_use` after its own `tool_result` (failed dispatch retries), which left the `⚡N agents` widget stuck on indefinitely.
- Surface the running named subagent's type (e.g. `pepito`, `feature-dev:code-reviewer`) on line 1's cubes-icon widget. Generic dispatches (`general-purpose`/`unknown`) and multi-named-running cases stay collapsed under the line 3 count to avoid noise. Closes the workaround documented in anthropics/claude-code#14306.

## Test plan
- [x] 808 unit tests pass (~+50 new across parsers/render).
- [x] Live verification on a real session — pepito heartbeat shows `⬚ pepito` on line 1 and `⚡1 agent` on line 3 while running; both clear the moment the agent ends or is stopped.
- [x] Tested 1 / 3 / 5-pepito + general-purpose mixes; multi-named correctly suppresses the cube and falls back to `⚡N agents`.
- [x] Six rounds of cross-AI Opus review — final pass: `READY TO MERGE — no findings.`