### PR TITLE
fix(render): surface 7d projection warning below 50% used

### DIFF
--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -106,8 +106,11 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
 
   // 7d quota projection — computed once, surfaced two ways depending on whether
   // the 7d badge is visible. The badge filter (≥50%) hides noise; the projection
-  // surfaces signal — they are independent concerns wired together previously by
-  // accident. Below 50% the warning still renders, just standalone.
+  // surfaces signal — they are independent concerns. The projection is also
+  // independent of `display.rateLimits`: a user who hides the rate-limit family
+  // still benefits from the exhaustion warning. This mirrors `paceDelta` below
+  // (line ~165), which is also independent of `display.rateLimits` for the same
+  // reason.
   let sevenDayProjWarning = '';
   if (display.quotaProjection && input.rateLimits?.sevenDay) {
     const sd = input.rateLimits.sevenDay;
@@ -125,6 +128,15 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
     }
   }
   let sevenDayWarningAttachedToBadge = false;
+
+  // Colour the projection by its severity tier. 🔥 (sub-12h, critical) escalates
+  // to red; ⚠ (warning) to yellow. Inferred from the format icon prefix — the
+  // icon is the tier indicator the format function already chose. See the
+  // follow-up tech-debt issue tracking a typed severity field.
+  const colorProjection = (warning: string): string => {
+    const isCritical = warning.startsWith('🔥');
+    return (isCritical ? c.red : c.yellow)(warning);
+  };
 
   // Rate limits (only show if >=50%)
   //
@@ -158,9 +170,11 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
       // 7d quota projection — extrapolates current burn rate and warns when the
       // quota would be hit before the window resets. Only attached to 7d: the 5h
       // segment carries the same signal via pace delta, so duplicating here
-      // would add noise without information.
+      // would add noise without information. The warning is coloured by its own
+      // severity (red/yellow) so it carries the same urgency whether attached
+      // here or rendered standalone below.
       if (label === '7d' && sevenDayProjWarning) {
-        limitStr += ` ${sevenDayProjWarning}`;
+        limitStr += ` ${colorProjection(sevenDayProjWarning)}`;
         sevenDayWarningAttachedToBadge = true;
       }
       if (win.usedPercentage >= QUOTA_CRITICAL) {
@@ -172,13 +186,13 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
     }
   }
 
-  // 7d projection — standalone fallback when the badge is hidden (<50%) but the
-  // burn rate predicts exhaustion. This is the most actionable window for the
-  // warning: the user can still change behaviour. 🔥 (sub-12h) carries red, ⚠
-  // carries yellow — colour is inferred from the format icon, no extra API.
+  // 7d projection — standalone fallback. Fires when the warning was computed
+  // but not attached to a badge — either because the badge is suppressed by the
+  // <50% filter, or because `display.rateLimits` is off (independent toggle, see
+  // colorProjection block above). This is the most actionable window for the
+  // warning: the user can still change behaviour.
   if (sevenDayProjWarning && !sevenDayWarningAttachedToBadge) {
-    const isCritical = sevenDayProjWarning.startsWith('🔥');
-    leftParts.push((isCritical ? c.red : c.yellow)(sevenDayProjWarning));
+    leftParts.push(colorProjection(sevenDayProjWarning));
   }
 
   // Pace delta — shows how far ahead/behind of expected quota burn rate.

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -104,6 +104,28 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
   // Qwen metrics (shared helper)
   leftParts.push(...formatQwenMetrics(input, c, icons));
 
