### PR TITLE
fix(render): cache hit rate color escalation in powerline mode

### DIFF
--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -119,17 +119,30 @@ export function getPaceColor(delta: number): ColorName {
 }
 
 /**
- * Color for the cache hit rate widget. Rendered only when below the alarm
- * threshold (≥90% is hidden as healthy steady-state), so the tiers reflect
- * degrees of "something is wrong" rather than degrees of healthy.
- *   70–89%: yellow (mild concern — TTL expiry, fresh content arrived)
- *   40–69%: orange (caching not engaging)
- *    <40%:  blinkRed (cache likely broken)
+ * Cache hit rate severity tier — the single source of truth for the cache
+ * widget's threshold boundaries. Rendered only when below the alarm threshold
+ * (≥90% is hidden as healthy steady-state), so the tiers reflect degrees of
+ * "something is wrong" rather than degrees of healthy.
+ *   70–89%: mild     (TTL expiry, fresh content arrived — yellow / versionBg)
+ *   40–69%: moderate (caching not engaging — orange / taskBg)
+ *    <40%:  critical (cache likely broken — blinkRed / branchDirtyBg)
+ * Both classic-mode fg (getCacheHitColor) and powerline-mode bg (the helper
+ * in powerline-line2.ts) consume this so the boundaries cannot drift apart.
  */
+export type CacheHitTier = 'mild' | 'moderate' | 'critical';
+
+export function getCacheHitTier(pct: number): CacheHitTier {
+  if (pct >= 70) return 'mild';
+  if (pct >= 40) return 'moderate';
+  return 'critical';
+}
+
 export function getCacheHitColor(pct: number): ColorName {
-  if (pct >= 70) return 'yellow';
-  if (pct >= 40) return 'orange';
-  return 'blinkRed';
+  switch (getCacheHitTier(pct)) {
+    case 'mild': return 'yellow';
+    case 'moderate': return 'orange';
+    case 'critical': return 'blinkRed';
+  }
 }
 
 export function getQuotaColor(pct: number): ColorName {

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -13,10 +13,22 @@ import { computePaceDelta, formatPaceDelta } from './pace.js';
 import type { RenderContext } from '../types.js';
 import {
   type PowerlinePalette,
+  type RGB,
   derivePowerlinePalette,
   DEFAULT_POWERLINE_PALETTE,
   type ThemePalette,
 } from '../themes.js';
+
+// Maps cache hit rate to a powerline bg slot, mirroring the 3-tier thresholds
+// from getCacheHitColor in colors.ts. Yellow tier (>=70) keeps versionBg as
+// the visual baseline since the segment is already inside the <90% alarm-mode
+// gate. Orange (>=40) and blinkRed (<40) escalate to the warm/critical slots
+// already used by cost and >=85% rate-limits respectively.
+function getCacheHitBg(rate: number, palette: PowerlinePalette): RGB {
+  if (rate >= 70) return palette.versionBg;
+  if (rate >= 40) return palette.taskBg;
+  return palette.branchDirtyBg;
+}
 
 // Line 2 powerline palette — reuses PowerlinePalette bg slots with semantic remapping:
 //   modelBg    → context bar segment
@@ -122,8 +134,10 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
   }
 
   // Cache metrics (hit rate) — alarm-mode: only when <90%. See line2.ts for why.
