### PR TITLE
fix(render): close powerline-line1 widget parity gap with classic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.2] - 2026-05-08
+
+### Fixed
+- **Powerline-line1 widget parity gap** — `display.linesChanged`, `.worktree`, `.agent`, `.sessionName`, and `.style` were all honored by classic line1 but silently dropped by the powerline render. Users with these toggles enabled in `~/.config/lumira/config.json` got no rendering in powerline mode. Added the 5 segments with priorities 18–24 (drop after `tokenSpeed` when narrow; `style` drops first), palette assignments matching their semantic category (`linesChanged` and `sessionName` on `branchCleanBg`, `worktree` on `dirBg`, `agent` on `taskBg`). `linesChanged` renders as a single `+N -M` segment in powerline (vs classic's two-color spans, which the segment model can't express).
+
 ## [1.2.1] - 2026-05-07
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lumira",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lumira",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "bin": {
         "lumira": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Real-time statusline HUD for Claude Code and Qwen Code — context bar, burn rate, themes, powerline, zero deps.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/render/powerline-line1.ts
+++ b/src/render/powerline-line1.ts
@@ -4,6 +4,7 @@ import { truncField } from './text.js';
 import { getActiveTodo } from './shared.js';
 import { formatDuration } from '../utils/format.js';
 import { hyperlink } from './hyperlink.js';
+import { isNamedAgentType } from '../parsers/subagents.js';
 import {
   renderPowerline,
   resolveStyle,
@@ -21,12 +22,20 @@ import {
 
 /**
  * Build the line1 segment list for the powerline renderer. Segment priorities
- * control which get dropped first when the terminal is narrow:
- *   model:   100  (always kept)
- *   branch:   80
- *   dir:      60
- *   task:     40
- *   version:  20  (dropped first)
+ * control which get dropped first when the terminal is narrow (lower = drops first):
+ *   model:        100  (always kept)
+ *   branch:        80
+ *   dir:           60
+ *   task:          40
+ *   duration:      35
+ *   memory:        30
+ *   tokenSpeed:    25
+ *   linesChanged:  24
+ *   worktree:      23
+ *   agent:         22
+ *   sessionName:   21
+ *   version:       20
+ *   style:         18  (dropped first)
  */
 function buildSegments(ctx: RenderContext, palette: PowerlinePalette): PowerlineSegment[] {
   const { input, git, transcript, config: { display }, icons, memory, tokenSpeed } = ctx;
@@ -116,6 +125,71 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette): Powerline
       bg: palette.branchCleanBg,
       fg: palette.fg,
       priority: 25,
+    });
+  }
+
+  // Lines changed — emitted as a single segment in powerline (classic uses
+  // two-color spans inside one cell, which the segment model can't express).
+  // Signed numbers carry the semantic without needing per-token color.
+  if (display.linesChanged) {
+    const added = input.linesAdded;
+    const removed = input.linesRemoved;
+    if (added > 0 || removed > 0) {
+      segments.push({
+        text: `+${added} -${removed}`,
+        bg: palette.branchCleanBg,
+        fg: palette.fg,
+        priority: 24,
+      });
+    }
+  }
+
+  if (display.worktree && input.worktreeName) {
+    segments.push({
+      text: truncField(input.worktreeName, 15),
+      icon: icons.tree,
+      bg: palette.dirBg,
+      fg: palette.fg,
+      priority: 23,
+    });
+  }
+
+  // Mirrors classic line1: prefer the explicit input.agentName (subagent
+  // session render), else show the cubes badge when exactly one *named*
+  // subagent is running on the parent. Anonymous agents stay collapsed
+  // under the line 3 ⚡N agents widget to avoid noise.
+  if (display.agent) {
+    let agentName = input.agentName;
+    if (!agentName) {
+      const named = transcript.agents.filter(a => a.status === 'running' && isNamedAgentType(a.type));
+      if (named.length === 1) agentName = named[0].type;
+    }
+    if (agentName) {
+      segments.push({
+        text: truncField(agentName, 15),
+        icon: icons.cubes,
+        bg: palette.taskBg,
+        fg: palette.fg,
+        priority: 22,
+      });
+    }
+  }
+
+  if (display.sessionName && input.sessionName) {
+    segments.push({
+      text: truncField(input.sessionName, 20),
+      bg: palette.branchCleanBg,
+      fg: palette.fg,
+      priority: 21,
+    });
+  }
+
+  if (display.style && input.outputStyle) {
+    segments.push({
+      text: input.outputStyle,
+      bg: palette.branchCleanBg,
+      fg: palette.fg,
+      priority: 18,
     });
   }
 

--- a/tests/render/powerline-line1.test.ts
+++ b/tests/render/powerline-line1.test.ts
@@ -434,6 +434,179 @@ describe('renderPowerlineLine1', () => {
     });
   });
 