+  // 7d quota projection — computed once, surfaced two ways depending on whether
+  // the 7d badge is visible. The badge filter (≥50%) hides noise; the projection
+  // surfaces signal — they are independent concerns wired together previously by
+  // accident. Below 50% the warning still renders, just standalone.
+  let sevenDayProjWarning = '';
+  if (display.quotaProjection && input.rateLimits?.sevenDay) {
+    const sd = input.rateLimits.sevenDay;
+    if (Number.isFinite(sd.usedPercentage)) {
+      const proj = computeQuotaProjection(
+        sd.usedPercentage,
+        sd.resetsAt,
+        SEVEN_DAY_WINDOW_SEC,
+        undefined,
+        SEVEN_DAY_MIN_ELAPSED_SEC,
+      );
+      if (proj && proj.willExhaustBefore) {
+        sevenDayProjWarning = formatProjectionWarning(proj);
+      }
+    }
+  }
+  let sevenDayWarningAttachedToBadge = false;
+
   // Rate limits (only show if >=50%)
   //
   // Critical-tier (>=85%) segments are inserted *after the context bar* instead
@@ -137,18 +159,9 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
       // quota would be hit before the window resets. Only attached to 7d: the 5h
       // segment carries the same signal via pace delta, so duplicating here
       // would add noise without information.
-      if (label === '7d' && display.quotaProjection) {
-        const proj = computeQuotaProjection(
-          win.usedPercentage,
-          win.resetsAt,
-          SEVEN_DAY_WINDOW_SEC,
-          undefined,
-          SEVEN_DAY_MIN_ELAPSED_SEC,
-        );
-        if (proj && proj.willExhaustBefore) {
-          const warning = formatProjectionWarning(proj);
-          if (warning) limitStr += ` ${warning}`;
-        }
+      if (label === '7d' && sevenDayProjWarning) {
+        limitStr += ` ${sevenDayProjWarning}`;
+        sevenDayWarningAttachedToBadge = true;
       }
       if (win.usedPercentage >= QUOTA_CRITICAL) {
         leftParts.splice(criticalInsertAt, 0, limitStr);
@@ -157,6 +170,15 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
         leftParts.push(limitStr);
       }
     }
+  }
+
+  // 7d projection — standalone fallback when the badge is hidden (<50%) but the
+  // burn rate predicts exhaustion. This is the most actionable window for the
+  // warning: the user can still change behaviour. 🔥 (sub-12h) carries red, ⚠
+  // carries yellow — colour is inferred from the format icon, no extra API.
+  if (sevenDayProjWarning && !sevenDayWarningAttachedToBadge) {
+    const isCritical = sevenDayProjWarning.startsWith('🔥');
+    leftParts.push((isCritical ? c.red : c.yellow)(sevenDayProjWarning));
   }
 
   // Pace delta — shows how far ahead/behind of expected quota burn rate.

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -80,6 +80,8 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
   // 7d projection — computed once, surfaced inside the 7d segment when the
   // badge is visible (≥50%), or as a standalone segment when it isn't. Mirrors
   // classic line2: badge filter hides noise, projection surfaces signal.
+  // Independent of `display.rateLimits` — mirrors paceDelta below; users who
+  // hide rate-limit badges still benefit from the exhaustion warning.
   let sevenDayProjWarning = '';
   if (display.quotaProjection && input.rateLimits?.sevenDay) {
     const sd = input.rateLimits.sevenDay;
@@ -98,6 +100,14 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
   }
   let sevenDayWarningAttachedToBadge = false;
 
+  // Colour the projection inline (only when it rides inside the 7d badge
+  // segment). The standalone segment expresses severity via bg colour
+  // (branchDirtyBg for 🔥, taskBg for ⚠), so it does not need an inline wrap.
+  const colorProjectionInline = (warning: string): string => {
+    const isCritical = warning.startsWith('🔥');
+    return (isCritical ? c.red : c.yellow)(warning);
+  };
+
   // Rate limits — urgency expressed via priority (critical survives eviction longer).
   // Loop order (5h then 7d) is always preserved; priority is the eviction knob only.
   // Note: countdown timer (line2.ts:127) is intentionally omitted in powerline mode.
@@ -115,9 +125,10 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
       let text = `${icons.battery(win.usedPercentage)} ${win.usedPercentage.toFixed(0)}%(${label})`;
       // 7d quota projection — rides inside the existing segment (no new
       // powerline cell) so it inherits the segment's bg and survives/falls
