### PR TITLE
chore(release): v1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.3] - 2026-05-13
+
+### Fixed
+- **Powerline cache hit rate now escalates color with severity** — the cache segment rendered with `palette.versionBg` regardless of urgency, so a degraded 39% reading looked identical to a still-healthy 85% one. Classic mode already escalated via `getCacheHitColor` on the foreground; powerline now does the same on the background: `mild` keeps `versionBg` (the segment already sits inside the <90% alarm-mode gate), `moderate` (40–69%) escalates to `taskBg`, `critical` (<40%) to `branchDirtyBg`. Mirrors the rate-limit escalation pattern at `powerline-line2.ts:73-77`. (#124, closes #120)
+
+### Changed
+- **Cache hit threshold logic lifted into a shared SSOT** — extracted `getCacheHitTier()` in `colors.ts` returning `'mild' | 'moderate' | 'critical'`. Both `getCacheHitColor` (classic fg) and the new powerline bg mapper consume it, eliminating the duplicated 70/40 boundaries that produced #120 in the first place. TypeScript exhaustiveness on both switches catches future tier extensions at compile time.
+
 ## [1.2.2] - 2026-05-08
 
 ### Fixed
@@ -421,7 +429,9 @@ First stable release. API is now considered stable under SemVer.
 - GSD session IDs sanitized against path traversal
 - `execFile` used instead of `exec` to prevent shell injection (except terminal width detection where shell redirect is required with procfs-sourced paths)
 
-[Unreleased]: https://github.com/cativo23/lumira/compare/v1.2.1...HEAD
+[Unreleased]: https://github.com/cativo23/lumira/compare/v1.2.3...HEAD
+[1.2.3]: https://github.com/cativo23/lumira/compare/v1.2.2...v1.2.3
+[1.2.2]: https://github.com/cativo23/lumira/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/cativo23/lumira/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/cativo23/lumira/compare/v1.1.2...v1.2.0
 [1.1.2]: https://github.com/cativo23/lumira/compare/v1.1.0...v1.1.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lumira",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lumira",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "bin": {
         "lumira": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Real-time statusline HUD for Claude Code and Qwen Code — context bar, burn rate, themes, powerline, zero deps.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Cuts v1.2.3, a patch release containing the powerline cache color escalation fix (#124) plus the underlying threshold-SSOT refactor.

## Includes

- **#124 / closes #120** — powerline cache segment now escalates background through 3 tiers (`versionBg` → `taskBg` → `branchDirtyBg`) as cache hit rate degrades, matching the urgency signal classic mode communicates via fg.
- **Refactor** — `getCacheHitTier()` extracted as the single source of truth for the threshold boundaries; consumed by both classic-mode `getCacheHitColor` and powerline-mode `getCacheHitBg` so they cannot drift apart again.

## Files

- `package.json` / `package-lock.json` — version 1.2.2 → 1.2.3
- `CHANGELOG.md` — new `## [1.2.3]` entry, plus backfilled the `[1.2.2]` link ref that v1.2.2 didn't add

## Release flow

Once merged, tag `v1.2.3` against the merge commit and push the tag — `release.yml` fires on `push: tags: [v*]`, runs the CI gate against the tagged SHA, and publishes to npm + creates the GitHub Release.