### PR TITLE
feat(render): 7d quota projection warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **7d quota projection warning** — the 7d rate-limit segment now extrapolates the current burn rate and appends a warning when the quota would be hit before the window resets: `⚠ ~24h`, `⚠ ~2d`, `⚠ Tue`, or `🔥 ~8h` (critical icon under 12h). Renders in both classic and powerline modes; coexists with the existing reset countdown (e.g. `75%(7d) 144h00m 🔥 ~8h`). Default-on; off in the `minimal` preset. Gated by `display.quotaProjection`. Different from pace delta: pace looks at the 5h window's actual vs proportional burn; projection looks at the 7d window's exhaustion ETA. New module `src/render/quota-projection.ts` exposes `computeQuotaProjection` and `formatProjectionWarning` as a window-agnostic helper with an injectable `minElapsedSec` floor — the 7d caller pins it to 3600 (1h) so early-session bursts don't trigger projections the steady-state rate won't sustain. Weekday names use `'en-US'` locale to keep snapshots reproducible. Closes #118.
+
 ## [1.2.3] - 2026-05-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Inspired by [claude-hud](https://github.com/jarrodwatts/claude-hud); takes a dif
 - **Git status** — branch + staged/modified/untracked counts, 5s TTL cache. Branch turns red on dirty repos in powerline mode.
 - **Rate limits** — 5h/7d usage as a battery glyph (Nerd Font level fill, or 🔋/🪫 in emoji mode) with color tier and reset countdown. Threshold-gated at 50% to stay invisible while you have margin.
 - **Pace delta** — `usedPct − elapsedPct` of the 5h window. Turtle when behind pace (healthy), car with time-to-exhaustion when ahead. Color escalates green → yellow → orange → blinkRed. Toggle independently via `display.paceDelta`.