-      // together under fitSegments eviction.
+      // together under fitSegments eviction. The inline severity colour keeps
+      // the warning's urgency visible across the segment background.
       if (label === '7d' && sevenDayProjWarning) {
-        text += ` ${sevenDayProjWarning}`;
+        text += ` ${colorProjectionInline(sevenDayProjWarning)}`;
         sevenDayWarningAttachedToBadge = true;
       }
       segments.push({ text, bg, fg: palette.fg, priority: critical ? 85 : 40 });

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -77,6 +77,27 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
     }
   }
 
+  // 7d projection — computed once, surfaced inside the 7d segment when the
+  // badge is visible (≥50%), or as a standalone segment when it isn't. Mirrors
+  // classic line2: badge filter hides noise, projection surfaces signal.
+  let sevenDayProjWarning = '';
+  if (display.quotaProjection && input.rateLimits?.sevenDay) {
+    const sd = input.rateLimits.sevenDay;
+    if (Number.isFinite(sd.usedPercentage)) {
+      const proj = computeQuotaProjection(
+        sd.usedPercentage,
+        sd.resetsAt,
+        SEVEN_DAY_WINDOW_SEC,
+        undefined,
+        SEVEN_DAY_MIN_ELAPSED_SEC,
+      );
+      if (proj && proj.willExhaustBefore) {
+        sevenDayProjWarning = formatProjectionWarning(proj);
+      }
+    }
+  }
+  let sevenDayWarningAttachedToBadge = false;
+
   // Rate limits — urgency expressed via priority (critical survives eviction longer).
   // Loop order (5h then 7d) is always preserved; priority is the eviction knob only.
   // Note: countdown timer (line2.ts:127) is intentionally omitted in powerline mode.
@@ -92,24 +113,28 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
       const critical = win.usedPercentage >= QUOTA_CRITICAL;
       const bg = critical ? palette.branchDirtyBg : palette.taskBg;
       let text = `${icons.battery(win.usedPercentage)} ${win.usedPercentage.toFixed(0)}%(${label})`;
-      // 7d quota projection — same gate as classic line2. The warning rides
-      // inside the existing segment (no new powerline cell) so it inherits the
-      // segment's bg and survives/falls together under fitSegments eviction.
-      if (label === '7d' && display.quotaProjection) {
-        const proj = computeQuotaProjection(
-          win.usedPercentage,
-          win.resetsAt,
-          SEVEN_DAY_WINDOW_SEC,
-          undefined,
-          SEVEN_DAY_MIN_ELAPSED_SEC,
-        );
-        if (proj && proj.willExhaustBefore) {
-          const warning = formatProjectionWarning(proj);
-          if (warning) text += ` ${warning}`;
-        }
+      // 7d quota projection — rides inside the existing segment (no new
+      // powerline cell) so it inherits the segment's bg and survives/falls
+      // together under fitSegments eviction.
+      if (label === '7d' && sevenDayProjWarning) {
+        text += ` ${sevenDayProjWarning}`;
+        sevenDayWarningAttachedToBadge = true;
       }
       segments.push({ text, bg, fg: palette.fg, priority: critical ? 85 : 40 });
     }
+  }
+
+  // 7d projection standalone — surfaces when the badge is hidden (<50%) but
+  // the burn rate predicts exhaustion. 🔥 (sub-12h) escalates to branchDirtyBg
+  // with high priority (80) to survive eviction; ⚠ uses taskBg at priority 50.
+  if (sevenDayProjWarning && !sevenDayWarningAttachedToBadge) {
+    const isCritical = sevenDayProjWarning.startsWith('🔥');
+    segments.push({
+      text: sevenDayProjWarning,
+      bg: isCritical ? palette.branchDirtyBg : palette.taskBg,
+      fg: palette.fg,
+      priority: isCritical ? 80 : 50,
+    });
   }
 
   // Pace delta — how far ahead/behind of expected quota burn rate.

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -137,14 +137,17 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
 
   // 7d projection standalone — surfaces when the badge is hidden (<50%) but
   // the burn rate predicts exhaustion. 🔥 (sub-12h) escalates to branchDirtyBg
