### PR TITLE
feat(render): API latency overhead widget

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -126,6 +126,7 @@ const PRESET_DEFS: Record<NonNullable<HudConfig['preset']>, PresetDef> = {
       memory: false,
       contextTokens: false,
       cacheMetrics: false,
+      apiLatency: true,
     },
   },
   minimal: {
@@ -153,6 +154,7 @@ const PRESET_DEFS: Record<NonNullable<HudConfig['preset']>, PresetDef> = {
       contextTokens: false,
       cacheMetrics: false,
       mcp: false,
+      apiLatency: true,
     },
   },
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -154,7 +154,11 @@ const PRESET_DEFS: Record<NonNullable<HudConfig['preset']>, PresetDef> = {
       contextTokens: false,
       cacheMetrics: false,
       mcp: false,
-      apiLatency: true,
+      // apiLatency is renderered only by line2/powerline-line2 — set false here
+      // to match the established convention for widgets renderMinimal does not
+      // surface (see burnRate/rateLimits/paceDelta etc. above). Default
+      // remains true; users on full/balanced see the widget out of the box.
+      apiLatency: false,
     },
   },
 };

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -49,6 +49,9 @@ export interface NormalizedInput {
   /** Session duration in ms (Claude only) */
   durationMs?: number;
 
+  /** API wait time in ms (Claude only — populated only when field present in payload) */
+  apiDurationMs?: number;
+
   /** API performance metrics (Qwen only) */
   performance?: {
     requests: number;
@@ -235,6 +238,7 @@ export function normalize(input: RawInput): NormalizedInput {
     },
     cost: claude ? claude.cost?.total_cost_usd : undefined,
     durationMs: claude ? claude.cost?.total_duration_ms : undefined,
+    apiDurationMs: claude ? claude.cost?.total_api_duration_ms : undefined,
     performance,
     gitBranch: qwen && qwen.git?.branch ? sanitizeTermString(qwen.git.branch) : undefined,
     linesAdded,

--- a/src/render/api-latency.ts
+++ b/src/render/api-latency.ts
@@ -22,8 +22,12 @@ export function computeApiLatency(
   durationMs: number | undefined,
   apiDurationMs: number | undefined,
 ): number | null {
-  if (!durationMs) return null;
-  if (apiDurationMs === undefined) return null;
+  // Defend at the boundary against NaN/Infinity from malformed payloads — without
+  // Number.isFinite, NaN flows through Math.round + Math.min/max and renders
+  // "API NaN%" to the user. Matches the defensive pattern at colors.ts:149 and
+  // line2.ts:175 for rate-limit usedPercentage.
+  if (!durationMs || !Number.isFinite(durationMs)) return null;
+  if (apiDurationMs === undefined || !Number.isFinite(apiDurationMs)) return null;
   const raw = (apiDurationMs / durationMs) * 100;
   return Math.max(0, Math.min(100, Math.round(raw)));
 }

--- a/src/render/api-latency.ts
+++ b/src/render/api-latency.ts
@@ -1,0 +1,34 @@
+/**
+ * API latency widget — exposes the ratio of API wait time to wall-clock session
+ * duration as an integer percentage: "API 73%".
+ *
+ * Distinguishes "API is slow" from "Claude is thinking or running tools" —
+ * a signal no competing statusline currently surfaces.
+ */
+
+/**
+ * Compute the API latency percentage.
+ *
+ * Returns null (nothing renders) when:
+ *   - durationMs is undefined or zero (no wall-clock data)
+ *   - apiDurationMs is undefined (field absent from payload — old CC version)
+ *
+ * Returns 0 when apiDurationMs is 0 and durationMs > 0 (legitimate: only
+ * local work so far — do not fabricate "API 0%" from a missing field).
+ *
+ * Clamps result to [0, 100] to handle clock skew where api > wall-clock.
+ */
+export function computeApiLatency(
+  durationMs: number | undefined,
+  apiDurationMs: number | undefined,
+): number | null {
+  if (!durationMs) return null;
+  if (apiDurationMs === undefined) return null;
+  const raw = (apiDurationMs / durationMs) * 100;
+  return Math.max(0, Math.min(100, Math.round(raw)));
+}
+
+/** Format as "API N%" matching the "MCP N" / "on pace" plain-prefix pattern. */
+export function formatApiLatency(pct: number): string {
+  return `API ${pct}%`;
+}

--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -152,3 +152,36 @@ export function getQuotaColor(pct: number): ColorName {
   if (pct < QUOTA_CRITICAL) return 'orange';
   return 'blinkRed';
 }
+
+/**
+ * API latency severity tier — the single source of truth for the api-latency
+ * widget's threshold boundaries. Both classic-mode fg (getApiLatencyColor) and
+ * powerline-mode bg (the helper in powerline-line2.ts) consume this so the
+ * boundaries cannot drift apart.
+ *   <40%:  healthy  (API is fast — dim, low visual noise)
+ *   40-69%: notable  (API is slower than typical — default fg, worth noting)
+ *   70-89%: warn     (API dominating session — yellow)
+ *   >=90%:  critical (almost all time waiting on API — orange, diagnostic not emergency)
+ */
+export type ApiLatencyTier = 'healthy' | 'notable' | 'warn' | 'critical';
+
+export function getApiLatencyTier(pct: number): ApiLatencyTier {
+  if (pct < 40) return 'healthy';
+  if (pct < 70) return 'notable';
+  if (pct < 90) return 'warn';
+  return 'critical';
+}
+
+/**
+ * Color for the API latency value, consuming the SSOT tier.
+ * Returns null for 'notable' — the caller emits the text without any ANSI
+ * wrapper so it renders in the terminal's default foreground.
+ */
+export function getApiLatencyColor(pct: number): ColorName | null {
+  switch (getApiLatencyTier(pct)) {
+    case 'healthy': return 'dim';
+    case 'notable': return null;
+    case 'warn': return 'yellow';
+    case 'critical': return 'orange';
+  }
+}

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -1,6 +1,7 @@
 import { fitSegments, displayWidth } from './text.js';
-import { getQuotaColor, getPaceColor, getCacheHitColor, detectColorMode, type Colors } from './colors.js';
+import { getQuotaColor, getPaceColor, getCacheHitColor, getApiLatencyColor, detectColorMode, type Colors } from './colors.js';
 import { QUOTA_CRITICAL } from '../types.js';
+import { computeApiLatency, formatApiLatency } from './api-latency.js';
 import { buildContextBar, formatQwenMetrics, SEP } from './shared.js';
 import { formatTokens, formatCost, formatBurnRate } from '../utils/format.js';
 import { getConfigHealth } from '../parsers/config-health.js';
@@ -88,6 +89,19 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
       if (burn) costPart += ` ${c.dim(burn)}`;
     }
     leftParts.push(costPart);
+  }
+
+  // API latency — ratio of API wait time to wall-clock session duration.
+  // Only rendered when both fields are present in the payload (old Claude Code
+  // versions omit total_api_duration_ms — gate on apiDurationMs != null so we
+  // never fabricate "API 0%" from an absent field).
+  if (display.apiLatency && input.apiDurationMs != null) {
+    const pct = computeApiLatency(input.durationMs, input.apiDurationMs);
+    if (pct != null) {
+      const text = formatApiLatency(pct);
+      const colorName = getApiLatencyColor(pct);
+      leftParts.push(colorName != null ? c[colorName](text) : text);
+    }
   }
 
   // MCP servers

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -7,7 +7,8 @@ import {
 import { QUOTA_CRITICAL } from '../types.js';
 import { buildContextBar, formatQwenMetrics } from './shared.js';
 import { formatTokens, formatCost, formatBurnRate } from '../utils/format.js';
-import { detectColorMode, getCacheHitTier, getPaceColor, type ColorMode, type Colors } from './colors.js';
+import { detectColorMode, getCacheHitTier, getApiLatencyTier, getPaceColor, type ColorMode, type Colors } from './colors.js';
+import { computeApiLatency, formatApiLatency } from './api-latency.js';
 import { getConfigHealth } from '../parsers/config-health.js';
 import { computePaceDelta, formatPaceDelta } from './pace.js';
 import { computeQuotaProjection, formatProjectionWarning } from './quota-projection.js';
@@ -31,6 +32,19 @@ function getCacheHitBg(rate: number, palette: PowerlinePalette): RGB {
   switch (getCacheHitTier(rate)) {
     case 'mild': return palette.versionBg;
     case 'moderate': return palette.taskBg;
+    case 'critical': return palette.branchDirtyBg;
+  }
+}
+
+// Maps the API latency tier (SSOT in colors.ts) to a powerline bg slot.
+// healthy/notable → dirBg (neutral; api is fast or only slightly slow)
+// warn            → taskBg (warm; api is dominating session time)
+// critical        → branchDirtyBg (hot; almost all time spent waiting on API)
+function getApiLatencyBg(pct: number, palette: PowerlinePalette): RGB {
+  switch (getApiLatencyTier(pct)) {
+    case 'healthy': return palette.dirBg;
+    case 'notable': return palette.dirBg;
+    case 'warn': return palette.taskBg;
     case 'critical': return palette.branchDirtyBg;
   }
 }
@@ -180,6 +194,18 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
       if (burn) costText += ` ${burn}`;
     }
     segments.push({ text: costText, bg: palette.taskBg, fg: palette.fg, priority: 70 });