+- **7d quota projection** — when the current burn rate would exhaust the 7d quota before the window resets, the 7d segment grows a warning: `⚠ ~24h`, `⚠ ~2d`, `⚠ Tue`, or `🔥 ~8h` (critical icon under 12h). Default on. Toggle via `display.quotaProjection`; off in the `minimal` preset. Different from pace delta — pace looks backwards at the 5h window's actual vs proportional burn, projection looks forwards at the 7d window's exhaustion ETA.
 - **Active agents** — live count of running subagents (`⚡N agents`) plus types parsed from the transcript. Toggle via `display.agents`.
 - **Cache hit rate** — prompt cache efficiency for the current turn (`87%⚡`). Alarm-mode: hidden while ≥90% (Anthropic's prompt cache pins this near 99% in healthy steady state, so an always-on number is wallpaper, not signal). Surfaces as yellow/orange/blinkRed only when the cache is actually degrading. Same hide-when-healthy pattern as rate-limits and agent count.
 - **GSD integration** — current task and update notifications (opt-in).
@@ -245,6 +246,7 @@ Create `~/.config/lumira/config.json`:
     "tokenSpeed": true,
     "rateLimits": true,
     "paceDelta": true,
+    "quotaProjection": true,
     "tools": true,
     "todos": true,
     "mcp": true,

--- a/skills/lumira/SKILL.md
+++ b/skills/lumira/SKILL.md
@@ -44,7 +44,7 @@ Your job: read the user's current config, translate their natural-language reque
 
 Valid keys (anything else must be rejected):
 
-`model`, `branch`, `gitChanges`, `directory`, `contextBar`, `contextTokens`, `tokens`, `cost`, `burnRate`, `duration`, `tokenSpeed`, `rateLimits`, `paceDelta`, `tools`, `todos`, `vim`, `effort`, `worktree`, `agent`, `agents`, `sessionName`, `style`, `version`, `linesChanged`, `memory`, `cacheMetrics`, `mcp`, `health`
+`model`, `branch`, `gitChanges`, `directory`, `contextBar`, `contextTokens`, `tokens`, `cost`, `burnRate`, `duration`, `tokenSpeed`, `rateLimits`, `paceDelta`, `quotaProjection`, `tools`, `todos`, `vim`, `effort`, `worktree`, `agent`, `agents`, `sessionName`, `style`, `version`, `linesChanged`, `memory`, `cacheMetrics`, `mcp`, `health`
 
 ### Display thresholds (`display.*`, numeric)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -138,6 +138,7 @@ const PRESET_DEFS: Record<NonNullable<HudConfig['preset']>, PresetDef> = {
       tokenSpeed: false,
       rateLimits: false,
       paceDelta: false,
+      quotaProjection: false,
       tools: false,
       todos: false,
       vim: false,

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -5,7 +5,11 @@ import { buildContextBar, formatQwenMetrics, SEP } from './shared.js';
 import { formatTokens, formatCost, formatBurnRate } from '../utils/format.js';
 import { getConfigHealth } from '../parsers/config-health.js';
 import { computePaceDelta, formatPaceDelta } from './pace.js';
+import { computeQuotaProjection, formatProjectionWarning } from './quota-projection.js';
 import type { RenderContext } from '../types.js';
+
+const SEVEN_DAY_WINDOW_SEC = 7 * 24 * 3600;
+const SEVEN_DAY_MIN_ELAPSED_SEC = 3600; // 1h floor — see quota-projection.ts
 
 export function formatCountdown(resetsAt: number): string {
   const resetsAtMs = resetsAt < 1e12 ? resetsAt * 1000 : resetsAt;
@@ -128,6 +132,23 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
       if (win.usedPercentage >= 70 && win.resetsAt) {
         const countdown = formatCountdown(win.resetsAt);
         if (countdown) limitStr += c.dim(` ${countdown}`);
+      }
+      // 7d quota projection — extrapolates current burn rate and warns when the
+      // quota would be hit before the window resets. Only attached to 7d: the 5h
+      // segment carries the same signal via pace delta, so duplicating here
+      // would add noise without information.
+      if (label === '7d' && display.quotaProjection) {
+        const proj = computeQuotaProjection(
+          win.usedPercentage,
+          win.resetsAt,
+          SEVEN_DAY_WINDOW_SEC,
+          undefined,
+          SEVEN_DAY_MIN_ELAPSED_SEC,
+        );
+        if (proj && proj.willExhaustBefore) {
+          const warning = formatProjectionWarning(proj);
+          if (warning) limitStr += ` ${warning}`;
+        }
       }
       if (win.usedPercentage >= QUOTA_CRITICAL) {
         leftParts.splice(criticalInsertAt, 0, limitStr);

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -10,7 +10,11 @@ import { formatTokens, formatCost, formatBurnRate } from '../utils/format.js';
 import { detectColorMode, getCacheHitTier, getPaceColor, type ColorMode, type Colors } from './colors.js';
 import { getConfigHealth } from '../parsers/config-health.js';
 import { computePaceDelta, formatPaceDelta } from './pace.js';
+import { computeQuotaProjection, formatProjectionWarning } from './quota-projection.js';
 import type { RenderContext } from '../types.js';
+
+const SEVEN_DAY_WINDOW_SEC = 7 * 24 * 3600;
+const SEVEN_DAY_MIN_ELAPSED_SEC = 3600; // 1h floor — see quota-projection.ts
 import {
   type PowerlinePalette,
   type RGB,
@@ -87,7 +91,24 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
       if (!win || !Number.isFinite(win.usedPercentage) || win.usedPercentage < 50) continue;
       const critical = win.usedPercentage >= QUOTA_CRITICAL;
       const bg = critical ? palette.branchDirtyBg : palette.taskBg;
-      segments.push({ text: `${icons.battery(win.usedPercentage)} ${win.usedPercentage.toFixed(0)}%(${label})`, bg, fg: palette.fg, priority: critical ? 85 : 40 });
+      let text = `${icons.battery(win.usedPercentage)} ${win.usedPercentage.toFixed(0)}%(${label})`;
+      // 7d quota projection — same gate as classic line2. The warning rides
+      // inside the existing segment (no new powerline cell) so it inherits the
+      // segment's bg and survives/falls together under fitSegments eviction.
+      if (label === '7d' && display.quotaProjection) {
+        const proj = computeQuotaProjection(
+          win.usedPercentage,
+          win.resetsAt,
+          SEVEN_DAY_WINDOW_SEC,
+          undefined,
+          SEVEN_DAY_MIN_ELAPSED_SEC,
+        );
+        if (proj && proj.willExhaustBefore) {
+          const warning = formatProjectionWarning(proj);
+          if (warning) text += ` ${warning}`;
+        }
+      }
+      segments.push({ text, bg, fg: palette.fg, priority: critical ? 85 : 40 });
     }
   }
 

--- a/src/render/quota-projection.ts
+++ b/src/render/quota-projection.ts
@@ -1,0 +1,113 @@
+import { debug } from '../utils/debug.js';
+
+const log = debug('quota-projection');
+
+export interface QuotaProjection {
+  /** Seconds from `now` until the quota is projected to hit 100% at current burn rate. */
+  timeToExhaustSec: number;
+  /** True when timeToExhaustSec is strictly less than the seconds remaining until resetsAt. */
+  willExhaustBefore: boolean;
+}
+
+/**
+ * Extrapolates current burn rate to when the quota would hit 100%.
+ *
+ * Window-agnostic: caller passes `windowSec` (e.g. 5*3600 for 5h, 7*24*3600 for 7d).
+ * The 7d caller must override `minElapsedSec` to 3600 — the default 300s is the right
+ * floor for a 5h window but too aggressive for 7d: a user who burns 10% in the first
+ * hour would otherwise trigger projection warnings the steady-state rate won't sustain.
+ */
+export function computeQuotaProjection(
+  usedPct: number,
+  resetsAt: number | undefined,
+  windowSec: number,
+  nowSec?: number,
+  minElapsedSec: number = 300,
+): QuotaProjection | null {
+  const now = nowSec ?? Date.now() / 1000;
+
+  if (resetsAt === undefined || resetsAt <= now) {
+    if (log.enabled) log({ reason: 'no resetsAt or already past', resetsAt, now });
+    return null;
+  }
+
+  if (!Number.isFinite(usedPct) || usedPct <= 0 || usedPct >= 100) {
+    if (log.enabled) log({ reason: 'usedPct out of projectable range', usedPct });
+    return null;
+  }
+
+  const remainingSec = resetsAt - now;
+  const elapsedSec = windowSec - remainingSec;
+
+  if (elapsedSec < minElapsedSec) {
+    if (log.enabled) log({ reason: 'insufficient elapsed', elapsedSec, minElapsedSec });
+    return null;
+  }
+
+  // burnRate is in pct-per-second
+  const burnRate = usedPct / elapsedSec;
+  const timeToExhaustSec = (100 - usedPct) / burnRate;
+  const willExhaustBefore = timeToExhaustSec < remainingSec;
+
+  if (log.enabled) {
+    log({
+      usedPct,
+      elapsedSec: Math.round(elapsedSec),
+      remainingSec: Math.round(remainingSec),
+      burnRate,
+      timeToExhaustSec: Math.round(timeToExhaustSec),
+      willExhaustBefore,
+    });
+  }
+
+  return { timeToExhaustSec, willExhaustBefore };
+}
+
+/**
+ * Renders a projection as a short warning string (e.g. "⚠ Mon", "🔥 ~12h").
+ *
+ * Returns "" when the projection does not predict exhaustion before reset. Caller
+ * may still call with `willExhaustBefore=false`; nothing breaks, output is just empty.
+ *
+ * `timeZone` parameter is for test determinism — in production callers omit it so
+ * weekday names render in the user's local TZ. Tests pin `timeZone='UTC'` to keep
+ * snapshots reproducible across CI runners.
+ */
+export function formatProjectionWarning(
+  proj: QuotaProjection,
+  nowSec?: number,
+  timeZone?: string,
+): string {
+  if (!proj.willExhaustBefore) return '';
+
+  const tte = proj.timeToExhaustSec;
+  const icon = tte < 12 * 3600 ? '🔥' : '⚠';
+
+  if (tte < 3600) {
+    // < 1h → minutes (ceil so sub-minute values don't render as "~0min")
+    const mins = Math.max(1, Math.ceil(tte / 60));
+    return `${icon} ~${mins}min`;
+  }
+
+  if (tte < 48 * 3600) {
+    // 1h to <48h → hours
+    const hours = Math.floor(tte / 3600);
+    return `${icon} ~${hours}h`;
+  }
+
+  if (tte < 7 * 24 * 3600) {
+    // 2d to <7d → days
+    const days = Math.floor(tte / (24 * 3600));
+    return `${icon} ~${days}d`;
+  }
+
+  // >= 7d → render weekday name. Pin locale to en-US so output is the same
+  // 3-letter English abbreviation regardless of the user's system locale,
+  // which prevents snapshot drift across machines.
+  const now = nowSec ?? Date.now() / 1000;
+  const exhaustDate = new Date((now + tte) * 1000);
+  const formatOpts: Intl.DateTimeFormatOptions = { weekday: 'short' };
+  if (timeZone) formatOpts.timeZone = timeZone;
+  const weekday = exhaustDate.toLocaleDateString('en-US', formatOpts);
+  return `${icon} ${weekday}`;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,6 +206,7 @@ export interface DisplayToggles {
   tokenSpeed: boolean;
   rateLimits: boolean;
   paceDelta: boolean;
+  quotaProjection: boolean;
   tools: boolean;
   todos: boolean;
   vim: boolean;
@@ -260,6 +261,7 @@ export const DEFAULT_DISPLAY: DisplayToggles = {
   tokenSpeed: true,
   rateLimits: true,
   paceDelta: true,
+  quotaProjection: true,
   tools: true,
   todos: true,
   vim: true,

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -540,6 +540,134 @@ describe('renderLine2', () => {
     // No +/- delta markers appear (context bar %-suffix is still present, that's fine)
     expect(out).not.toMatch(/[+-]\d+%/);
   });
+
+  // ── Quota projection (7d) ───────────────────────────────────────────────────
+
+  describe('quota projection warning (7d)', () => {
+    it('shows ⚠ ~24h projection when burn rate will exhaust 7d quota before reset', () => {
+      const pinnedNow = 1_700_000_000_000;
+      vi.useFakeTimers({ now: pinnedNow });
+      const nowSec = pinnedNow / 1000;
+      // 1d elapsed of 7d, 50% used → TTE = 24h. Remaining = 6d. willExhaustBefore=true. 24h >= 12h → ⚠
+      const resetsAt = nowSec + (7 * 24 * 3600 - 86400);
+      const inputOverride = {
+        rate_limits: { seven_day: { used_percentage: 50, resets_at: resetsAt } },
+      };
+      const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+      expect(out).toContain('50%(7d)');
+      expect(out).toContain('⚠ ~24h');
+    });
+
+    it('uses 🔥 critical icon when projection < 12h', () => {
+      const pinnedNow = 1_700_000_000_000;
+      vi.useFakeTimers({ now: pinnedNow });
+      const nowSec = pinnedNow / 1000;
+      // 6h elapsed of 7d, 60% used → TTE = 4h. Remaining ≈ 6.75d. willExhaustBefore=true. 4h < 12h → 🔥
+      const resetsAt = nowSec + (7 * 24 * 3600 - 6 * 3600);
+      const inputOverride = {
+        rate_limits: { seven_day: { used_percentage: 60, resets_at: resetsAt } },
+      };
+      const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+      expect(out).toContain('🔥 ~4h');
+    });
+
+    it('coexists with countdown when >= 70% — both signals appear', () => {
+      const pinnedNow = 1_700_000_000_000;
+      vi.useFakeTimers({ now: pinnedNow });
+      const nowSec = pinnedNow / 1000;
+      // 1d elapsed of 7d, 75% used → TTE = 25/(75/86400) ≈ 28800s = 8h. Remaining 6d. willExhaustBefore=true. 8h < 12h → 🔥
+      const resetsAt = nowSec + (7 * 24 * 3600 - 86400);
+      const inputOverride = {
+        rate_limits: { seven_day: { used_percentage: 75, resets_at: resetsAt } },
+      };
+      const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+      expect(out).toContain('75%(7d)');
+      // Countdown still appears (>=70% gate)
+      expect(out).toMatch(/\d+d\d+h|\d+h\d+m/);
+      // Projection appears after countdown
+      expect(out).toContain('🔥 ~8h');
+      // Order: countdown comes BEFORE projection in the segment text
+      const countdownPos = out.search(/\d+d\d+h|\d+h\d+m/);
+      const projPos = out.indexOf('🔥');
+      expect(countdownPos).toBeGreaterThan(-1);
+      expect(projPos).toBeGreaterThan(countdownPos);
+    });
+
+    it('hides projection when display.quotaProjection toggle is off', () => {
+      const pinnedNow = 1_700_000_000_000;
+      vi.useFakeTimers({ now: pinnedNow });
+      const nowSec = pinnedNow / 1000;
+      const resetsAt = nowSec + (7 * 24 * 3600 - 86400);
+      const inputOverride = {
+        rate_limits: { seven_day: { used_percentage: 50, resets_at: resetsAt } },
+      };
+      const ctx = makeCtx(
+        { config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, quotaProjection: false } } },
+        inputOverride,
+      );
+      const out = stripAnsi(renderLine2(ctx, c));
+      expect(out).toContain('50%(7d)');
+      expect(out).not.toContain('⚠ ~');
+      expect(out).not.toContain('🔥 ~');
+    });
+
+    it('hides projection when 7d will NOT exhaust before reset', () => {
+      const pinnedNow = 1_700_000_000_000;
+      vi.useFakeTimers({ now: pinnedNow });
+      const nowSec = pinnedNow / 1000;
+      // 6d elapsed of 7d, 60% used → low burn → TTE ≈ 4d. Remaining 1d. 4d > 1d → false.
+      const resetsAt = nowSec + (7 * 24 * 3600 - 518400);
+      const inputOverride = {
+        rate_limits: { seven_day: { used_percentage: 60, resets_at: resetsAt } },
+      };
+      const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+      expect(out).toContain('60%(7d)');
+      expect(out).not.toContain('⚠ ~');
+      expect(out).not.toContain('🔥 ~');
+    });
+
+    it('no projection when sevenDay has no resetsAt (no crash)', () => {
+      const inputOverride = {
+        rate_limits: { seven_day: { used_percentage: 70 } }, // no resets_at
+      };
+      const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+      expect(out).toContain('70%(7d)');
+      expect(out).not.toContain('⚠ ~');
+      expect(out).not.toContain('🔥 ~');
+    });
+
+    it('respects 1h minElapsed guard for 7d (no projection at 30min elapsed)', () => {
+      const pinnedNow = 1_700_000_000_000;
+      vi.useFakeTimers({ now: pinnedNow });
+      const nowSec = pinnedNow / 1000;
+      // 30min elapsed of 7d window — below the 3600 minElapsed for the 7d caller
+      const resetsAt = nowSec + (7 * 24 * 3600 - 1800);
+      const inputOverride = {
+        rate_limits: { seven_day: { used_percentage: 60, resets_at: resetsAt } },
+      };
+      const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+      expect(out).toContain('60%(7d)');
+      expect(out).not.toContain('⚠ ~');
+      expect(out).not.toContain('🔥 ~');
+    });
+
+    it('does NOT add projection to 5h segment — pace delta carries that signal', () => {
+      const pinnedNow = 1_700_000_000_000;
+      vi.useFakeTimers({ now: pinnedNow });
+      const nowSec = pinnedNow / 1000;
+      const resetsAt = nowSec + (5 * 3600 - 3600);
+      const inputOverride = {
+        rate_limits: { five_hour: { used_percentage: 60, resets_at: resetsAt } },
+      };
+      const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+      expect(out).toContain('60%(5h)');
+      // 5h segment must not carry projection icons (pace delta already communicates TTE)
+      const fhPos = out.indexOf('60%(5h)');
+      const segmentTail = out.slice(fhPos, fhPos + 40);
+      expect(segmentTail).not.toContain('⚠ ~');
+      expect(segmentTail).not.toContain('🔥 ~');
+    });
+  });
 });
 
 describe('formatCountdown', () => {

--- a/tests/render/powerline-line2.test.ts
+++ b/tests/render/powerline-line2.test.ts
@@ -414,4 +414,100 @@ describe('renderPowerlineLine2', () => {
       expect(out).toContain('\u{F007F}'); // battery_60 glyph for 60% (5h)
     });
   });
+
+  describe('quota projection warning (7d)', () => {
+    function ctxWith7dProjection(usedPercentage: number, elapsedSec: number, toggles: Partial<typeof DEFAULT_DISPLAY> = {}) {
+      const pinnedNow = 1_700_000_000_000;
+      vi.useFakeTimers({ now: pinnedNow });
+      const nowSec = pinnedNow / 1000;
+      const resetsAt = nowSec + (7 * 24 * 3600 - elapsedSec);
+      const rawInput = {
+        model: 'Claude Sonnet 4.6',
+        session_id: 'test',
+        context_window: { used_percentage: 42, remaining_percentage: 58, total_input_tokens: 12000, total_output_tokens: 1800 },
+        cost: { total_cost_usd: 0.42, total_duration_ms: 185000 },
+        rate_limits: { seven_day: { used_percentage: usedPercentage, resets_at: resetsAt } },
+      };
+      return makeCtx({
+        input: normalize(rawInput),
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, ...toggles } },
+      });
+    }
+
+    it('appends ⚠ ~Xh projection inside the 7d segment when it will exhaust before reset', () => {
+      // 1d elapsed of 7d, 50% used → TTE = 24h → ⚠ ~24h (24h is NOT <12h boundary).
+      const ctx = ctxWith7dProjection(50, 86400);
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).toContain('50%(7d)');
+      expect(out).toContain('⚠ ~24h');
+    });
+
+    it('uses 🔥 critical icon when projection < 12h', () => {
+      // 6h elapsed of 7d, 60% used → TTE = 4h → 🔥
+      const ctx = ctxWith7dProjection(60, 6 * 3600);
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).toContain('🔥 ~4h');
+    });
+
+    it('hides projection when display.quotaProjection toggle is off', () => {
+      const ctx = ctxWith7dProjection(50, 86400, { quotaProjection: false });
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).toContain('50%(7d)');
+      expect(out).not.toContain('⚠ ~');
+      expect(out).not.toContain('🔥 ~');
+    });
+
+    it('no projection when sevenDay has no resetsAt', () => {
+      const rawInput = {
+        model: 'Claude Sonnet 4.6',
+        session_id: 'test',
+        context_window: { used_percentage: 42, remaining_percentage: 58, total_input_tokens: 12000, total_output_tokens: 1800 },
+        cost: { total_cost_usd: 0.42, total_duration_ms: 185000 },
+        rate_limits: { seven_day: { used_percentage: 70 } }, // no resets_at
+      };
+      const ctx = makeCtx({ input: normalize(rawInput) });
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).toContain('70%(7d)');
+      expect(out).not.toContain('⚠ ~');
+      expect(out).not.toContain('🔥 ~');
+    });
+
+    it('hides projection when 7d will NOT exhaust before reset', () => {
+      // 6d elapsed of 7d, 60% used → TTE ≈ 4d, remaining 1d → false
+      const ctx = ctxWith7dProjection(60, 518400);
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).toContain('60%(7d)');
+      expect(out).not.toContain('⚠ ~');
+      expect(out).not.toContain('🔥 ~');
+    });
+
+    it('respects 1h minElapsed guard for 7d (no projection at 30min elapsed)', () => {
+      const ctx = ctxWith7dProjection(60, 1800);
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).toContain('60%(7d)');
+      expect(out).not.toContain('⚠ ~');
+      expect(out).not.toContain('🔥 ~');
+    });
+
+    it('does NOT add projection to 5h segment — pace delta carries that signal', () => {
+      const pinnedNow = 1_700_000_000_000;
+      vi.useFakeTimers({ now: pinnedNow });
+      const nowSec = pinnedNow / 1000;
+      const resetsAt = nowSec + (5 * 3600 - 3600);
+      const rawInput = {
+        model: 'Claude Sonnet 4.6',
+        session_id: 'test',
+        context_window: { used_percentage: 42, remaining_percentage: 58, total_input_tokens: 12000, total_output_tokens: 1800 },
+        cost: { total_cost_usd: 0.42, total_duration_ms: 185000 },
+        rate_limits: { five_hour: { used_percentage: 60, resets_at: resetsAt } },
+      };
+      const ctx = makeCtx({ input: normalize(rawInput) });
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).toContain('60%(5h)');
+      const fhPos = out.indexOf('60%(5h)');
+      const segmentTail = out.slice(fhPos, fhPos + 40);
+      expect(segmentTail).not.toContain('⚠ ~');
+      expect(segmentTail).not.toContain('🔥 ~');
+    });
+  });
 });