-  // with high priority (80) to survive eviction; ⚠ uses taskBg at priority 50.
+  // with priority 86 — one above the 5h critical (85). The 5h critical has a
+  // redundant carrier in paceDelta, but standalone 🔥 has no other surface; if
+  // narrow-cols eviction must drop one, the more actionable signal stays. ⚠
+  // (non-imminent) sits at priority 50 and yields to short-window urgency.
   if (sevenDayProjWarning && !sevenDayWarningAttachedToBadge) {
     const isCritical = sevenDayProjWarning.startsWith('🔥');
     segments.push({
       text: sevenDayProjWarning,
       bg: isCritical ? palette.branchDirtyBg : palette.taskBg,
       fg: palette.fg,
-      priority: isCritical ? 80 : 50,
+      priority: isCritical ? 86 : 50,
     });
   }
 

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -728,6 +728,52 @@ describe('renderLine2', () => {
       expect(out).not.toContain('⚠ ~');
       expect(out).not.toContain('🔥 ~');
     });
+
+    // The projection signal is independent of `display.rateLimits` — mirrors
+    // the pace-delta pattern (line2.ts:165 has the same independence). A user
+    // who hides the rate-limit badges still benefits from the exhaustion
+    // warning when burn rate predicts they will not make it to reset.
+    it('renders standalone projection even when display.rateLimits is off (independent toggles)', () => {
+      const pinnedNow = 1_700_000_000_000;
+      vi.useFakeTimers({ now: pinnedNow });
+      const nowSec = pinnedNow / 1000;
+      // 1d elapsed of 7d, 60% used → would normally attach to badge, but
+      // rateLimits is off so the badge is suppressed. Warning must surface
+      // standalone instead.
+      const resetsAt = nowSec + (7 * 24 * 3600 - 86400);
+      const inputOverride = {
+        rate_limits: { seven_day: { used_percentage: 60, resets_at: resetsAt } },
+      };
+      const ctx = makeCtx(
+        { config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, rateLimits: false } } },
+        inputOverride,
+      );
+      const out = stripAnsi(renderLine2(ctx, c));
+      // Badge suppressed by rateLimits=false
+      expect(out).not.toContain('60%(7d)');
+      // Projection still surfaces standalone — toggles are independent
+      expect(out).toContain('⚠ ~');
+    });
+
+    // I2 regression guard: the projection appended to a visible badge must
+    // carry the same severity color it carries when standalone. Otherwise
+    // crossing 49%→50% silently demotes the visual urgency of the warning.
+    it('colors the attached projection with severity color (red for 🔥, yellow for ⚠)', () => {
+      const pinnedNow = 1_700_000_000_000;
+      vi.useFakeTimers({ now: pinnedNow });
+      const nowSec = pinnedNow / 1000;
+      // 1d elapsed of 7d, 50% used → TTE = 24h → ⚠ ~24h, badge visible
+      const resetsAt = nowSec + (7 * 24 * 3600 - 86400);
+      const inputOverride = {
+        rate_limits: { seven_day: { used_percentage: 50, resets_at: resetsAt } },
+      };
+      const out = renderLine2(makeCtx({}, inputOverride), c);
+      // Match an ANSI open sequence (not a reset) directly preceding the
+      // warning glyph. `(?!0)` rejects the `\x1b[0m` reset that closes the
+      // badge — the warning must be wrapped in its OWN color open, not
+      // inherit blanket from the badge wrap.
+      expect(out).toMatch(/\x1b\[(?!0m)[\d;]+m⚠ ~24h/u);
+    });
   });
 });
 

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -667,6 +667,67 @@ describe('renderLine2', () => {
       expect(segmentTail).not.toContain('⚠ ~');
       expect(segmentTail).not.toContain('🔥 ~');
     });