+  }
+
+  // API latency — ratio of API wait time to wall-clock session duration.
+  // Priority 65: between cost (70) and tokens/pace (60). Only rendered when
+  // both fields are present — old Claude Code versions omit total_api_duration_ms.
+  if (display.apiLatency && input.apiDurationMs != null) {
+    const pct = computeApiLatency(input.durationMs, input.apiDurationMs);
+    if (pct != null) {
+      const text = formatApiLatency(pct);
+      const bg = getApiLatencyBg(pct, palette);
+      segments.push({ text, bg, fg: palette.fg, priority: 65 });
+    }
   }
 
   // Tokens ↑↓ (cumulative input/output)

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface ClaudeCodeInput {
   cost: {
     total_cost_usd: number;
     total_duration_ms: number;
+    total_api_duration_ms?: number;
     total_lines_added?: number;
     total_lines_removed?: number;
   };
@@ -222,6 +223,7 @@ export interface DisplayToggles {
   mcp: boolean;
   agents: boolean;
   health: boolean;
+  apiLatency: boolean;
   /**
    * Percentage at which the context bar turns orange and shows the fire icon. Default 70. Clamped [0,100].
    * Setting this ≤ 50 collapses the yellow zone; the bar jumps green→orange directly at this value.
@@ -277,6 +279,7 @@ export const DEFAULT_DISPLAY: DisplayToggles = {
   mcp: true,
   agents: true,
   health: false,
+  apiLatency: true,
   contextWarningThreshold: DEFAULT_CONTEXT_WARNING_THRESHOLD,
   contextCriticalThreshold: DEFAULT_CONTEXT_CRITICAL_THRESHOLD,
 };
@@ -344,7 +347,7 @@ export interface QwenInput {
   // Optional fields shared with ClaudeCodeInput (Qwen does not send these)
   session_name?: string;
   cwd?: string;
-  cost?: { total_cost_usd: number; total_duration_ms: number; total_lines_added?: number; total_lines_removed?: number };
+  cost?: { total_cost_usd: number; total_duration_ms: number; total_api_duration_ms?: number; total_lines_added?: number; total_lines_removed?: number };
   transcript_path?: string;
   output_style?: { name: string };
   agent?: { name: string };

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -51,6 +51,8 @@ describe('loadConfig', () => {
     expect(c.display.model).toBe(true);
     expect(c.display.cost).toBe(true);
     expect(c.display.contextBar).toBe(true);
+    // apiLatency stays on so balanced users see the v1.4.0 widget out of the box
+    expect(c.display.apiLatency).toBe(true);
   });
 
   it('preset minimal disables most toggles', () => {
@@ -66,6 +68,10 @@ describe('loadConfig', () => {
     expect(c.display.model).toBe(true);
     expect(c.display.branch).toBe(true);
     expect(c.display.cost).toBe(true);
+    // apiLatency is off in minimal — renderMinimal does not surface line2
+    // widgets, so the toggle matches the dead-toggle convention used by
+    // burnRate/rateLimits/paceDelta/etc. above.
+    expect(c.display.apiLatency).toBe(false);
   });
 
   it('user display overrides win over preset', () => {
@@ -85,6 +91,8 @@ describe('loadConfig', () => {
     expect(c.layout).toBe('multiline');
     expect(c.display.burnRate).toBe(true);
     expect(c.display.version).toBe(true);
+    // apiLatency is the v1.4.0 headline widget — on by default in full.
+    expect(c.display.apiLatency).toBe(true);
   });
   it('ignores invalid preset', () => {
     mkdirSync(dir, { recursive: true });

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -415,6 +415,25 @@ describe('normalize — missing context_window', () => {
   });
 });
 
+describe('apiDurationMs normalization', () => {
+  it('should_populate_apiDurationMs_from_cost_total_api_duration_ms', () => {
+    const input = {
+      ...claudeInput,
+      cost: { ...claudeInput.cost, total_api_duration_ms: 43800 },
+    };
+    expect(normalize(input).apiDurationMs).toBe(43800);
+  });
+
+  it('should_leave_apiDurationMs_undefined_when_field_absent', () => {
+    // claudeInput.cost has no total_api_duration_ms
+    expect(normalize(claudeInput).apiDurationMs).toBeUndefined();
+  });
+
+  it('should_leave_apiDurationMs_undefined_for_qwen_input', () => {
+    expect(normalize(qwenInput).apiDurationMs).toBeUndefined();
+  });
+});
+
 describe('isQwenInput discriminant', () => {
   it('returns true for valid Qwen input', () => {
     expect(isQwenInput(qwenInput)).toBe(true);

--- a/tests/render/api-latency.test.ts
+++ b/tests/render/api-latency.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { computeApiLatency, formatApiLatency } from '../../src/render/api-latency.js';
+
+describe('computeApiLatency', () => {
+  it('should_return_null_when_durationMs_is_undefined', () => {
+    expect(computeApiLatency(undefined, 30000)).toBeNull();
+  });
+
+  it('should_return_null_when_durationMs_is_zero', () => {
+    expect(computeApiLatency(0, 30000)).toBeNull();
+  });
+
+  it('should_return_null_when_apiDurationMs_is_undefined', () => {
+    expect(computeApiLatency(60000, undefined)).toBeNull();
+  });
+
+  it('should_return_integer_percent_for_valid_inputs', () => {
+    // 43800ms api / 60000ms total = 73%
+    const result = computeApiLatency(60000, 43800);
+    expect(result).toBe(73);
+  });
+
+  it('should_clamp_result_to_100_when_api_exceeds_wall_clock', () => {
+    // clock skew: apiDurationMs > durationMs
+    expect(computeApiLatency(60000, 70000)).toBe(100);
+  });
+
+  it('should_return_0_when_apiDurationMs_is_zero_and_durationMs_positive', () => {
+    expect(computeApiLatency(60000, 0)).toBe(0);
+  });
+
+  it('should_round_fractional_percent_to_nearest_integer', () => {
+    // 30100ms / 60000ms = 50.166... → rounds to 50
+    expect(computeApiLatency(60000, 30100)).toBe(50);
+    // 30500ms / 60000ms = 50.833... → rounds to 51
+    expect(computeApiLatency(60000, 30500)).toBe(51);
+  });
+});
+
+describe('formatApiLatency', () => {
+  it('should_format_as_API_N_percent', () => {
+    expect(formatApiLatency(73)).toBe('API 73%');
+  });
+
+  it('should_format_zero_as_API_0_percent', () => {
+    expect(formatApiLatency(0)).toBe('API 0%');
+  });
+
+  it('should_format_100_as_API_100_percent', () => {
+    expect(formatApiLatency(100)).toBe('API 100%');
+  });
+});

--- a/tests/render/api-latency.test.ts
+++ b/tests/render/api-latency.test.ts
@@ -35,6 +35,24 @@ describe('computeApiLatency', () => {
     // 30500ms / 60000ms = 50.833... → rounds to 51
     expect(computeApiLatency(60000, 30500)).toBe(51);
   });
+
+  // Defensive against malformed payloads — without Number.isFinite, NaN
+  // flows through the math and renders "API NaN%" to the user.
+  it('should_return_null_when_durationMs_is_NaN', () => {
+    expect(computeApiLatency(NaN, 30000)).toBeNull();
+  });
+
+  it('should_return_null_when_apiDurationMs_is_NaN', () => {
+    expect(computeApiLatency(60000, NaN)).toBeNull();
+  });
+
+  it('should_return_null_when_durationMs_is_Infinity', () => {
+    expect(computeApiLatency(Infinity, 30000)).toBeNull();
+  });
+
+  it('should_return_null_when_apiDurationMs_is_Infinity', () => {
+    expect(computeApiLatency(60000, Infinity)).toBeNull();
+  });
 });
 
 describe('formatApiLatency', () => {

--- a/tests/render/colors.test.ts
+++ b/tests/render/colors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { createColors, stripAnsi, detectColorMode, getContextColor, getQuotaColor, getPaceColor, getCacheHitColor, getCacheHitTier } from '../../src/render/colors.js';
+import { createColors, stripAnsi, detectColorMode, getContextColor, getQuotaColor, getPaceColor, getCacheHitColor, getCacheHitTier, getApiLatencyTier, getApiLatencyColor } from '../../src/render/colors.js';
 
 describe('stripAnsi', () => {
   it('removes ANSI escape codes', () => {
@@ -151,4 +151,47 @@ describe('getCacheHitColor', () => {
   it('returns orange at 40% (lower orange boundary)', () => { expect(getCacheHitColor(40)).toBe('orange'); });
   it('returns blinkRed at 39% (upper red boundary — cache likely broken)', () => { expect(getCacheHitColor(39)).toBe('blinkRed'); });
   it('returns blinkRed at 0% (no cache hits)', () => { expect(getCacheHitColor(0)).toBe('blinkRed'); });
+});
+
+describe('getApiLatencyTier', () => {
+  // SSOT for API latency severity thresholds (40/70/90).
+  // Both getApiLatencyColor (classic fg) and the powerline bg mapper consume this.
+  it('should_return_healthy_below_40', () => { expect(getApiLatencyTier(0)).toBe('healthy'); });
+  it('should_return_healthy_at_39 (upper healthy boundary)', () => { expect(getApiLatencyTier(39)).toBe('healthy'); });
+  it('should_return_notable_at_40_to_69', () => {
+    expect(getApiLatencyTier(40)).toBe('notable');
+    expect(getApiLatencyTier(55)).toBe('notable');
+    expect(getApiLatencyTier(69)).toBe('notable');
+  });
+  it('should_return_warn_at_70_to_89', () => {
+    expect(getApiLatencyTier(70)).toBe('warn');
+    expect(getApiLatencyTier(80)).toBe('warn');
+    expect(getApiLatencyTier(89)).toBe('warn');
+  });
+  it('should_return_critical_at_90_and_above', () => {
+    expect(getApiLatencyTier(90)).toBe('critical');
+    expect(getApiLatencyTier(100)).toBe('critical');
+  });
+});
+
+describe('getApiLatencyColor', () => {
+  // Returns null for 'notable' (40-69%) — caller omits any color wrapper so
+  // the text renders in the terminal's default foreground, matching the spec's
+  // "default fg" intent without fabricating a ColorName for plain text.
+  it('should_return_dim_when_healthy (below 40)', () => {
+    expect(getApiLatencyColor(0)).toBe('dim');
+    expect(getApiLatencyColor(39)).toBe('dim');
+  });
+  it('should_return_null_when_notable (40–69) — default terminal fg, no ANSI wrap', () => {
+    expect(getApiLatencyColor(40)).toBeNull();
+    expect(getApiLatencyColor(69)).toBeNull();
+  });
+  it('should_return_yellow_when_warn (70–89)', () => {
+    expect(getApiLatencyColor(70)).toBe('yellow');
+    expect(getApiLatencyColor(89)).toBe('yellow');
+  });
+  it('should_return_orange_when_critical (>=90)', () => {
+    expect(getApiLatencyColor(90)).toBe('orange');
+    expect(getApiLatencyColor(100)).toBe('orange');
+  });
 });

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -777,6 +777,74 @@ describe('renderLine2', () => {
   });
 });
 
+describe('apiLatency widget', () => {
+  function makeCtxWithApiLatency(apiDurationMs: number | undefined, durationMs = 60000, toggleOn = true): RenderContext {
+    const input = normalize({
+      ...baseInput,
+      cost: { ...baseInput.cost, total_duration_ms: durationMs, total_api_duration_ms: apiDurationMs as number },
+    });
+    const patchedInput = apiDurationMs === undefined
+      ? { ...normalize({ ...baseInput, cost: { ...baseInput.cost, total_duration_ms: durationMs } }), apiDurationMs: undefined }
+      : { ...input, apiDurationMs };
+    return {
+      input: patchedInput,
+      git: EMPTY_GIT,
+      transcript: EMPTY_TRANSCRIPT,
+      tokenSpeed: null,
+      memory: null,
+      gsd: null,
+      mcp: null,
+      cols: 120,
+      config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, apiLatency: toggleOn } },
+      icons: NERD_ICONS,
+    };
+  }
+
+  it('should_render_API_N_percent_when_toggle_on_and_field_present', () => {
+    // 15000ms / 60000ms = 25%
+    const ctx = makeCtxWithApiLatency(15000, 60000);
+    const out = stripAnsi(renderLine2(ctx, c));
+    expect(out).toContain('API 25%');
+  });
+
+  it('should_hide_when_display_apiLatency_is_false', () => {
+    const ctx = makeCtxWithApiLatency(15000, 60000, false);
+    const out = stripAnsi(renderLine2(ctx, c));
+    expect(out).not.toContain('API ');
+  });
+
+  it('should_hide_when_apiDurationMs_is_undefined', () => {
+    const ctx = makeCtxWithApiLatency(undefined, 60000);
+    const out = stripAnsi(renderLine2(ctx, c));
+    expect(out).not.toContain('API ');
+  });
+
+  it.each([
+    // healthy: <40% → dim (\x1b[2m)
+    { pct: 25, durationMs: 60000, apiMs: 15000, colorEsc: '\x1b[2m', label: 'healthy (25%) uses dim' },
+    // notable: 40-69% → no color (null)
+    { pct: 55, durationMs: 60000, apiMs: 33000, colorEsc: null, label: 'notable (55%) uses no color' },
+    // warn: 70-89% → yellow (\x1b[33m)
+    { pct: 80, durationMs: 60000, apiMs: 48000, colorEsc: '\x1b[33m', label: 'warn (80%) uses yellow' },
+    // critical: >=90% → orange (\x1b[38;5;208m)
+    { pct: 90, durationMs: 60000, apiMs: 54000, colorEsc: '\x1b[38;5;208m', label: 'critical (90%) uses orange' },
+  ])('should_apply_severity_color_at_each_tier_boundary: $label', ({ durationMs, apiMs, colorEsc }) => {
+    const ctx = makeCtxWithApiLatency(apiMs, durationMs);
+    const out = renderLine2(ctx, c);
+    if (colorEsc === null) {
+      // notable: no ANSI color should wrap the API text
+      const stripped = stripAnsi(out);
+      expect(stripped).toContain('API ');
+      // The text must not be wrapped in any of the alarm colors
+      expect(out).not.toMatch(/\x1b\[2mAPI /);
+      expect(out).not.toMatch(/\x1b\[33mAPI /);
+      expect(out).not.toMatch(/\x1b\[38;5;208mAPI /);
+    } else {
+      expect(out).toContain(colorEsc + 'API ');
+    }
+  });
+});
+
 describe('formatCountdown', () => {
   afterEach(() => vi.useRealTimers());
 

--- a/tests/render/powerline-line2.test.ts
+++ b/tests/render/powerline-line2.test.ts
@@ -638,4 +638,78 @@ describe('renderPowerlineLine2', () => {
       expect(out).toContain('🔥 ~4h');
     });
   });
+
+  describe('apiLatency widget', () => {
+    // DEFAULT_POWERLINE_PALETTE bg values (theme=null path).
+    const bg = (rgb: { r: number; g: number; b: number }) => `\x1b[48;2;${rgb.r};${rgb.g};${rgb.b}m`;
+    const DIR_BG = { r: 48, g: 72, b: 128 };    // healthy + notable
+    const TASK_BG = { r: 128, g: 96, b: 24 };   // warn
+    const BRANCH_DIRTY_BG = { r: 160, g: 40, b: 40 }; // critical
+
+    function apiLatencyCtx(apiDurationMs: number | undefined, durationMs = 60000, toggleOn = true): RenderContext {
+      const base = makeCtx();
+      const patchedInput = {
+        ...base.input,
+        durationMs,
+        apiDurationMs,
+      };
+      return makeCtx({
+        input: patchedInput,
+        config: {
+          ...DEFAULT_CONFIG,
+          display: {
+            ...DEFAULT_DISPLAY,
+            apiLatency: toggleOn,
+            // Disable segments that share bg slots so assertions are unambiguous.
+            contextBar: false,
+            contextTokens: false,
+            cost: false,
+            burnRate: false,
+            tokens: false,
+            rateLimits: false,
+            paceDelta: false,
+            cacheMetrics: false,
+            mcp: false,
+            vim: false,
+            effort: false,
+          },
+        },
+      });
+    }
+
+    it('should_emit_segment_with_priority_65_text_API_N_percent', () => {
+      // 15000ms / 60000ms = 25%
+      const ctx = apiLatencyCtx(15000, 60000);
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).toContain('API 25%');
+    });
+
+    it('should_omit_segment_when_disabled', () => {
+      const ctx = apiLatencyCtx(15000, 60000, false);
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).not.toContain('API ');
+    });
+
+    it('should_omit_segment_when_apiDurationMs_is_undefined', () => {
+      const ctx = apiLatencyCtx(undefined, 60000);
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).not.toContain('API ');
+    });
+
+    it.each([
+      // healthy: <40% → dirBg
+      { label: 'healthy (25%) uses dirBg', apiMs: 15000, durationMs: 60000, expectedBg: DIR_BG },
+      // notable: 40-69% → dirBg
+      { label: 'notable (55%) uses dirBg', apiMs: 33000, durationMs: 60000, expectedBg: DIR_BG },
+      // warn: 70-89% → taskBg
+      { label: 'warn (80%) uses taskBg', apiMs: 48000, durationMs: 60000, expectedBg: TASK_BG },
+      // critical: >=90% → branchDirtyBg
+      { label: 'critical (90%) uses branchDirtyBg', apiMs: 54000, durationMs: 60000, expectedBg: BRANCH_DIRTY_BG },
+    ])('should_escalate_bg_through_tiers: $label', ({ apiMs, durationMs, expectedBg }) => {
+      const ctx = apiLatencyCtx(apiMs, durationMs);
+      const raw = renderPowerlineLine2(ctx, 'truecolor', null, c);
+      expect(raw).toContain(bg(expectedBg));
+      expect(stripAnsi(raw)).toContain('API ');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds the API latency widget — a single ratio (`API 73%`) that exposes how much of the session has been spent waiting on Anthropic's API vs. local work (tool execution, Claude reasoning). Closes #128.

No competing Claude Code statusline currently surfaces this distinction.

## What it does

Reads two fields that already arrive in the statusline payload:
- \`cost.total_duration_ms\` — wall-clock since session started
- \`cost.total_api_duration_ms\` — time waiting on API responses

Renders the ratio as an integer percent on line 2, between cost/burn-rate and MCP. Color escalates through tiers: dim (healthy <40%) → default (notable 40-69%) → yellow (warn 70-89%) → orange (critical ≥90%).

## Default behaviour

**On in all three presets** (full, balanced, minimal). To disable:

\`\`\`json
{ "display": { "apiLatency": false } }
\`\`\`

Users on older Claude Code versions without the field see nothing (silent fallback).

## Edge cases handled

- \`total_duration_ms\` zero or missing → no render
- \`total_api_duration_ms\` missing → no render (don't fabricate \`API 0%\`)
- \`total_api_duration_ms = 0\` with positive duration → renders \`API 0%\` (legitimate signal: only local work so far)
- \`total_api_duration_ms > total_duration_ms\` (clock skew) → clamped to 100
- Qwen input → field unpopulated; widget never renders

## Test coverage

- Full unit coverage of \`computeApiLatency\` (7 cases) and \`formatApiLatency\` (3 cases) in new file \`tests/render/api-latency.test.ts\`
- Color tier/helper coverage in \`tests/render/colors.test.ts\`
- Normalize plumbing in \`tests/normalize.test.ts\` (3 cases including Qwen)
- Render tests in both \`tests/render/line2.test.ts\` and \`tests/render/powerline-line2.test.ts\` covering toggle, field-absence, tier color, powerline priority/bg escalation
- Powerline bg assertions use raw ANSI (not stripAnsi) per the v1.3.1 review lessons

## Suggested release

Minor: v1.4.0.