### PR TITLE
docs: soften tone in README + package.json description

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Interactive wizard — preset, theme, icons — previewed live before write.
 
 > 3,400+ monthly downloads, zero marketing. Try it for one session — `npx lumira install`.
 
-> **What's new in v1.5:** the [`lumira stats` CLI](#stats-cli) prints post-session analytics (cost, tokens, cache hit, tool frequency, burn rate) — no competing statusline ships this. Combined with the `API N%` latency widget (v1.4.0), 7-day quota projection warning (v1.3.0), and auto-compact proximity glyph ⚠ (v1.4.1), lumira surfaces a set of signals nothing else does.
+> **What's new in v1.5:** the [`lumira stats` CLI](#stats-cli) prints post-session analytics (cost, tokens, cache hit, tool frequency, burn rate). Combined with the `API N%` latency widget (v1.4.0), 7-day quota projection warning (v1.3.0), and auto-compact proximity glyph ⚠ (v1.4.1), recent releases add several diagnostic signals to the session.
 
 ## Table of contents
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lumira",
   "version": "1.5.0",
-  "description": "Real-time statusline HUD for Claude Code and Qwen Code — context bar, burn rate, themes, powerline, zero deps.",
+  "description": "Real-time statusline HUD for Claude Code and Qwen Code. Includes session analytics CLI, API latency overhead widget, 7d quota projection, auto-compact proximity warnings, themes, and powerline. Zero deps.",
   "type": "module",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Replaces comparative/braggy framings ('no competing statusline ships this', 'widgets nothing else has', 'a set of signals nothing else does') with neutral descriptive language.

- README intro callout: rewritten to describe what each feature does without comparison claims.
- package.json description: lists features (session analytics CLI, API latency, quota projection, auto-compact warnings, themes, powerline) instead of asserting uniqueness.

Carlos feedback: 'no me gusta que digas widgets nothing else has, es muy braggy'. This applies the same softening principle across both surfaces that npm and GitHub render.