+
+    // ── Standalone projection (badge-decoupled) ────────────────────────────
+    //
+    // When usedPercentage < 50 the 7d badge is suppressed as noise, but the
+    // projection may still predict exhaustion before reset. Without surfacing
+    // the warning standalone the most actionable signal (early-window
+    // unsustainable burn) is silenced. These tests lock the decoupled
+    // behaviour.
+
+    it.each([
+      // 1d elapsed of 7d, 20% used → TTE = 4d, willExhaust=true, ⚠ tier (≥12h)
+      { label: '⚠ warning tier renders yellow standalone when below 50%', usedPct: 20, elapsedSec: 86400, expectedWarning: '⚠ ~4d' },
+      // 3h elapsed of 7d, 40% used → TTE = 4.5h, 🔥 tier (sub-12h), badge hidden
+      { label: '🔥 critical tier renders red standalone when below 50%', usedPct: 40, elapsedSec: 10800, expectedWarning: '🔥 ~4h' },
+    ])('$label', ({ usedPct, elapsedSec, expectedWarning }) => {
+      const pinnedNow = 1_700_000_000_000;
+      vi.useFakeTimers({ now: pinnedNow });
+      const nowSec = pinnedNow / 1000;
+      const resetsAt = nowSec + (7 * 24 * 3600 - elapsedSec);
+      const inputOverride = {
+        rate_limits: { seven_day: { used_percentage: usedPct, resets_at: resetsAt } },
+      };
+      const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+      // Badge is hidden (below 50% gate)
+      expect(out).not.toContain(`${usedPct}%(7d)`);
+      // Warning still renders standalone
+      expect(out).toContain(expectedWarning);
+    });
+
+    it('attaches projection to badge when usedPercentage >= 50 (no duplicate standalone)', () => {
+      const pinnedNow = 1_700_000_000_000;
+      vi.useFakeTimers({ now: pinnedNow });
+      const nowSec = pinnedNow / 1000;
+      // 1d elapsed of 7d, 50% used → ⚠ ~24h, badge visible
+      const resetsAt = nowSec + (7 * 24 * 3600 - 86400);
+      const inputOverride = {
+        rate_limits: { seven_day: { used_percentage: 50, resets_at: resetsAt } },
+      };
+      const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+      // Badge AND warning both present in the same segment
+      expect(out).toContain('50%(7d)');
+      expect(out).toContain('⚠ ~24h');
+      // Exactly one occurrence of the warning glyph (not duplicated standalone)
+      const matches = out.match(/⚠ ~/g) ?? [];
+      expect(matches.length).toBe(1);
+    });
+
+    it('does not render standalone when projection does not predict exhaustion (below 50%)', () => {
+      const pinnedNow = 1_700_000_000_000;
+      vi.useFakeTimers({ now: pinnedNow });
+      const nowSec = pinnedNow / 1000;
+      // 6d elapsed of 7d, 10% used → low burn, TTE > remaining → no warning
+      const resetsAt = nowSec + (7 * 24 * 3600 - 518400);
+      const inputOverride = {
+        rate_limits: { seven_day: { used_percentage: 10, resets_at: resetsAt } },
+      };
+      const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
+      expect(out).not.toContain('10%(7d)');
+      expect(out).not.toContain('⚠ ~');
+      expect(out).not.toContain('🔥 ~');
+    });
   });
 });
 

--- a/tests/render/powerline-line2.test.ts
+++ b/tests/render/powerline-line2.test.ts
@@ -543,5 +543,17 @@ describe('renderPowerlineLine2', () => {
       expect(out).not.toContain('⚠ ~');
       expect(out).not.toContain('🔥 ~');
     });
+
+    // The projection signal is independent of `display.rateLimits` (mirrors
+    // pace-delta). Users who hide rate-limit badges still benefit from the
+    // exhaustion warning.
+    it('renders standalone projection even when display.rateLimits is off (independent toggles)', () => {
+      // 1d elapsed of 7d, 60% used → would normally attach, but rateLimits is
+      // off so the badge is suppressed. Warning must surface standalone.
+      const ctx = ctxWith7dProjection(60, 86400, { rateLimits: false });
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).not.toContain('60%(7d)');
+      expect(out).toContain('⚠ ~');
+    });
   });
 });