+  // Bg escalates with degradation: versionBg (70-89), taskBg (40-69), branchDirtyBg (<40).
   if (display.cacheMetrics && input.cacheHitRate != null && input.cacheHitRate < 90) {
-    segments.push({ text: `${input.cacheHitRate}%${icons.lightning}`, bg: palette.versionBg, fg: palette.fg, priority: 50 });
+    const bg = getCacheHitBg(input.cacheHitRate, palette);
+    segments.push({ text: `${input.cacheHitRate}%${icons.lightning}`, bg, fg: palette.fg, priority: 50 });
   }
 
   // MCP servers

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -7,7 +7,7 @@ import {
 import { QUOTA_CRITICAL } from '../types.js';
 import { buildContextBar, formatQwenMetrics } from './shared.js';
 import { formatTokens, formatCost, formatBurnRate } from '../utils/format.js';
-import { detectColorMode, getPaceColor, type ColorMode, type Colors } from './colors.js';
+import { detectColorMode, getCacheHitTier, getPaceColor, type ColorMode, type Colors } from './colors.js';
 import { getConfigHealth } from '../parsers/config-health.js';
 import { computePaceDelta, formatPaceDelta } from './pace.js';
 import type { RenderContext } from '../types.js';
@@ -19,15 +19,16 @@ import {
   type ThemePalette,
 } from '../themes.js';
 
-// Maps cache hit rate to a powerline bg slot, mirroring the 3-tier thresholds
-// from getCacheHitColor in colors.ts. Yellow tier (>=70) keeps versionBg as
-// the visual baseline since the segment is already inside the <90% alarm-mode
-// gate. Orange (>=40) and blinkRed (<40) escalate to the warm/critical slots
-// already used by cost and >=85% rate-limits respectively.
+// Maps the cache severity tier (SSOT in colors.ts) to a powerline bg slot.
+// `mild` keeps versionBg as the visual baseline since the segment is already
+// inside the <90% alarm-mode gate; `moderate` and `critical` escalate to the
+// warm/critical slots already used by cost and >=85% rate-limits respectively.
 function getCacheHitBg(rate: number, palette: PowerlinePalette): RGB {
-  if (rate >= 70) return palette.versionBg;
-  if (rate >= 40) return palette.taskBg;
-  return palette.branchDirtyBg;
+  switch (getCacheHitTier(rate)) {
+    case 'mild': return palette.versionBg;
+    case 'moderate': return palette.taskBg;
+    case 'critical': return palette.branchDirtyBg;
+  }
 }
 
 // Line 2 powerline palette — reuses PowerlinePalette bg slots with semantic remapping:

--- a/tests/render/colors.test.ts
+++ b/tests/render/colors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { createColors, stripAnsi, detectColorMode, getContextColor, getQuotaColor, getPaceColor, getCacheHitColor } from '../../src/render/colors.js';
+import { createColors, stripAnsi, detectColorMode, getContextColor, getQuotaColor, getPaceColor, getCacheHitColor, getCacheHitTier } from '../../src/render/colors.js';
 
 describe('stripAnsi', () => {
   it('removes ANSI escape codes', () => {
@@ -128,9 +128,23 @@ describe('getPaceColor', () => {
   it('returns blinkRed for very high delta', () => { expect(getPaceColor(80)).toBe('blinkRed'); });
 });
 
+describe('getCacheHitTier', () => {
+  // SSOT for cache severity thresholds — both getCacheHitColor (classic fg)
+  // and the powerline bg mapper consume this. Boundary tests pin both edges
+  // of every tier so a future threshold tweak fails loudly.
+  it('returns mild at 89% (just below alarm gate)', () => { expect(getCacheHitTier(89)).toBe('mild'); });
+  it('returns mild at 70% (lower mild boundary)', () => { expect(getCacheHitTier(70)).toBe('mild'); });
+  it('returns moderate at 69% (upper moderate boundary)', () => { expect(getCacheHitTier(69)).toBe('moderate'); });
+  it('returns moderate at 40% (lower moderate boundary)', () => { expect(getCacheHitTier(40)).toBe('moderate'); });
+  it('returns critical at 39% (upper critical boundary)', () => { expect(getCacheHitTier(39)).toBe('critical'); });
+  it('returns critical at 0% (cache fully broken)', () => { expect(getCacheHitTier(0)).toBe('critical'); });
+});
+
 describe('getCacheHitColor', () => {
   // Alarm-mode tiers: ≥90% is hidden by the renderer entirely; the colors below
   // describe degrees of "cache is degrading" for the visible-warning range.
+  // The threshold logic itself is pinned by getCacheHitTier above; this suite
+  // verifies the tier→ColorName mapping has not regressed.
   it('returns yellow at 89% (mild concern, just below alarm threshold)', () => { expect(getCacheHitColor(89)).toBe('yellow'); });
   it('returns yellow at 70% (lower yellow boundary)', () => { expect(getCacheHitColor(70)).toBe('yellow'); });
   it('returns orange at 69% (upper orange boundary)', () => { expect(getCacheHitColor(69)).toBe('orange'); });

--- a/tests/render/powerline-line2.test.ts
+++ b/tests/render/powerline-line2.test.ts
@@ -137,10 +137,14 @@ describe('renderPowerlineLine2', () => {
         input: patchedInput,
         config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, cacheMetrics: true } },
       });
-      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      const raw = renderPowerlineLine2(ctx, 'truecolor', null, c);
+      const out = stripAnsi(raw);
       // New format: N%⚡ (no 'cache' prefix)
       expect(out).toContain('75%');
       expect(out).not.toContain('cache 75%');
+      // Lock yellow-tier bg: 75% sits in the [70, 90) range and must keep
+      // DEFAULT_POWERLINE_PALETTE.versionBg as its background, matching pre-escalation behavior.
+      expect(raw).toContain('\x1b[48;2;64;64;72m');
     });
 
     it('burnRate segment appears next to cost when display.burnRate true', () => {
@@ -196,6 +200,72 @@ describe('renderPowerlineLine2', () => {
       const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
       // delta = 60 - 40 = +20%
       expect(out).toContain('+20%');
+    });
+  });
+
+  describe('cache color escalation', () => {
+    // DEFAULT_POWERLINE_PALETTE values (theme=null path).
+    // The escape format is \x1b[48;2;R;G;Bm — produced by powerline.ts:61-62.
+    const bg = (rgb: { r: number; g: number; b: number }) => `\x1b[48;2;${rgb.r};${rgb.g};${rgb.b}m`;
+    const VERSION_BG = { r: 64, g: 64, b: 72 };
+    const TASK_BG = { r: 128, g: 96, b: 24 };
+    const BRANCH_DIRTY_BG = { r: 160, g: 40, b: 40 };
+
+    function cacheCtx(rate: number) {
+      const base = makeCtx();
+      // Disable every other display toggle so the only bg escape in the
+      // output belongs to the cache segment. Otherwise `cost` (taskBg) and
+      // `mcp` (taskBg) would make orange-tier assertions pass spuriously.
+      return makeCtx({
+        input: { ...base.input, cacheHitRate: rate },
+        config: {
+          ...DEFAULT_CONFIG,
+          display: {
+            ...DEFAULT_DISPLAY,
+            cacheMetrics: true,
+            contextBar: false,
+            contextTokens: false,
+            cost: false,
+            burnRate: false,
+            tokens: false,
+            rateLimits: false,
+            paceDelta: false,
+            mcp: false,
+            vim: false,
+            effort: false,
+          },
+        },
+      });
+    }
+
+    it('yellow tier lower boundary (70%) renders with versionBg', () => {
+      const raw = renderPowerlineLine2(cacheCtx(70), 'truecolor', null, c);
+      expect(raw).toContain(bg(VERSION_BG));
+      expect(stripAnsi(raw)).toContain('70%');
+    });
+
+    it('orange tier upper boundary (69%) escalates to taskBg', () => {
+      const raw = renderPowerlineLine2(cacheCtx(69), 'truecolor', null, c);
+      expect(raw).toContain(bg(TASK_BG));
+      expect(stripAnsi(raw)).toContain('69%');
+    });
+
+    it('orange tier lower boundary (40%) renders with taskBg', () => {
+      const raw = renderPowerlineLine2(cacheCtx(40), 'truecolor', null, c);
+      expect(raw).toContain(bg(TASK_BG));
+      expect(stripAnsi(raw)).toContain('40%');
+    });
+
+    it('blinkRed tier upper boundary (39%) escalates to branchDirtyBg', () => {
+      const raw = renderPowerlineLine2(cacheCtx(39), 'truecolor', null, c);
+      expect(raw).toContain(bg(BRANCH_DIRTY_BG));
+      expect(stripAnsi(raw)).toContain('39%');
+    });
+
+    it('blinkRed tier deep (30%) renders with branchDirtyBg', () => {
+      const raw = renderPowerlineLine2(cacheCtx(30), 'truecolor', null, c);
+      expect(raw).toContain(bg(BRANCH_DIRTY_BG));
+      expect(stripAnsi(raw)).toContain('30%');
     });
   });
 


### PR DESCRIPTION
## Summary

- Powerline cache segment used `palette.versionBg` unconditionally, so a degraded 39% reading and a still-healthy 85% one looked identical — the urgency signal classic mode communicates via `getCacheHitColor` on fg was absent.
- Maps the same 3-tier thresholds to powerline bg slots: `mild` keeps `versionBg` (baseline; the segment is already inside the <90% alarm-mode gate), `moderate` escalates to `taskBg`, `critical` to `branchDirtyBg`. Mirrors the pattern already used by rate-limits at `powerline-line2.ts:73-77`.
- Extracted `getCacheHitTier()` in `colors.ts` as the single source of truth for the boundaries so the classic-mode (`getCacheHitColor`) and powerline-mode bg mappers cannot drift apart — that drift is what produced #120 in the first place.

## Files

- `src/render/colors.ts` — added `CacheHitTier` type + `getCacheHitTier()`; refactored `getCacheHitColor` to consume it
- `src/render/powerline-line2.ts` — added `getCacheHitBg()` helper consuming the tier, wired into the cache segment
- `tests/render/colors.test.ts` — 6 boundary tests pinning every tier edge
- `tests/render/powerline-line2.test.ts` — 5 new escalation tests (70/69/40/39/30) + updated the existing 75% test to lock in the yellow-tier `versionBg`

## Test plan

- [x] `npm test` → 837 passing (was 831, +6 new tier tests)
- [x] `npm run lint` → typecheck clean
- [x] Red phase confirmed before implementation: 4 failing tests at 69/40/39/30 with the expected bg-escape mismatch
- [x] Tier boundaries pinned at both edges (70/69, 40/39) in `colors.test.ts`
- [x] Powerline tests run with all other display toggles disabled so `taskBg` from `cost`/`mcp` segments cannot mask spurious passes
- [x] Verified themed palettes (all 7) provide distinct RGB triples for `versionBg`, `taskBg`, `branchDirtyBg` — no tier-collapse risk

Closes #120