### PR TITLE
chore(release): v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-05-23
+
 ### Added
 
 - **Auto-compact proximity warning glyph (⚠)** — `contextBar` now emits a red ⚠ icon when context fill is in the 5pp window before the platform's auto-compact threshold (75–80% on Claude Code, 65–70% on Qwen Code by default). The glyph is independent of the user-configurable warning/critical thresholds — it tracks the platform constraint, not user preference. Qwen Code users who customized `model.chatCompression.contextPercentageThreshold` should mirror that value in lumira's `contextCriticalThreshold` for accurate gating. The install wizard preview now surfaces an educational footer explaining the behavior. Resolves [#138](https://github.com/cativo23/lumira/issues/138).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lumira",
-  "version": "1.2.3",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lumira",
-      "version": "1.2.3",
+      "version": "1.4.1",
       "license": "MIT",
       "bin": {
         "lumira": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Real-time statusline HUD for Claude Code and Qwen Code — context bar, burn rate, themes, powerline, zero deps.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v1.4.1

Bundles two feature merges:

- **PR #137** — `realUsedPercentage` for contextBar (issue #136). Computes context % from `current_usage` primitives (input + output + cache_read + cache_creation) with fallback to `used_percentage` for legacy payloads.
- **PR #139** — Auto-compact proximity warning glyph + lowered defaults (issue #138). Red ⚠ glyph at 75-80% (Claude) / 65-70% (Qwen). Defaults lowered: warning 70→65, critical 85→78.

Also raises CI bundle ceiling from 440KB to 450KB to accommodate the additions.

## Test plan

- [x] 966/966 tests passing
- [x] tsc --noEmit clean
- [x] Bundle size within new 450KB ceiling
- [x] CHANGELOG updated with both feature entries