--- a/tests/render/powerline-line2.test.ts
+++ b/tests/render/powerline-line2.test.ts
@@ -509,5 +509,39 @@ describe('renderPowerlineLine2', () => {
       expect(segmentTail).not.toContain('⚠ ~');
       expect(segmentTail).not.toContain('🔥 ~');
     });
+
+    // ── Standalone projection segment (badge-decoupled) ────────────────────
+    //
+    // Mirrors line2.ts: when usedPercentage < 50 the 7d badge is suppressed,
+    // but a projection that predicts exhaustion before reset must still
+    // surface — as a dedicated powerline segment.
+
+    it.each([
+      { label: '⚠ warning tier renders standalone when below 50%', usedPct: 20, elapsedSec: 86400, expectedWarning: '⚠ ~4d' },
+      { label: '🔥 critical tier renders standalone when below 50%', usedPct: 40, elapsedSec: 10800, expectedWarning: '🔥 ~4h' },
+    ])('$label', ({ usedPct, elapsedSec, expectedWarning }) => {
+      const ctx = ctxWith7dProjection(usedPct, elapsedSec);
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).not.toContain(`${usedPct}%(7d)`);
+      expect(out).toContain(expectedWarning);
+    });
+
+    it('attaches projection to 7d segment when usedPercentage >= 50 (no duplicate standalone)', () => {
+      const ctx = ctxWith7dProjection(50, 86400);
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).toContain('50%(7d)');
+      expect(out).toContain('⚠ ~24h');
+      const matches = out.match(/⚠ ~/g) ?? [];
+      expect(matches.length).toBe(1);
+    });
+
+    it('does not render standalone when projection does not predict exhaustion (below 50%)', () => {
+      // 6d elapsed of 7d, 10% used → TTE far exceeds remaining → no warning
+      const ctx = ctxWith7dProjection(10, 518400);
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).not.toContain('10%(7d)');
+      expect(out).not.toContain('⚠ ~');
+      expect(out).not.toContain('🔥 ~');
+    });
   });
 });

--- a/tests/render/powerline-line2.test.ts
+++ b/tests/render/powerline-line2.test.ts
@@ -555,5 +555,80 @@ describe('renderPowerlineLine2', () => {
       expect(out).not.toContain('60%(7d)');
       expect(out).toContain('⚠ ~');
     });
