### PR TITLE
chore(release): v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-05-19
+
+### Added
+- **API latency overhead widget** — line 2 now exposes the ratio of `cost.total_api_duration_ms` to `cost.total_duration_ms` as an integer percentage: `API 73%`. Distinguishes "the API is slow / network is the bottleneck" from "Claude is reasoning or running tools locally" — a signal no competing Claude Code statusline currently surfaces. Color escalates through severity tiers via a new SSOT `getApiLatencyTier` in `colors.ts`: dim (<40%, healthy) → default (40–69%, notable) → yellow (70–89%, warn) → orange (≥90%, critical, not blinkRed — this is a diagnostic signal, not an actionable emergency). Powerline mode escalates the segment background through the same tiers (`dirBg`/`taskBg`/`branchDirtyBg`) and sits at priority 65 between cost (70) and tokens (60). New `display.apiLatency` toggle is on by default in `full` and `balanced` — users who don't want the widget set `"display": { "apiLatency": false }` in their config. The `minimal` preset does not surface the widget (`renderMinimal` is opinionated). Defensive against malformed payloads with `Number.isFinite` guards on both timing fields. Closes #128.
+
 ## [1.3.1] - 2026-05-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Real-time statusline HUD for Claude Code and Qwen Code — context bar, burn rate, themes, powerline, zero deps.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Minor release v1.4.0 — adds the API latency overhead widget (PR #134, closes #128). Differentiator: no competing Claude Code statusline currently exposes the `total_api_duration_ms` / `total_duration_ms` ratio.

## Changes since v1.3.1

### Added
- API latency overhead widget — `API N%` on line 2, on by default in `full` and `balanced` presets. Color escalates dim/default/yellow/orange across 40/70/90 thresholds. Powerline bg matches via shared SSOT tier function. (PR #134)

## Test plan
- [x] `npm test` → 937/937
- [x] `npm run lint` clean
- [x] CHANGELOG entry under `[1.4.0]`
- [x] `package.json` version bumped 1.3.1 → 1.4.0