--- a/tests/render/quota-projection.test.ts
+++ b/tests/render/quota-projection.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect } from 'vitest';
+import { computeQuotaProjection, formatProjectionWarning } from '../../src/render/quota-projection.js';
+
+// Deterministic clock for tests
+const NOW = 1_000_000; // seconds since epoch
+// 7d window in seconds
+const WINDOW_7D = 7 * 24 * 3600;
+// 5h window in seconds (used to verify the same module works for the shorter window)
+const WINDOW_5H = 5 * 3600;
+
+describe('computeQuotaProjection', () => {
+  describe('null guards', () => {
+    it('returns null when resetsAt is undefined', () => {
+      expect(computeQuotaProjection(50, undefined, WINDOW_7D, NOW)).toBeNull();
+    });
+
+    it('returns null when resetsAt is in the past', () => {
+      expect(computeQuotaProjection(50, NOW - 1, WINDOW_7D, NOW)).toBeNull();
+    });
+
+    it('returns null when resetsAt equals now (boundary)', () => {
+      expect(computeQuotaProjection(50, NOW, WINDOW_7D, NOW)).toBeNull();
+    });
+
+    it('returns null when usedPct is 0 (no burn rate to project from)', () => {
+      const resetsAt = NOW + (WINDOW_7D - 7200); // 2h elapsed
+      expect(computeQuotaProjection(0, resetsAt, WINDOW_7D, NOW)).toBeNull();
+    });
+
+    it('returns null when usedPct is negative', () => {
+      const resetsAt = NOW + (WINDOW_7D - 7200);
+      expect(computeQuotaProjection(-5, resetsAt, WINDOW_7D, NOW)).toBeNull();
+    });
+
+    it('returns null when usedPct is NaN', () => {
+      const resetsAt = NOW + (WINDOW_7D - 7200);
+      expect(computeQuotaProjection(Number.NaN, resetsAt, WINDOW_7D, NOW)).toBeNull();
+    });
+
+    it('returns null when usedPct is Infinity', () => {
+      const resetsAt = NOW + (WINDOW_7D - 7200);
+      expect(computeQuotaProjection(Number.POSITIVE_INFINITY, resetsAt, WINDOW_7D, NOW)).toBeNull();
+    });
+
+    it('returns null when usedPct >= 100 (already exhausted)', () => {
+      const resetsAt = NOW + (WINDOW_7D - 7200);
+      expect(computeQuotaProjection(100, resetsAt, WINDOW_7D, NOW)).toBeNull();
+      expect(computeQuotaProjection(101, resetsAt, WINDOW_7D, NOW)).toBeNull();
+    });
+  });
+
+  describe('minElapsedSec guard', () => {
+    it('returns null when elapsedSec < default minElapsedSec (300)', () => {
+      // 4 minutes elapsed (240s)
+      const resetsAt = NOW + (WINDOW_7D - 240);
+      expect(computeQuotaProjection(10, resetsAt, WINDOW_7D, NOW)).toBeNull();
+    });
+
+    it('returns non-null at exactly default minElapsedSec (300s) elapsed', () => {
+      const resetsAt = NOW + (WINDOW_7D - 300);
+      const result = computeQuotaProjection(10, resetsAt, WINDOW_7D, NOW);
+      expect(result).not.toBeNull();
+    });
+
+    it('returns null when elapsedSec < custom minElapsedSec (3600 for 7d window)', () => {
+      // 30 minutes elapsed
+      const resetsAt = NOW + (WINDOW_7D - 1800);
+      expect(computeQuotaProjection(10, resetsAt, WINDOW_7D, NOW, 3600)).toBeNull();
+    });
+
+    it('returns non-null at exactly custom minElapsedSec (3600s) elapsed', () => {
+      const resetsAt = NOW + (WINDOW_7D - 3600);
+      const result = computeQuotaProjection(10, resetsAt, WINDOW_7D, NOW, 3600);
+      expect(result).not.toBeNull();
+    });
+
+    it('high burn-rate trap: 10% burned in 1h with minElapsed=300 would project exhaust, but minElapsed=3600 hides it', () => {
+      // 1h elapsed of 7d window, 10% used.
+      // burnRate = 10 / 3600 pct/s → TTE = 90 / (10/3600) = 32400s (9h). Way before reset (7d).
+      // willExhaustBefore=true, BUT this is too aggressive — minElapsed=3600 should suppress.
+      const resetsAt = NOW + (WINDOW_7D - 3600);
+      // With default (300): would compute and warn
+      expect(computeQuotaProjection(10, resetsAt, WINDOW_7D, NOW)).not.toBeNull();
+      // With 7d override (3600): exactly at boundary, computes
+      expect(computeQuotaProjection(10, resetsAt, WINDOW_7D, NOW, 3600)).not.toBeNull();
+      // With 3601 minElapsed: blocked
+      expect(computeQuotaProjection(10, resetsAt, WINDOW_7D, NOW, 3601)).toBeNull();
+    });
+  });
+
+  describe('willExhaustBefore', () => {
+    it('willExhaustBefore=true when projected exhaustion is before resetsAt', () => {
+      // 1d elapsed of 7d → 86400s elapsed, 518400s remaining
+      // 50% used → burnRate = 50/86400 → TTE = 50 / (50/86400) = 86400s = 1d. < 6d remaining.
+      const elapsedSec = 86400;
+      const resetsAt = NOW + (WINDOW_7D - elapsedSec);
+      const result = computeQuotaProjection(50, resetsAt, WINDOW_7D, NOW, 3600);
+      expect(result).not.toBeNull();
+      expect(result!.willExhaustBefore).toBe(true);
+    });
+
+    it('willExhaustBefore=false when projected exhaustion is after resetsAt', () => {
+      // 6d elapsed of 7d → 518400s elapsed, 86400s remaining
+      // 5% used → burnRate very low → TTE = 95 / (5/518400) = 9849600s = 114d. >> 1d remaining.
+      const elapsedSec = 518400; // 6 days
+      const resetsAt = NOW + (WINDOW_7D - elapsedSec);
+      const result = computeQuotaProjection(5, resetsAt, WINDOW_7D, NOW, 3600);
+      expect(result).not.toBeNull();
+      expect(result!.willExhaustBefore).toBe(false);
+    });
+
+    it('willExhaustBefore=false at exact boundary (TTE === remainingSec)', () => {
+      // Construct a case where TTE exactly equals remainingSec.
+      // 50% elapsed of window, 50% used → burnRate matches → TTE = remaining exactly.
+      // elapsedSec = WINDOW_7D / 2 = 302400; remaining = 302400
+      // TTE = (100 - 50) / (50 / 302400) = 50 / 0.0001653... = 302400s exactly.
+      const elapsedSec = WINDOW_7D / 2;
+      const resetsAt = NOW + (WINDOW_7D - elapsedSec);
+      const result = computeQuotaProjection(50, resetsAt, WINDOW_7D, NOW, 3600);
+      expect(result).not.toBeNull();
+      // Exactly at boundary: NOT strictly before → false
+      expect(result!.willExhaustBefore).toBe(false);
+    });
+  });
+
+  describe('timeToExhaustSec computation', () => {
+    it('25% elapsed at 50% used → burn 2x → TTE = elapsed (since 50% remaining at burn rate that did 50% in elapsed)', () => {
+      // elapsedSec = WINDOW_7D / 4 = 151200s; 50% used
+      // burnRate = 50/151200 pct/s
+      // TTE = (100 - 50) / (50 / 151200) = 151200s
+      const elapsedSec = WINDOW_7D / 4;
+      const resetsAt = NOW + (WINDOW_7D - elapsedSec);
+      const result = computeQuotaProjection(50, resetsAt, WINDOW_7D, NOW, 3600);
+      expect(result).not.toBeNull();
+      expect(result!.timeToExhaustSec).toBeCloseTo(151200, 0);
+    });
+
+    it('works for 5h window too (module is window-agnostic)', () => {
+      // 1h elapsed of 5h, 25% used → TTE = (100 - 25) / (25 / 3600) = 75 * 3600 / 25 = 10800s = 3h
+      // Remaining = 4h. 3h < 4h → willExhaustBefore=true.
+      const elapsedSec = 3600;
+      const resetsAt = NOW + (WINDOW_5H - elapsedSec);
+      const result = computeQuotaProjection(25, resetsAt, WINDOW_5H, NOW);
+      expect(result).not.toBeNull();
+      expect(result!.timeToExhaustSec).toBeCloseTo(10800, 0);
+      expect(result!.willExhaustBefore).toBe(true);
+    });
+
+    it('nowSec is injectable — deterministic across runs', () => {
+      const elapsedSec = 86400;
+      const resetsAt = NOW + (WINDOW_7D - elapsedSec);
+      const a = computeQuotaProjection(40, resetsAt, WINDOW_7D, NOW, 3600);
+      const b = computeQuotaProjection(40, resetsAt, WINDOW_7D, NOW, 3600);
+      expect(a).toEqual(b);
+    });
+  });
+});
+
+describe('formatProjectionWarning', () => {
+  // Helper to construct a QuotaProjection without going through compute (lets us
+  // exercise format ranges directly).
+  const proj = (timeToExhaustSec: number) => ({ timeToExhaustSec, willExhaustBefore: true });
+
+  describe('icon tier', () => {
+    it('uses 🔥 when timeToExhaustSec < 12h (critical)', () => {
+      const out = formatProjectionWarning(proj(6 * 3600));
+      expect(out).toContain('🔥');
+      expect(out).not.toContain('⚠');
+    });
+
+    it('uses ⚠ when timeToExhaustSec >= 12h (warning)', () => {
+      const out = formatProjectionWarning(proj(13 * 3600));
+      expect(out).toContain('⚠');
+      expect(out).not.toContain('🔥');
+    });
+
+    it('uses ⚠ at exactly 12h boundary (boundary is non-critical)', () => {
+      const out = formatProjectionWarning(proj(12 * 3600));
+      expect(out).toContain('⚠');
+      expect(out).not.toContain('🔥');
+    });
+  });
+
+  describe('time formatting', () => {
+    it('< 1h → "~Xmin"', () => {
+      expect(formatProjectionWarning(proj(45 * 60))).toBe('🔥 ~45min');
+      expect(formatProjectionWarning(proj(59 * 60))).toBe('🔥 ~59min');
+    });
+
+    it('rounds sub-minute up to nearest minute', () => {
+      expect(formatProjectionWarning(proj(90))).toBe('🔥 ~2min'); // 90s → 2min
+    });
+
+    it('1h to <48h → "~Xh"', () => {
+      expect(formatProjectionWarning(proj(60 * 60))).toBe('🔥 ~1h');
+      expect(formatProjectionWarning(proj(11 * 3600))).toBe('🔥 ~11h');
+      expect(formatProjectionWarning(proj(24 * 3600))).toBe('⚠ ~24h');
+      expect(formatProjectionWarning(proj(47 * 3600))).toBe('⚠ ~47h');
+    });
+
+    it('2d to <7d → "~Xd"', () => {
+      expect(formatProjectionWarning(proj(2 * 24 * 3600))).toBe('⚠ ~2d');
+      expect(formatProjectionWarning(proj(5 * 24 * 3600))).toBe('⚠ ~5d');
+      expect(formatProjectionWarning(proj(6 * 24 * 3600 + 12 * 3600))).toBe('⚠ ~6d'); // 6.5d → 6d (floor)
+    });
+
+    it('>= 7d → weekday name in en-US (pinned locale)', () => {
+      // Use timeZone=UTC for determinism — pin both locale and tz in tests.
+      // Pick a "now" we can verify: 2026-01-05 is a Monday in UTC.
+      // Unix epoch 1767571200 = 2026-01-05T00:00:00Z (Monday UTC).
+      const mondayUtc = 1_767_571_200;
+      // Project 8 days from "now" → 2026-01-13 = Tuesday UTC
+      const out = formatProjectionWarning(
+        proj(8 * 24 * 3600),
+        mondayUtc,
+        'UTC',
+      );
+      expect(out).toBe('⚠ Tue');
+    });
+
+    it('exactly 7d → weekday format (not "~7d")', () => {
+      const mondayUtc = 1_767_571_200; // 2026-01-05 Mon UTC
+      // 7d from now → 2026-01-12 = Monday UTC
+      const out = formatProjectionWarning(
+        proj(7 * 24 * 3600),
+        mondayUtc,
+        'UTC',
+      );
+      expect(out).toBe('⚠ Mon');
+    });
+  });
+
+  describe('locale pin (en-US)', () => {
+    it('returns 3-letter English short weekday regardless of system locale', () => {
+      const mondayUtc = 1_767_571_200; // 2026-01-05 Mon UTC
+      // 9 days later → Wed UTC
+      const out = formatProjectionWarning(proj(9 * 24 * 3600), mondayUtc, 'UTC');
+      // 3-letter English short weekday
+      expect(out).toMatch(/^⚠ (Mon|Tue|Wed|Thu|Fri|Sat|Sun)$/);
+      expect(out).toBe('⚠ Wed');
+    });
+  });
+
+  describe('willExhaustBefore=false', () => {
+    it('returns empty string when willExhaustBefore is false', () => {
+      const out = formatProjectionWarning({ timeToExhaustSec: 999999, willExhaustBefore: false });
+      expect(out).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The 7d rate-limit segment now extrapolates the current burn rate and appends a warning when projected exhaustion lands before the window resets — `⚠ ~24h`, `⚠ ~2d`, `⚠ Tue`, or `🔥 ~8h` (critical icon under 12h). Renders in both classic and powerline modes; coexists with the existing reset countdown.

A steady 75% burn at the 1-day mark used to look identical to a 75% burn at the 6-day mark, even though the first will hit 100% before reset and the second will not. The projection answers "at this rate, when do I run out", which the countdown ("when does the window reset") doesn't.

Closes #118.

## Design notes

- **7d only, not 5h.** Pace delta already carries the time-to-exhaustion signal for the short window. Projection complements pace, not replaces it: pace looks *backwards* at actual vs proportional burn; projection looks *forwards* at exhaustion ETA.
- **`minElapsedSec` floor is parameterized.** Module defaults to 300s (matches `pace.ts`); the 7d caller pins it to 3600s. A user who burns 10% in the first hour of a 7-day window would otherwise trigger projection warnings the steady-state rate won't sustain.
- **Coexists with countdown.** Both signals render together (e.g. `75%(7d) 144h00m 🔥 ~8h`) because they answer different questions. UX decision confirmed by hand-comparing the three options against ASCII previews.
- **Locale pin `'en-US'`** in `toLocaleDateString` keeps snapshot output stable across CI runners. Production uses local TZ; tests inject `timeZone: 'UTC'` for determinism.
- **No new color escape.** Warning rides plain inside the segment's existing color wrap — the 🔥 / ⚠ icon carries urgency, avoids stacking a third color channel per segment.

## Toggle

- New `display.quotaProjection: boolean` (after `paceDelta` in `DisplayToggles`)
- `DEFAULT_DISPLAY`: `true` (default-on, all users get the signal)
- `minimal` preset: `false` (preserves its quiet contract)
- `balanced` preset: unchanged (inherits default-on)

## What changed

| File | Change |
|---|---|
| `src/render/quota-projection.ts` | NEW — `computeQuotaProjection` + `formatProjectionWarning`, window-agnostic |
| `src/render/line2.ts` | Import + append warning inside 7d branch of rate-limit loop |
| `src/render/powerline-line2.ts` | Same integration in powerline render |
| `src/types.ts` | Add `quotaProjection` to `DisplayToggles` + `DEFAULT_DISPLAY` |
| `src/config.ts` | Off in `minimal` preset |
| `tests/render/quota-projection.test.ts` | NEW — 30 unit tests (null guards, boundaries, format ranges, locale pin) |
| `tests/render/line2.test.ts` | +8 integration tests |
| `tests/render/powerline-line2.test.ts` | +7 integration tests |
| `README.md`, `CHANGELOG.md`, `skills/lumira/SKILL.md` | Documented |

## Test plan

- [x] `npm test` → 882/882 passing (45 new tests; was 837)
- [x] `npm run lint` (tsc --noEmit) → clean
- [x] `npm run themes:validate` → WCAG AA OK across all 7 themes
- [x] Manual: classic + powerline renderer produce expected output for the four scenarios (will/won't exhaust × < 12h / >= 12h projection)
- [x] Code review by feature-dev:code-reviewer (opus) → APPROVE, no HIGH findings