+
+    // ── ANSI/bg robustness (post-second-review tightening) ─────────────────
+    //
+    // The previous projection tests all stripped ANSI before asserting, so a
+    // future change that drops the inline colour wrap or flattens the severity
+    // bg to a neutral palette slot would not be caught. These tests lock both.
+
+    it('attached projection in 7d segment carries inline yellow ANSI wrap (⚠ tier)', () => {
+      // 1d elapsed of 7d, 50% used → ⚠ ~24h, badge visible at >=50%.
+      // Module-level `c` is truecolor — yellow emits \x1b[38;2;255;255;0m.
+      const ctx = ctxWith7dProjection(50, 86400);
+      const raw = renderPowerlineLine2(ctx, 'truecolor', null, c);
+      expect(raw).toContain('\x1b[38;2;255;255;0m⚠ ~24h\x1b[0m');
+    });
+
+    it('attached projection in 7d segment carries inline red ANSI wrap (🔥 tier)', () => {
+      // 6h elapsed of 7d, 60% used → TTE 4h → 🔥. Badge visible at >=50%.
+      // Note: createColors keeps `red` in named mode even when overall mode is
+      // truecolor (colors.ts:53 spread leaves red/blinkRed at \x1b[31m). The
+      // assertion tracks the actual emitted escape, not the theoretical
+      // truecolor red.
+      const ctx = ctxWith7dProjection(60, 6 * 3600);
+      const raw = renderPowerlineLine2(ctx, 'truecolor', null, c);
+      expect(raw).toContain('\x1b[31m🔥 ~4h\x1b[0m');
+    });
+
+    it('standalone 🔥 emits BRANCH_DIRTY_BG; standalone ⚠ emits TASK_BG', () => {
+      // Default truecolor palette values (theme=null path, see themes.ts).
+      const BRANCH_DIRTY_BG = '\x1b[48;2;160;40;40m';
+      const TASK_BG = '\x1b[48;2;128;96;24m';
+
+      // 3h elapsed of 7d, 40% used → TTE 4.5h → 🔥 ~4h standalone (<50% badge hidden)
+      const critCtx = ctxWith7dProjection(40, 10800);
+      const critRaw = renderPowerlineLine2(critCtx, 'truecolor', null, c);
+      expect(critRaw).toContain('🔥 ~4h');
+      expect(critRaw).toContain(BRANCH_DIRTY_BG);
+
+      // 1d elapsed of 7d, 20% used → TTE 4d → ⚠ ~4d standalone (<50% badge hidden)
+      const warnCtx = ctxWith7dProjection(20, 86400);
+      const warnRaw = renderPowerlineLine2(warnCtx, 'truecolor', null, c);
+      expect(warnRaw).toContain('⚠ ~4d');
+      expect(warnRaw).toContain(TASK_BG);
+    });
+
+    it('standalone 🔥 outlives 5h critical under narrow-cols eviction', () => {
+      // Concurrence pattern the headline scenario must protect: heavy short-
+      // burst usage (5h critical, priority 85) AND silent weekly trajectory
+      // off-rails (7d sub-50% projection 🔥). At cols=45 only one of the two
+      // fits; whichever has lower priority is dropped.
+      //
+      // Reasoning behind 🔥 winning: 5h critical has redundant time-to-exhaust
+      // signal via paceDelta. The standalone 🔥 has no other carrier — if it
+      // evicts, the user sees the immediate fire but loses the warning about
+      // weekly trajectory. The more-actionable signal must win the contest.
+      //
+      // This test fails with standalone 🔥 priority <= 85; passes when > 85.
+      const pinnedNow = 1_700_000_000_000;
+      vi.useFakeTimers({ now: pinnedNow });
+      const nowSec = pinnedNow / 1000;
+      const fiveHourReset = nowSec + 600;
+      const sevenDayReset = nowSec + (7 * 24 * 3600 - 10800);
+      const rawInput = {
+        model: 'Claude Sonnet 4.6',
+        session_id: 'test',
+        context_window: { used_percentage: 42, remaining_percentage: 58, total_input_tokens: 12000, total_output_tokens: 1800 },
+        cost: { total_cost_usd: 0.42, total_duration_ms: 185000 },
+        rate_limits: {
+          five_hour: { used_percentage: 90, resets_at: fiveHourReset },
+          seven_day: { used_percentage: 40, resets_at: sevenDayReset },
+        },
+      };
+      const ctx = makeCtx({ input: normalize(rawInput), cols: 45 });
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).toContain('🔥 ~4h');
+    });
   });
 });