+  // ── Parity widgets (linesChanged / worktree / agent / sessionName / style)
+  // Classic line1 has rendered these for several releases; powerline-line1
+  // silently dropped them until v1.2.2. Tests pin both shapes (toggle on +
+  // value present → segment appears; toggle off → not).
+
+  describe('linesChanged segment', () => {
+    it('renders +N -M when added or removed > 0', () => {
+      const ctx = makeCtx({
+        input: {
+          ...normalize({
+            model: 'Claude',
+            session_id: 't',
+            context_window: { used_percentage: 10, remaining_percentage: 90 },
+            cost: { total_cost_usd: 0, total_duration_ms: 0, total_lines_added: 16, total_lines_removed: 4 },
+          }),
+        },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).toContain('+16 -4');
+    });
+
+    it('renders segment when only lines are removed (added = 0)', () => {
+      const ctx = makeCtx({
+        input: {
+          ...normalize({
+            model: 'Claude',
+            session_id: 't',
+            context_window: { used_percentage: 10, remaining_percentage: 90 },
+            cost: { total_cost_usd: 0, total_duration_ms: 0, total_lines_added: 0, total_lines_removed: 7 },
+          }),
+        },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).toContain('+0 -7');
+    });
+
+    it('omits segment when both added and removed are 0', () => {
+      const ctx = makeCtx({
+        input: {
+          ...normalize({
+            model: 'Claude',
+            session_id: 't',
+            context_window: { used_percentage: 10, remaining_percentage: 90 },
+            cost: { total_cost_usd: 0, total_duration_ms: 0, total_lines_added: 0, total_lines_removed: 0 },
+          }),
+        },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).not.toMatch(/\+0 -0/);
+    });
+
+    it('omits segment when display.linesChanged is false', () => {
+      const ctx = makeCtx({
+        input: {
+          ...normalize({
+            model: 'Claude',
+            session_id: 't',
+            context_window: { used_percentage: 10, remaining_percentage: 90 },
+            cost: { total_cost_usd: 0, total_duration_ms: 0, total_lines_added: 99, total_lines_removed: 99 },
+          }),
+        },
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, linesChanged: false } },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).not.toContain('+99');
+    });
+  });
+
+  describe('worktree segment', () => {
+    it('renders worktree name when present', () => {
+      const ctx = makeCtx({
+        input: { ...normalize({ model: 'Claude', session_id: 't', context_window: { used_percentage: 10, remaining_percentage: 90 }, cost: { total_cost_usd: 0, total_duration_ms: 0 }, worktree: { name: 'feat-x' } }) },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).toContain('feat-x');
+    });
+
+    it('omits segment when worktreeName is undefined', () => {
+      const ctx = makeCtx();
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).not.toContain('feat-');
+    });
+
+    it('omits segment when display.worktree is false', () => {
+      const ctx = makeCtx({
+        input: { ...normalize({ model: 'Claude', session_id: 't', context_window: { used_percentage: 10, remaining_percentage: 90 }, cost: { total_cost_usd: 0, total_duration_ms: 0 }, worktree: { name: 'feat-x' } }) },
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, worktree: false } },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).not.toContain('feat-x');
+    });
+  });
+
+  describe('agent segment', () => {
+    it('renders explicit input.agentName', () => {
+      const ctx = makeCtx({
+        input: { ...normalize({ model: 'Claude', session_id: 't', context_window: { used_percentage: 10, remaining_percentage: 90 }, cost: { total_cost_usd: 0, total_duration_ms: 0 }, agent: { name: 'code-reviewer' } }) },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).toContain('code-reviewer');
+    });
+
+    it('renders single named running subagent from transcript', () => {
+      const ctx = makeCtx({
+        transcript: { ...EMPTY_TRANSCRIPT, agents: [{ id: 'a1', type: 'code-reviewer', status: 'running' }] },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).toContain('code-reviewer');
+    });
+
+    it('omits segment when multiple named agents are running (collapses to line 3)', () => {
+      const ctx = makeCtx({
+        transcript: {
+          ...EMPTY_TRANSCRIPT,
+          agents: [
+            { id: 'a1', type: 'code-reviewer', status: 'running' },
+            { id: 'a2', type: 'security-auditor', status: 'running' },
+          ],
+        },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).not.toContain('code-reviewer');
+      expect(out).not.toContain('security-auditor');
+    });
+
+    it('omits segment when display.agent is false', () => {
+      const ctx = makeCtx({
+        input: { ...normalize({ model: 'Claude', session_id: 't', context_window: { used_percentage: 10, remaining_percentage: 90 }, cost: { total_cost_usd: 0, total_duration_ms: 0 }, agent: { name: 'code-reviewer' } }) },
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, agent: false } },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).not.toContain('code-reviewer');
+    });
+  });
+
+  describe('sessionName segment', () => {
+    it('renders session name when present', () => {
+      const ctx = makeCtx({
+        input: { ...normalize({ model: 'Claude', session_id: 't', context_window: { used_percentage: 10, remaining_percentage: 90 }, cost: { total_cost_usd: 0, total_duration_ms: 0 }, session_name: 'main-flow' }) },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).toContain('main-flow');
+    });
+
+    it('omits segment when display.sessionName is false', () => {
+      const ctx = makeCtx({
+        input: { ...normalize({ model: 'Claude', session_id: 't', context_window: { used_percentage: 10, remaining_percentage: 90 }, cost: { total_cost_usd: 0, total_duration_ms: 0 }, session_name: 'main-flow' }) },
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, sessionName: false } },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).not.toContain('main-flow');
+    });
+  });
+
+  describe('style segment', () => {
+    it('renders output style name when present', () => {
+      const ctx = makeCtx({
+        input: { ...normalize({ model: 'Claude', session_id: 't', context_window: { used_percentage: 10, remaining_percentage: 90 }, cost: { total_cost_usd: 0, total_duration_ms: 0 }, output_style: { name: 'jarvis' } }) },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).toContain('jarvis');
+    });
+
+    it('omits segment when display.style is false', () => {
+      const ctx = makeCtx({
+        input: { ...normalize({ model: 'Claude', session_id: 't', context_window: { used_percentage: 10, remaining_percentage: 90 }, cost: { total_cost_usd: 0, total_duration_ms: 0 }, output_style: { name: 'jarvis' } }) },
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, style: false } },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).not.toContain('jarvis');
+    });
+  });
+
   // ── Segment priorities / eviction ───────────────────────────────────
 
   describe('segment priority ordering', () => {
@@ -559,6 +732,30 @@ describe('renderPowerlineLine1', () => {
       const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
       expect(out).toContain('55 tok/s');
       expect(out).toContain('60% mem');
+    });
+
+    it('renders all five parity widgets together (linesChanged + worktree + agent + sessionName + style)', () => {
+      const ctx = makeCtx({
+        cols: 250,
+        input: {
+          ...normalize({
+            model: 'Claude',
+            session_id: 't',
+            session_name: 'main-flow',
+            output_style: { name: 'jarvis' },
+            agent: { name: 'code-reviewer' },
+            worktree: { name: 'feat-x' },
+            context_window: { used_percentage: 10, remaining_percentage: 90 },
+            cost: { total_cost_usd: 0, total_duration_ms: 0, total_lines_added: 21, total_lines_removed: 14 },
+          }),
+        },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).toContain('+21 -14');
+      expect(out).toContain('feat-x');
+      expect(out).toContain('code-reviewer');
+      expect(out).toContain('main-flow');
+      expect(out).toContain('jarvis');
     });
   });
 });


### PR DESCRIPTION
## Summary

`display.linesChanged`, `.worktree`, `.agent`, `.sessionName`, and `.style` were honored by classic `line1.ts` but silently dropped by the powerline render. Users with these toggles set to `true` in `~/.config/lumira/config.json` got no rendering in powerline mode — a config-honored bug, not a missing feature.

Adds the 5 segments to `powerline-line1.ts` with priorities 18–24 (drop after `tokenSpeed` when narrow; `style` at 18 drops first). Matches classic semantics exactly for each widget (gating, value sources, truncation widths).

## Visual choices

- `linesChanged` renders as a single `+N -M` segment in powerline (the segment model can't express classic's two-color `+N` green / `-N` red spans). Single bg, signed numbers carry the semantic.
- Palettes match semantic categories: `linesChanged`/`sessionName`/`style` on `branchCleanBg`, `worktree` on `dirBg`, `agent` on `taskBg`.
- `agent` segment mirrors classic's logic: explicit `input.agentName` wins, else fall back to the single named running subagent when exactly one is present (anonymous agents stay collapsed under the line 3 agents widget).

## Tests

- 15 new tests in `powerline-line1.test.ts` covering toggle on/off, value present/absent, and edge cases (delete-only `linesChanged`, multiple-named-agents collapse, missing `worktree`/`sessionName`/`outputStyle`).
- Combined-render test fires all 5 parity widgets at once.
- Full suite: **826/826 passing**.

## Verification

- Build clean (tsc)
- Lint clean (tsc --noEmit)
- Bundle: 419 KB / 440 KB ceiling
- Manual visual comparison: classic and powerline render the same widget set on lines 1–3 with realistic input (tools, todos, rate-limits, agents).

## Code review

Two Opus review passes (cross-AI, in-session):
- Pass 1: 0 HIGH, 0 MEDIUM, 2 LOW — both LOW addressed (stale docstring, missing delete-only test).
- Pass 2 (extensive): 0 HIGH, 0 MEDIUM, 4 LOW + INFO bundle. Only L-1 (combined-segments test) was actionable and is included. Other LOWs out-of-scope (sanitization integration test belongs to `normalize.test.ts`; palette aesthetic documented in CHANGELOG; boundary tests covered by `truncField` unit tests).

## Release

Targets **v1.2.2** as a patch — fixes config toggles that were silently ignored in powerline mode. Backward-compatible: `balanced` and `minimal` presets continue to hide these toggles; only users on `full` preset (or explicit `display.*: true`) will see new segments appear after upgrade.

## Test plan

- [x] Build / lint / test green locally
- [x] Bundle size under ceiling
- [x] Manual render comparison (classic vs powerline, full preset, every widget visible in both)
- [ ] CI checks green on PR