--- a/tests/render/powerline-line2.test.ts
+++ b/tests/render/powerline-line2.test.ts
@@ -586,14 +586,21 @@ describe('renderPowerlineLine2', () => {
       const BRANCH_DIRTY_BG = '\x1b[48;2;160;40;40m';
       const TASK_BG = '\x1b[48;2;128;96;24m';
 
-      // 3h elapsed of 7d, 40% used → TTE 4.5h → 🔥 ~4h standalone (<50% badge hidden)
+      // 3h elapsed of 7d, 40% used → TTE 4.5h → 🔥 ~4h standalone (<50% badge hidden).
+      // BRANCH_DIRTY_BG is unique to the standalone 🔥 in this context (no
+      // rate-limit segment ≥85%, no cacheMetrics <40%), so the assertion is
+      // strict without further toggle gating.
       const critCtx = ctxWith7dProjection(40, 10800);
       const critRaw = renderPowerlineLine2(critCtx, 'truecolor', null, c);
       expect(critRaw).toContain('🔥 ~4h');
       expect(critRaw).toContain(BRANCH_DIRTY_BG);
 
-      // 1d elapsed of 7d, 20% used → TTE 4d → ⚠ ~4d standalone (<50% badge hidden)
-      const warnCtx = ctxWith7dProjection(20, 86400);
+      // 1d elapsed of 7d, 20% used → TTE 4d → ⚠ ~4d standalone (<50% badge hidden).
+      // `cost: false` disables the cost segment (which also emits TASK_BG) so
+      // the assertion locks the standalone ⚠ segment's bg specifically. Without
+      // this gate the test would pass even if the standalone ⚠ used a
+      // different bg.
+      const warnCtx = ctxWith7dProjection(20, 86400, { cost: false });
       const warnRaw = renderPowerlineLine2(warnCtx, 'truecolor', null, c);
       expect(warnRaw).toContain('⚠ ~4d');
       expect(warnRaw).toContain(TASK_BG);


### PR DESCRIPTION
## Problem

The 7d quota projection warning shipped in v1.3.0 (#118) was wired inside the rate-limits loop and inherited the loop's 50% badge filter. The warning was silenced precisely in the range where it's most actionable: early-window unsustainable burn the user can still correct.

Example: at 20% used on day 1 of a 7-day window, linear extrapolation predicts hitting 100% by day 5 — well before the day-7 reset. The math fires, the format produces `⚠ ~4d`, but the renderer drops it because the badge filter skips the segment under 50%.

## Fix

**Commit 1 (`203f76c`):** decouple the projection from the badge filter.
- Compute the projection once upfront.
- Attach to the badge when visible (≥50%, behavior unchanged).
- Push as a standalone segment otherwise.

**Commit 2 (`72d72c8`):** two follow-ups from code review.
- I1: standalone projection is now independent of `display.rateLimits` (matches existing `paceDelta` precedent). Documented and locked with a test. Users who hide rate-limit badges still benefit from the exhaustion warning.
- I2: the projection attached to a visible badge now carries its own severity color (red for 🔥, yellow for ⚠). Previously the attached warning rendered uncolored, so crossing 49%→50% silently demoted the warning's visual urgency.

## Math validation

| Scenario | usedPct | Time elapsed | Time remaining | TTE | Before fix | After fix |
|---|---|---|---|---|---|---|
| S1 | 20% | 1d | 6d | 4d | (silent) | `⚠ ~4d` standalone |
| S2 | 30% | 1d | 6d | 2.3d | (silent) | `⚠ ~2d` standalone |
| S3 | 40% | 2d | 5d | 3d | (silent) | `⚠ ~3d` standalone |
| S4 | 50% | 2d | 5d | 2d | `⚠ ~2d` attached (uncolored) | `⚠ ~2d` attached (yellow) |
| S5 | 95% | 6d | 1d | 7h | `🔥 ~7h` attached (uncolored) | `🔥 ~7h` attached (red) |

## Test coverage

- 893 tests passing (882 → +11 new).
- New tests cover both renderers in parallel:
  - Standalone ⚠ tier below 50%.
  - Standalone 🔥 tier below 50%.
  - Attached-vs-standalone non-duplication at 50% boundary.
  - No-render when burn rate is sustainable.
  - Independent of `display.rateLimits` toggle.
  - Attached projection carries severity ANSI color (classic).

## Behavior change for release notes

The standalone 7d projection warning now renders independently of `display.rateLimits`, matching the existing `paceDelta` behavior. Users who have `rateLimits: false` may now see a projection warning that was previously suppressed. This is intended — the projection is a discrete alarm signal, not part of the rate-limit family display.

## Follow-up

#131 — `refactor(render): consolidate pace + projection burn-rate math into shared compute` — tracks the duplicated burn-rate math between `pace.ts` and `quota-projection.ts`. Not blocking this fix.

## Suggested release

Patch: v1.3.1.