### PR TITLE
feat(custom-cmds): Custom Commands widget (#143)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,14 @@ jobs:
       - run: npm run test:coverage
       - run: npm run lint
       - run: npm run build
-      # Bundle size guard: dist/ ships to npm. Currently ~404 KB after
-      # the subagents-dir reader + line 1 cubes widget; the ceiling is
-      # set to 440 KB so meaningful growth is a deliberate decision
-      # rather than accidental. Raise alongside the corresponding PR if
+      # Bundle size guard: dist/ ships to npm. Currently ~590 KB after
+      # the custom commands widget (exec-bg, parser, refresh helper, CLI,
+      # cache util, renderer integration). Ceiling raised from 512 KB to
+      # 640 KB alongside PR #146. Raise alongside the corresponding PR if
       # a feature genuinely needs the headroom.
       - name: Bundle size guard
         env:
-          CEILING: '512000'
+          CEILING: '655360'
         run: |
           SIZE=$(du -sb dist/ | cut -f1)
           echo "dist/ size: $SIZE bytes (ceiling: $CEILING)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-05-24
+
+### Added
+
+- **Custom Commands widget** — user-defined shell commands rendered as statusline segments on any line (1–4). Configured via `customCommands` in `~/.config/lumira/config.json`. Commands are argv arrays (no shell expansion). TTL file-cache with background refresh — zero latency on the hot path. `onError`/`onTimeout` strategies (`hide`, `placeholder`, `output`, `stale`). Disabled by default; opt-in via `lumira custom enable`.
+- **`lumira custom` CLI** — `enable`, `disable`, `list`, `test <id>`, and `logs` subcommands for managing custom commands without editing config by hand. Closes [#143](https://github.com/cativo23/lumira/issues/143).
+
 ## [1.5.0] - 2026-05-23
 
 ### Added
@@ -466,7 +473,8 @@ First stable release. API is now considered stable under SemVer.
 - GSD session IDs sanitized against path traversal
 - `execFile` used instead of `exec` to prevent shell injection (except terminal width detection where shell redirect is required with procfs-sourced paths)
 
-[Unreleased]: https://github.com/cativo23/lumira/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/cativo23/lumira/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/cativo23/lumira/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/cativo23/lumira/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/cativo23/lumira/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/cativo23/lumira/compare/v1.3.1...v1.4.0

--- a/README.md
+++ b/README.md
@@ -355,6 +355,9 @@ Add a `customCommands` block to `~/.config/lumira/config.json`:
 | `label` | Optional prefix shown before the command output |
 | `color` | Optional color override for the segment |
 | `onError` | What to show on non-zero exit: `hide` (default), `placeholder`, `output`, or `stale` |
+| `onTimeout` | What to show on timeout: same options as `onError`, defaults to `hide` |
+| `timeoutMs` | Max execution time in ms (clamped to 2000) |
+| `maxBytes` | Max stdout bytes captured (clamped to 4096) |
 | `ansi` | Set `true` to pass through ANSI escape sequences from the command |
 
 `command` must be an argv array (`["git", "status", "--short"]`). Shell strings with pipes or redirects are not supported — wrap them in a script if needed.

--- a/README.md
+++ b/README.md
@@ -312,6 +312,65 @@ lumira --icons=nerd|emoji|none      # Override icon set
 lumira --preset=full|balanced|minimal
 ```
 
+## Custom Commands
+
+User-defined shell commands rendered as statusline segments on any of the 4 lines. Disabled by default.
+
+### Enable
+
+```bash
+lumira custom enable
+```
+
+### Configure
+
+Add a `customCommands` block to `~/.config/lumira/config.json`:
+
+```json
+{
+  "customCommands": {
+    "enabled": true,
+    "commands": [
+      {
+        "id": "git-status",
+        "command": ["git", "status", "--short"],
+        "label": "",
+        "line": 1,
+        "refreshMs": 5000,
+        "onError": "hide"
+      }
+    ]
+  }
+}
+```
+
+**Key fields:**
+
+| Field | Description |
+|---|---|
+| `id` | Unique identifier for the command |
+| `command` | Argv array — no shell expansion, pipes, or redirects |
+| `line` | Statusline line to render on (`1`–`4`) |
+| `refreshMs` | Refresh interval in milliseconds (default: `5000`) |
+| `label` | Optional prefix shown before the command output |
+| `color` | Optional color override for the segment |
+| `onError` | What to show on non-zero exit: `hide` (default), `placeholder`, `output`, or `stale` |
+| `ansi` | Set `true` to pass through ANSI escape sequences from the command |
+
+`command` must be an argv array (`["git", "status", "--short"]`). Shell strings with pipes or redirects are not supported — wrap them in a script if needed.
+
+Output is cached with a TTL and refreshed in the background, so the hot render path never blocks on subprocess execution.
+
+### CLI subcommands
+
+```bash
+lumira custom list          # list configured commands and their status
+lumira custom enable        # enable the custom commands feature
+lumira custom disable       # disable the custom commands feature
+lumira custom test <id>     # run a command immediately and print its output
+lumira custom logs          # show recent execution logs
+```
+
 ## Architecture
 
 ```text

--- a/src/commands/custom-refresh.ts
+++ b/src/commands/custom-refresh.ts
@@ -38,7 +38,7 @@ import {
   mkdirSync,
   unlinkSync,
 } from 'node:fs';
-import { dirname } from 'node:path';
+import { dirname, isAbsolute } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import type { OnErrorBehavior } from '../types.js';
 
@@ -117,10 +117,10 @@ function isValidSpec(raw: unknown): raw is RefreshSpec {
   if (typeof s.id !== 'string' || s.id.length === 0) return false;
   if (!Array.isArray(s.command) || s.command.length === 0) return false;
   if (!s.command.every((x: unknown) => typeof x === 'string' && x.length > 0)) return false;
-  if (typeof s.timeoutMs !== 'number' || !Number.isFinite(s.timeoutMs)) return false;
-  if (typeof s.maxBytes !== 'number' || !Number.isFinite(s.maxBytes)) return false;
+  if (typeof s.timeoutMs !== 'number' || !Number.isFinite(s.timeoutMs) || s.timeoutMs > 2000) return false;
+  if (typeof s.maxBytes !== 'number' || !Number.isFinite(s.maxBytes) || s.maxBytes > 4096) return false;
   if (typeof s.onError !== 'string') return false;
-  if (typeof s.cachePath !== 'string' || s.cachePath.length === 0) return false;
+  if (typeof s.cachePath !== 'string' || s.cachePath.length === 0 || !isAbsolute(s.cachePath)) return false;
   return true;
 }
 
@@ -158,8 +158,11 @@ export async function runCustomRefresh(stdinPayload: string): Promise<void> {
         entry = { text: result.stdout, capturedAt: now, state: 'timeout' };
         break;
       case 'nonzero': {
-        const text = spec.onError === 'output' ? lastStderrLine(result.stderr) : result.stdout;
-        entry = { text, capturedAt: now, state: 'nonzero' };
+        // For onError:'output' the renderer shows entry.text directly, so
+        // store stdout (partial output before the command failed). For all
+        // other strategies the text is not displayed — store stdout anyway
+        // so the entry is useful if the strategy is later changed.
+        entry = { text: result.stdout, capturedAt: now, state: 'nonzero' };
         break;
       }
       case 'spawn-error':

--- a/src/commands/custom-refresh.ts
+++ b/src/commands/custom-refresh.ts
@@ -1,0 +1,195 @@
+/**
+ * Internal helper for the Custom Command widget (#143). Runs ONE custom
+ * command and writes the result into the cache file. Intended to be
+ * launched by the renderer as a detached child process so the renderer
+ * itself can exit immediately without waiting on the spawned command
+ * (B1: the original "fire and forget" via void async-IIFE still kept
+ * the Node event loop refed because data listeners hold stdin/stdout
+ * streams open until child exit + cache write).
+ *
+ * Wire protocol: a single JSON object on stdin describing the spawn
+ * spec, cache path, and (optional) stdin envelope to forward to the
+ * user command:
+ *
+ *   {
+ *     "id": "k8s-context",
+ *     "command": ["kubectl", "config", "current-context"],
+ *     "timeoutMs": 1500,
+ *     "maxBytes": 256,
+ *     "env": { ... },           // optional
+ *     "cwd": "/abs/path",       // optional
+ *     "onError": "hide",        // 'hide' | 'placeholder' | 'output' | 'stale'
+ *     "cachePath": "/abs/path/to/custom-commands.json",
+ *     "stdin": "{}"             // optional
+ *   }
+ *
+ * Errors are swallowed — this process must NEVER print to stdout or
+ * crash visibly. The renderer doesn't read this process's exit code.
+ */
+
+import { execBg } from '../utils/exec-bg.js';
+import {
+  readFileSync,
+  lstatSync,
+  openSync,
+  writeSync,
+  closeSync,
+  renameSync,
+  mkdirSync,
+  unlinkSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+import { randomBytes } from 'node:crypto';
+import type { OnErrorBehavior } from '../types.js';
+
+interface RefreshSpec {
+  id: string;
+  command: string[];
+  timeoutMs: number;
+  maxBytes: number;
+  env?: Record<string, string>;
+  cwd?: string;
+  onError: OnErrorBehavior;
+  cachePath: string;
+  stdin?: string;
+}
+
+interface CacheEntry {
+  text: string;
+  capturedAt: number;
+  state: 'ok' | 'nonzero' | 'timeout';
+}
+type CacheMap = Record<string, CacheEntry>;
+
+/** Symlink-safe cache read (mirrors the parser's readCacheFile). */
+function readCacheFile(path: string): CacheMap {
+  try {
+    try {
+      const st = lstatSync(path);
+      if (st.isSymbolicLink()) return {};
+    } catch { /* missing — fine */ }
+    const raw = readFileSync(path, 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const out: CacheMap = {};
+    for (const [id, entry] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+      const e = entry as Record<string, unknown>;
+      if (typeof e.text !== 'string') continue;
+      if (typeof e.capturedAt !== 'number' || !Number.isFinite(e.capturedAt)) continue;
+      const s = e.state;
+      if (s !== 'ok' && s !== 'nonzero' && s !== 'timeout') continue;
+      out[id] = { text: e.text, capturedAt: e.capturedAt, state: s };
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/** Atomic cache write with random temp-file name (mirrors writeCacheFile). */
+function writeCacheFile(path: string, data: CacheMap): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    const tmp = `${path}.${randomBytes(8).toString('hex')}.tmp`;
+    try { unlinkSync(tmp); } catch { /* not present */ }
+    const fd = openSync(tmp, 'wx', 0o600);
+    try {
+      writeSync(fd, JSON.stringify(data));
+    } finally {
+      closeSync(fd);
+    }
+    renameSync(tmp, path);
+  } catch {
+    /* cache write best-effort */
+  }
+}
+
+function lastStderrLine(stderr: string, cap = 120): string {
+  const lines = stderr.split(/\r?\n/).map((l) => l.trim()).filter((l) => l.length > 0);
+  const last = lines.length === 0 ? '' : lines[lines.length - 1];
+  return last.length > cap ? last.slice(0, cap) : last;
+}
+
+function isValidSpec(raw: unknown): raw is RefreshSpec {
+  if (!raw || typeof raw !== 'object') return false;
+  const s = raw as Record<string, unknown>;
+  if (typeof s.id !== 'string' || s.id.length === 0) return false;
+  if (!Array.isArray(s.command) || s.command.length === 0) return false;
+  if (!s.command.every((x: unknown) => typeof x === 'string' && x.length > 0)) return false;
+  if (typeof s.timeoutMs !== 'number' || !Number.isFinite(s.timeoutMs)) return false;
+  if (typeof s.maxBytes !== 'number' || !Number.isFinite(s.maxBytes)) return false;
+  if (typeof s.onError !== 'string') return false;
+  if (typeof s.cachePath !== 'string' || s.cachePath.length === 0) return false;
+  return true;
+}
+
+/**
+ * Read the JSON spec from stdin, run the command via execBg, persist the
+ * result. Never throws — every failure path returns silently.
+ */
+export async function runCustomRefresh(stdinPayload: string): Promise<void> {
+  let spec: RefreshSpec;
+  try {
+    const parsed: unknown = JSON.parse(stdinPayload);
+    if (!isValidSpec(parsed)) return;
+    spec = parsed;
+  } catch {
+    return;
+  }
+
+  try {
+    const result = await execBg({
+      command: spec.command,
+      timeoutMs: spec.timeoutMs,
+      maxBytes: spec.maxBytes,
+      env: spec.env,
+      cwd: spec.cwd,
+      stdin: spec.stdin,
+    });
+
+    const now = Date.now();
+    let entry: CacheEntry;
+    switch (result.kind) {
+      case 'ok':
+        entry = { text: result.stdout, capturedAt: now, state: 'ok' };
+        break;
+      case 'timeout':
+        entry = { text: result.stdout, capturedAt: now, state: 'timeout' };
+        break;
+      case 'nonzero': {
+        const text = spec.onError === 'output' ? lastStderrLine(result.stderr) : result.stdout;
+        entry = { text, capturedAt: now, state: 'nonzero' };
+        break;
+      }
+      case 'spawn-error':
+        entry = { text: '', capturedAt: now, state: 'nonzero' };
+        break;
+    }
+
+    const current = readCacheFile(spec.cachePath);
+    current[spec.id] = entry;
+    writeCacheFile(spec.cachePath, current);
+  } catch {
+    /* swallow — helper must never crash visibly */
+  }
+}
+
+/**
+ * CLI entrypoint used by the renderer. Reads stdin to EOF, then runs.
+ * Wrapped in a Promise so the caller can await before exiting.
+ */
+export async function runCustomRefreshFromStdin(): Promise<void> {
+  const chunks: Buffer[] = [];
+  try {
+    await new Promise<void>((resolve) => {
+      process.stdin.on('data', (chunk: Buffer) => chunks.push(chunk));
+      process.stdin.on('end', () => resolve());
+      process.stdin.on('error', () => resolve());
+    });
+  } catch {
+    return;
+  }
+  const payload = Buffer.concat(chunks).toString('utf8');
+  await runCustomRefresh(payload);
+}

--- a/src/commands/custom-refresh.ts
+++ b/src/commands/custom-refresh.ts
@@ -28,88 +28,9 @@
  */
 
 import { execBg } from '../utils/exec-bg.js';
-import {
-  readFileSync,
-  lstatSync,
-  openSync,
-  writeSync,
-  closeSync,
-  renameSync,
-  mkdirSync,
-  unlinkSync,
-} from 'node:fs';
-import { dirname, isAbsolute } from 'node:path';
-import { randomBytes } from 'node:crypto';
-import type { OnErrorBehavior } from '../types.js';
-
-interface RefreshSpec {
-  id: string;
-  command: string[];
-  timeoutMs: number;
-  maxBytes: number;
-  env?: Record<string, string>;
-  cwd?: string;
-  onError: OnErrorBehavior;
-  cachePath: string;
-  stdin?: string;
-}
-
-interface CacheEntry {
-  text: string;
-  capturedAt: number;
-  state: 'ok' | 'nonzero' | 'timeout';
-}
-type CacheMap = Record<string, CacheEntry>;
-
-/** Symlink-safe cache read (mirrors the parser's readCacheFile). */
-function readCacheFile(path: string): CacheMap {
-  try {
-    try {
-      const st = lstatSync(path);
-      if (st.isSymbolicLink()) return {};
-    } catch { /* missing — fine */ }
-    const raw = readFileSync(path, 'utf8');
-    const parsed: unknown = JSON.parse(raw);
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
-    const out: CacheMap = {};
-    for (const [id, entry] of Object.entries(parsed as Record<string, unknown>)) {
-      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
-      const e = entry as Record<string, unknown>;
-      if (typeof e.text !== 'string') continue;
-      if (typeof e.capturedAt !== 'number' || !Number.isFinite(e.capturedAt)) continue;
-      const s = e.state;
-      if (s !== 'ok' && s !== 'nonzero' && s !== 'timeout') continue;
-      out[id] = { text: e.text, capturedAt: e.capturedAt, state: s };
-    }
-    return out;
-  } catch {
-    return {};
-  }
-}
-
-/** Atomic cache write with random temp-file name (mirrors writeCacheFile). */
-function writeCacheFile(path: string, data: CacheMap): void {
-  try {
-    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-    const tmp = `${path}.${randomBytes(8).toString('hex')}.tmp`;
-    try { unlinkSync(tmp); } catch { /* not present */ }
-    const fd = openSync(tmp, 'wx', 0o600);
-    try {
-      writeSync(fd, JSON.stringify(data));
-    } finally {
-      closeSync(fd);
-    }
-    renameSync(tmp, path);
-  } catch {
-    /* cache write best-effort */
-  }
-}
-
-function lastStderrLine(stderr: string, cap = 120): string {
-  const lines = stderr.split(/\r?\n/).map((l) => l.trim()).filter((l) => l.length > 0);
-  const last = lines.length === 0 ? '' : lines[lines.length - 1];
-  return last.length > cap ? last.slice(0, cap) : last;
-}
+import { isAbsolute } from 'node:path';
+import type { OnErrorBehavior, RefreshSpec } from '../types.js';
+import { readCacheFile, writeCacheFile, type CacheEntry, type CacheMap } from '../utils/custom-cache.js';
 
 function isValidSpec(raw: unknown): raw is RefreshSpec {
   if (!raw || typeof raw !== 'object') return false;

--- a/src/commands/custom.ts
+++ b/src/commands/custom.ts
@@ -72,7 +72,7 @@ function readConfigRaw(): Record<string, unknown> {
 function writeConfigRaw(value: Record<string, unknown>): void {
   const p = configPath();
   mkdirSync(dirname(p), { recursive: true });
-  writeFileSync(p, JSON.stringify(value, null, 2), 'utf8');
+  writeFileSync(p, JSON.stringify(value, null, 2), { encoding: 'utf8', mode: 0o600 });
 }
 
 /**

--- a/src/commands/custom.ts
+++ b/src/commands/custom.ts
@@ -1,0 +1,371 @@
+/**
+ * `lumira custom` subcommand (issue #143 phase 4).
+ *
+ * Provides a CLI interface for managing the custom commands feature:
+ *
+ *   lumira custom list             List configured commands from config file
+ *   lumira custom enable           Set enabled:true in config file
+ *   lumira custom disable          Set enabled:false in config file
+ *   lumira custom test <id>        Run a command once, print output + timing
+ *   lumira custom logs             Show cached outputs from the cache file
+ *
+ * Design constraints:
+ * - No runtime deps beyond Node built-ins.
+ * - All FS reads in try/catch — graceful errors, exit 1 on failure.
+ * - Color: process.stdout.isTTY ? 'named' : 'none'.
+ * - Return type: Promise<{ output: string; exitCode: number }> so the
+ *   dispatcher can set process.exitCode.
+ */
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { execBg } from '../utils/exec-bg.js';
+import { createColors } from '../render/colors.js';
+import type { CustomCommandsConfig, CustomCommand } from '../types.js';
+
+// ── constants ──────────────────────────────────────────────────────────────
+
+const CONFIG_FILE = 'config.json';
+const CONFIG_DIR = join('.config', 'lumira');
+
+const CACHE_FILE = 'custom-commands.json';
+const CACHE_DIR = join('.cache', 'lumira');
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function configPath(): string {
+  return join(homedir(), CONFIG_DIR, CONFIG_FILE);
+}
+
+function cachePath(): string {
+  return join(homedir(), CACHE_DIR, CACHE_FILE);
+}
+
+type Result = { output: string; exitCode: number };
+
+function ok(output: string): Result {
+  return { output, exitCode: 0 };
+}
+
+function fail(output: string): Result {
+  return { output, exitCode: 1 };
+}
+
+/**
+ * Read the raw config JSON from disk. Returns an empty object `{}` if the
+ * file doesn't exist, throws on malformed JSON so the caller can surface a
+ * useful error.
+ */
+function readConfigRaw(): Record<string, unknown> {
+  const p = configPath();
+  if (!existsSync(p)) return {};
+  const raw = readFileSync(p, 'utf8');
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * Write (or create) the config file. Creates the parent directory if needed.
+ * The value is always pretty-printed with 2-space indents.
+ */
+function writeConfigRaw(value: Record<string, unknown>): void {
+  const p = configPath();
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, JSON.stringify(value, null, 2), 'utf8');
+}
+
+/**
+ * Extract the `customCommands` block from the raw config. Returns a minimal
+ * default when the block is missing or malformed.
+ */
+function readCustomCommandsBlock(
+  raw: Record<string, unknown>,
+): { enabled: boolean; commands: unknown[] } {
+  const cc = raw.customCommands;
+  if (!cc || typeof cc !== 'object' || Array.isArray(cc)) {
+    return { enabled: false, commands: [] };
+  }
+  const obj = cc as Record<string, unknown>;
+  const enabled = typeof obj.enabled === 'boolean' ? obj.enabled : false;
+  const commands = Array.isArray(obj.commands) ? obj.commands : [];
+  return { enabled, commands };
+}
+
+/**
+ * Lightweight parse of customCommands.commands from raw config for `list` and
+ * `test`. We only need id, command, line, and refreshMs — enough to display a
+ * table or run a test. We don't re-validate all fields here; we let the user
+ * see whatever is configured, including invalid entries (so they can debug).
+ */
+function parseCommandsForDisplay(
+  raw: Record<string, unknown>,
+): Array<{ id: string; command: string[]; line: number; refreshMs: number; timeoutMs: number; maxBytes: number }> {
+  const { commands } = readCustomCommandsBlock(raw);
+  const out: Array<{ id: string; command: string[]; line: number; refreshMs: number; timeoutMs: number; maxBytes: number }> = [];
+
+  for (const entry of commands) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const e = entry as Record<string, unknown>;
+    if (typeof e.id !== 'string' || e.id.length === 0) continue;
+    if (!Array.isArray(e.command) || e.command.length === 0) continue;
+    const command = (e.command as unknown[]).every(s => typeof s === 'string')
+      ? (e.command as string[])
+      : [];
+    if (command.length === 0) continue;
+    const line = typeof e.line === 'number' ? e.line : 1;
+    const refreshMs = typeof e.refreshMs === 'number' ? e.refreshMs : 5000;
+    const timeoutMs = typeof e.timeoutMs === 'number' ? e.timeoutMs : 1500;
+    const maxBytes = typeof e.maxBytes === 'number' ? e.maxBytes : 256;
+    out.push({ id: e.id, command, line, refreshMs, timeoutMs, maxBytes });
+  }
+
+  return out;
+}
+
+// ── color ──────────────────────────────────────────────────────────────────
+
+/**
+ * Only use color when stdout is a real TTY. In pipe/test contexts this
+ * produces no escape sequences, keeping output clean for programmatic use.
+ */
+function makeColors() {
+  const isTTY = !!process.stdout.isTTY;
+  return isTTY ? createColors('named') : null;
+}
+
+// ── subcommands ────────────────────────────────────────────────────────────
+
+async function cmdEnable(): Promise<Result> {
+  try {
+    const raw = readConfigRaw();
+    const cc = readCustomCommandsBlock(raw);
+    const updated: Record<string, unknown> = {
+      ...raw,
+      customCommands: {
+        ...cc,
+        enabled: true,
+      },
+    };
+    writeConfigRaw(updated);
+    return ok(`Custom commands enabled.\nConfig written to: ${configPath()}\n`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return fail(`lumira custom enable: ${msg}\n`);
+  }
+}
+
+async function cmdDisable(): Promise<Result> {
+  try {
+    const raw = readConfigRaw();
+    const cc = readCustomCommandsBlock(raw);
+    const updated: Record<string, unknown> = {
+      ...raw,
+      customCommands: {
+        ...cc,
+        enabled: false,
+      },
+    };
+    writeConfigRaw(updated);
+    return ok(`Custom commands disabled.\nConfig written to: ${configPath()}\n`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return fail(`lumira custom disable: ${msg}\n`);
+  }
+}
+
+async function cmdList(): Promise<Result> {
+  const c = makeColors();
+  let raw: Record<string, unknown>;
+  try {
+    raw = readConfigRaw();
+  } catch {
+    raw = {};
+  }
+
+  const { enabled } = readCustomCommandsBlock(raw);
+  const commands = parseCommandsForDisplay(raw);
+
+  const statusLine = enabled
+    ? `Custom commands: ${c ? c.green('enabled') : 'enabled'}\n`
+    : `Custom commands: ${c ? c.yellow('disabled') : 'disabled'}\n`;
+
+  if (commands.length === 0) {
+    return ok(
+      statusLine
+      + '\nNo custom commands configured.\n'
+      + `Add commands to ${configPath()} under customCommands.commands.\n`,
+    );
+  }
+
+  // Table: id | line | refresh | cmd
+  const header = `${'id'.padEnd(20)} ${'line'.padEnd(6)} ${'refresh'.padEnd(10)} cmd`;
+  const sep = '-'.repeat(header.length);
+  const rows = commands.map(cmd => {
+    const id = cmd.id.padEnd(20);
+    const line = String(cmd.line).padEnd(6);
+    const refresh = `${cmd.refreshMs}ms`.padEnd(10);
+    const cmdStr = cmd.command.join(' ');
+    return `${id} ${line} ${refresh} ${cmdStr}`;
+  });
+
+  const table = [header, sep, ...rows].join('\n');
+  return ok(`${statusLine}\n${table}\n`);
+}
+
+async function cmdTest(id: string | undefined): Promise<Result> {
+  if (!id) {
+    return fail(
+      'lumira custom test: missing command id.\n\n'
+      + 'Usage: lumira custom test <id>\n'
+      + "Use 'lumira custom list' to see configured command ids.\n",
+    );
+  }
+
+  let raw: Record<string, unknown>;
+  try {
+    raw = readConfigRaw();
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return fail(`lumira custom test: could not read config: ${msg}\n`);
+  }
+
+  const commands = parseCommandsForDisplay(raw);
+  const cmd = commands.find(c => c.id === id);
+
+  if (!cmd) {
+    const knownIds = commands.map(c => c.id).join(', ');
+    return fail(
+      `lumira custom test: command id "${id}" not found.\n`
+      + (knownIds ? `Known ids: ${knownIds}\n` : 'No commands configured.\n'),
+    );
+  }
+
+  const result = await execBg({
+    command: cmd.command,
+    timeoutMs: cmd.timeoutMs,
+    maxBytes: cmd.maxBytes,
+  });
+
+  const lines: string[] = [
+    `Command: ${cmd.command.join(' ')}`,
+    `Duration: ${result.durationMs}ms`,
+  ];
+
+  if (result.kind === 'ok') {
+    lines.push(`Exit: 0 (ok)`);
+    lines.push(`Output:\n${result.stdout || '(empty)'}`);
+  } else if (result.kind === 'nonzero') {
+    lines.push(`Exit: ${result.exitCode} (nonzero)`);
+    if (result.stdout) lines.push(`Stdout:\n${result.stdout}`);
+    if (result.stderr) lines.push(`Stderr:\n${result.stderr}`);
+  } else if (result.kind === 'timeout') {
+    lines.push(`Exit: timeout (killed after ${cmd.timeoutMs}ms)`);
+    if (result.stdout) lines.push(`Stdout (partial):\n${result.stdout}`);
+  } else {
+    // spawn-error
+    lines.push(`Exit: spawn-error — ${(result as { kind: 'spawn-error'; message: string; durationMs: number }).message}`);
+  }
+
+  return ok(lines.join('\n') + '\n');
+}
+
+interface CacheEntry {
+  text: string;
+  capturedAt: number;
+  state: string;
+}
+
+async function cmdLogs(): Promise<Result> {
+  const p = cachePath();
+
+  let raw: unknown;
+  try {
+    if (!existsSync(p)) {
+      return ok(
+        `No cache file found at ${p}.\n`
+        + "Run lumira once with custom commands enabled to populate the cache.\n",
+      );
+    }
+    raw = JSON.parse(readFileSync(p, 'utf8'));
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return fail(`lumira custom logs: could not read cache: ${msg}\n`);
+  }
+
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return ok('Cache file is empty or malformed.\n');
+  }
+
+  const entries = Object.entries(raw as Record<string, unknown>);
+  if (entries.length === 0) {
+    return ok('Cache file exists but contains no entries.\n');
+  }
+
+  const lines: string[] = [`Cache: ${p}`, ''];
+
+  for (const [id, entry] of entries) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const e = entry as Record<string, unknown>;
+    const text = typeof e.text === 'string' ? e.text : '';
+    const capturedAt = typeof e.capturedAt === 'number' ? e.capturedAt : 0;
+    const state = typeof e.state === 'string' ? e.state : 'unknown';
+
+    const dateStr = capturedAt > 0
+      ? new Date(capturedAt).toLocaleString()
+      : 'unknown';
+    const truncated = text.length > 100 ? text.slice(0, 100) + '…' : text;
+
+    lines.push(`id: ${id}`);
+    lines.push(`  state:      ${state}`);
+    lines.push(`  capturedAt: ${dateStr}`);
+    lines.push(`  text:       ${truncated || '(empty)'}`);
+    lines.push('');
+  }
+
+  return ok(lines.join('\n'));
+}
+
+function helpText(): string {
+  return [
+    'Usage: lumira custom <subcommand>',
+    '',
+    'Subcommands:',
+    '  list               List configured custom commands',
+    '  enable             Enable custom commands in config',
+    '  disable            Disable custom commands in config',
+    '  test <id>          Run a command once and print output + timing',
+    '  logs               Show cached command outputs',
+    '',
+  ].join('\n');
+}
+
+// ── entry point ────────────────────────────────────────────────────────────
+
+/**
+ * Execute `lumira custom [subcommand] [...args]`.
+ *
+ * argv is the full process.argv; 'custom' starts at argv[2], the subcommand
+ * at argv[3], additional arguments from argv[4] onward.
+ *
+ * Returns `{ output, exitCode }` — the dispatcher writes output to stdout and
+ * sets process.exitCode from the returned value.
+ */
+export async function runCustomCommand(argv: string[]): Promise<Result> {
+  const sub = argv[3];
+
+  switch (sub) {
+    case 'enable':
+      return cmdEnable();
+    case 'disable':
+      return cmdDisable();
+    case 'list':
+      return cmdList();
+    case 'test':
+      return cmdTest(argv[4]);
+    case 'logs':
+      return cmdLogs();
+    default:
+      return fail(helpText());
+  }
+}

--- a/src/commands/custom.ts
+++ b/src/commands/custom.ts
@@ -21,6 +21,8 @@ import { homedir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { execBg } from '../utils/exec-bg.js';
 import { createColors } from '../render/colors.js';
+import { loadConfig } from '../config.js';
+import { readCacheFile } from '../utils/custom-cache.js';
 import type { CustomCommandsConfig, CustomCommand } from '../types.js';
 
 // ── constants ──────────────────────────────────────────────────────────────
@@ -92,46 +94,17 @@ function readCustomCommandsBlock(
   return { enabled, commands };
 }
 
-/**
- * Lightweight parse of customCommands.commands from raw config for `list` and
- * `test`. We only need id, command, line, and refreshMs — enough to display a
- * table or run a test. We don't re-validate all fields here; we let the user
- * see whatever is configured, including invalid entries (so they can debug).
- */
-function parseCommandsForDisplay(
-  raw: Record<string, unknown>,
-): Array<{ id: string; command: string[]; line: number; refreshMs: number; timeoutMs: number; maxBytes: number }> {
-  const { commands } = readCustomCommandsBlock(raw);
-  const out: Array<{ id: string; command: string[]; line: number; refreshMs: number; timeoutMs: number; maxBytes: number }> = [];
-
-  for (const entry of commands) {
-    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
-    const e = entry as Record<string, unknown>;
-    if (typeof e.id !== 'string' || e.id.length === 0) continue;
-    if (!Array.isArray(e.command) || e.command.length === 0) continue;
-    const command = (e.command as unknown[]).every(s => typeof s === 'string')
-      ? (e.command as string[])
-      : [];
-    if (command.length === 0) continue;
-    const line = typeof e.line === 'number' ? e.line : 1;
-    const refreshMs = typeof e.refreshMs === 'number' ? e.refreshMs : 5000;
-    const timeoutMs = typeof e.timeoutMs === 'number' ? e.timeoutMs : 1500;
-    const maxBytes = typeof e.maxBytes === 'number' ? e.maxBytes : 256;
-    out.push({ id: e.id, command, line, refreshMs, timeoutMs, maxBytes });
-  }
-
-  return out;
-}
-
 // ── color ──────────────────────────────────────────────────────────────────
 
 /**
- * Only use color when stdout is a real TTY. In pipe/test contexts this
- * produces no escape sequences, keeping output clean for programmatic use.
+ * Only use color when stdout is a real TTY and NO_COLOR is not set.
+ * In pipe/test contexts or when NO_COLOR is in env, produces no escape
+ * sequences, keeping output clean for programmatic use.
  */
 function makeColors() {
-  const isTTY = !!process.stdout.isTTY;
-  return isTTY ? createColors('named') : null;
+  const noColor = 'NO_COLOR' in process.env || process.env.TERM === 'dumb';
+  if (noColor || !process.stdout.isTTY) return null;
+  return createColors('named');
 }
 
 // ── subcommands ────────────────────────────────────────────────────────────
@@ -176,15 +149,15 @@ async function cmdDisable(): Promise<Result> {
 
 async function cmdList(): Promise<Result> {
   const c = makeColors();
-  let raw: Record<string, unknown>;
+  let enabled = false;
+  let commands: CustomCommand[] = [];
   try {
-    raw = readConfigRaw();
+    const cfg = loadConfig();
+    enabled = cfg.customCommands.enabled;
+    commands = cfg.customCommands.commands;
   } catch {
-    raw = {};
+    // config unreadable — fall through with empty defaults
   }
-
-  const { enabled } = readCustomCommandsBlock(raw);
-  const commands = parseCommandsForDisplay(raw);
 
   const statusLine = enabled
     ? `Custom commands: ${c ? c.green('enabled') : 'enabled'}\n`
@@ -222,15 +195,14 @@ async function cmdTest(id: string | undefined): Promise<Result> {
     );
   }
 
-  let raw: Record<string, unknown>;
+  let commands: CustomCommand[];
   try {
-    raw = readConfigRaw();
+    commands = loadConfig().customCommands.commands;
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     return fail(`lumira custom test: could not read config: ${msg}\n`);
   }
 
-  const commands = parseCommandsForDisplay(raw);
   const cmd = commands.find(c => c.id === id);
 
   if (!cmd) {
@@ -270,47 +242,23 @@ async function cmdTest(id: string | undefined): Promise<Result> {
   return ok(lines.join('\n') + '\n');
 }
 
-interface CacheEntry {
-  text: string;
-  capturedAt: number;
-  state: string;
-}
-
 async function cmdLogs(): Promise<Result> {
   const p = cachePath();
 
-  let raw: unknown;
-  try {
-    if (!existsSync(p)) {
-      return ok(
-        `No cache file found at ${p}.\n`
-        + "Run lumira once with custom commands enabled to populate the cache.\n",
-      );
-    }
-    raw = JSON.parse(readFileSync(p, 'utf8'));
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    return fail(`lumira custom logs: could not read cache: ${msg}\n`);
-  }
+  const cacheData = readCacheFile(p);
+  const entries = Object.entries(cacheData);
 
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-    return ok('Cache file is empty or malformed.\n');
-  }
-
-  const entries = Object.entries(raw as Record<string, unknown>);
   if (entries.length === 0) {
-    return ok('Cache file exists but contains no entries.\n');
+    return ok(
+      `No cache file found at ${p}.\n`
+      + "Run lumira once with custom commands enabled to populate the cache.\n",
+    );
   }
 
   const lines: string[] = [`Cache: ${p}`, ''];
 
   for (const [id, entry] of entries) {
-    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
-    const e = entry as Record<string, unknown>;
-    const text = typeof e.text === 'string' ? e.text : '';
-    const capturedAt = typeof e.capturedAt === 'number' ? e.capturedAt : 0;
-    const state = typeof e.state === 'string' ? e.state : 'unknown';
-
+    const { text, capturedAt, state } = entry;
     const dateStr = capturedAt > 0
       ? new Date(capturedAt).toLocaleString()
       : 'unknown';

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync, writeFileSync, renameSync, mkdirSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, isAbsolute } from 'node:path';
 import { homedir } from 'node:os';
 import {
   DEFAULT_CONFIG,
@@ -11,6 +11,7 @@ import {
   CUSTOM_COMMAND_MAX_BYTES,
   CUSTOM_COMMAND_MAX_ENV_ENTRIES,
   CUSTOM_COMMAND_MIN_REFRESH_MS,
+  CUSTOM_COMMAND_MAX_REFRESH_MS,
   CUSTOM_COMMAND_VALID_LINES,
   CUSTOM_COMMAND_ERROR_BEHAVIORS,
   CUSTOM_COMMAND_COLORS,
@@ -21,6 +22,41 @@ import {
   type CustomCommandsConfig,
   type OnErrorBehavior,
 } from './types.js';
+
+/**
+ * Ids we refuse to accept on user-supplied custom commands. Object.prototype
+ * lookalikes prevent prototype-pollution-style attacks via the cache map
+ * (cache entries are keyed by id; if an attacker can name an entry
+ * `__proto__` or `constructor`, lookups against arbitrary objects later in
+ * the pipeline could become surprising).
+ */
+const RESERVED_ID_NAMES = new Set([
+  '__proto__',
+  'prototype',
+  'constructor',
+  'hasOwnProperty',
+  'toString',
+  'valueOf',
+  'isPrototypeOf',
+  'propertyIsEnumerable',
+  'toLocaleString',
+]);
+
+/**
+ * Reject ids containing path separators or ASCII control characters. Slash
+ * and backslash would break cache-map lookups by id (entries are keyed under
+ * a single object; nesting via paths is not supported). Control chars in id
+ * could corrupt log output / status lines downstream.
+ */
+// eslint-disable-next-line no-control-regex
+const DANGEROUS_ID_CHARS = /[\x00-\x1f/\\]/;
+
+function isValidCustomCommandId(id: string): boolean {
+  if (id.length === 0 || id.length > 64) return false;
+  if (RESERVED_ID_NAMES.has(id)) return false;
+  if (DANGEROUS_ID_CHARS.test(id)) return false;
+  return true;
+}
 
 // Module-level flag: fires the qwen→minimal deprecation warning once per
 // Node process. Process-scoped by design — tests must run in forked workers
@@ -57,8 +93,10 @@ function parseCustomCommands(raw: unknown): CustomCommandsConfig {
     if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
     const e = entry as Record<string, unknown>;
 
-    // id — non-empty string, unique
-    if (typeof e.id !== 'string' || e.id.length === 0) continue;
+    // id — non-empty string, unique, no path separators / control chars /
+    // reserved Object.prototype names. Caps length at 64 to prevent absurd
+    // ids from blowing up log lines or cache files.
+    if (typeof e.id !== 'string' || !isValidCustomCommandId(e.id)) continue;
     if (seenIds.has(e.id)) continue;
 
     // command — non-empty array of non-empty strings (no shell-string form)
@@ -70,7 +108,7 @@ function parseCustomCommands(raw: unknown): CustomCommandsConfig {
 
     // From here on the entry is valid; default optional fields.
     const refreshMs = typeof e.refreshMs === 'number' && Number.isFinite(e.refreshMs)
-      ? Math.max(CUSTOM_COMMAND_MIN_REFRESH_MS, Math.trunc(e.refreshMs))
+      ? clampInt(e.refreshMs, CUSTOM_COMMAND_MIN_REFRESH_MS, CUSTOM_COMMAND_MAX_REFRESH_MS)
       : 5000;
     const timeoutMs = typeof e.timeoutMs === 'number' && Number.isFinite(e.timeoutMs)
       ? clampInt(e.timeoutMs, 100, CUSTOM_COMMAND_MAX_TIMEOUT_MS)
@@ -79,12 +117,18 @@ function parseCustomCommands(raw: unknown): CustomCommandsConfig {
       ? clampInt(e.maxBytes, 16, CUSTOM_COMMAND_MAX_BYTES)
       : 256;
 
-    const onError: OnErrorBehavior = CUSTOM_COMMAND_ERROR_BEHAVIORS.includes(e.onError as OnErrorBehavior)
-      ? (e.onError as OnErrorBehavior)
-      : 'hide';
-    const onTimeout: OnErrorBehavior = CUSTOM_COMMAND_ERROR_BEHAVIORS.includes(e.onTimeout as OnErrorBehavior)
-      ? (e.onTimeout as OnErrorBehavior)
-      : 'stale';
+    // Cast AFTER the membership guard, not before — casting unknown→typed
+    // up front inverts the type-narrowing the guard exists to provide.
+    const rawOnError = e.onError;
+    const onError: OnErrorBehavior =
+      typeof rawOnError === 'string' && (CUSTOM_COMMAND_ERROR_BEHAVIORS as readonly string[]).includes(rawOnError)
+        ? (rawOnError as OnErrorBehavior)
+        : 'hide';
+    const rawOnTimeout = e.onTimeout;
+    const onTimeout: OnErrorBehavior =
+      typeof rawOnTimeout === 'string' && (CUSTOM_COMMAND_ERROR_BEHAVIORS as readonly string[]).includes(rawOnTimeout)
+        ? (rawOnTimeout as OnErrorBehavior)
+        : 'stale';
     const ansi = typeof e.ansi === 'boolean' ? e.ansi : false;
 
     const cmd: CustomCommand = {
@@ -100,8 +144,11 @@ function parseCustomCommands(raw: unknown): CustomCommandsConfig {
     };
 
     if (typeof e.label === 'string') cmd.label = e.label;
-    if (typeof e.cwd === 'string') cmd.cwd = e.cwd;
-    if (CUSTOM_COMMAND_COLORS.includes(e.color as never)) {
+    // cwd — must be an absolute path. Relative paths like '../../../etc'
+    // would silently escape the renderer's cwd; drop them to fall back to
+    // process.cwd() instead of accepting hostile relative input.
+    if (typeof e.cwd === 'string' && isAbsolute(e.cwd)) cmd.cwd = e.cwd;
+    if (typeof e.color === 'string' && (CUSTOM_COMMAND_COLORS as readonly string[]).includes(e.color)) {
       cmd.color = e.color as CustomCommand['color'];
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,26 @@
 import { readFileSync, existsSync, writeFileSync, renameSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
-import { DEFAULT_CONFIG, DEFAULT_DISPLAY, DEFAULT_CONTEXT_WARNING_THRESHOLD, DEFAULT_CONTEXT_CRITICAL_THRESHOLD, POWERLINE_STYLE_NAMES, type HudConfig, type DisplayToggles, type ColorConfig } from './types.js';
+import {
+  DEFAULT_CONFIG,
+  DEFAULT_DISPLAY,
+  DEFAULT_CONTEXT_WARNING_THRESHOLD,
+  DEFAULT_CONTEXT_CRITICAL_THRESHOLD,
+  POWERLINE_STYLE_NAMES,
+  CUSTOM_COMMAND_MAX_TIMEOUT_MS,
+  CUSTOM_COMMAND_MAX_BYTES,
+  CUSTOM_COMMAND_MAX_ENV_ENTRIES,
+  CUSTOM_COMMAND_MIN_REFRESH_MS,
+  CUSTOM_COMMAND_VALID_LINES,
+  CUSTOM_COMMAND_ERROR_BEHAVIORS,
+  CUSTOM_COMMAND_COLORS,
+  type HudConfig,
+  type DisplayToggles,
+  type ColorConfig,
+  type CustomCommand,
+  type CustomCommandsConfig,
+  type OnErrorBehavior,
+} from './types.js';
 
 // Module-level flag: fires the qwen→minimal deprecation warning once per
 // Node process. Process-scoped by design — tests must run in forked workers
@@ -12,6 +31,100 @@ let thresholdWarningShown = false;
 export function _resetMigrationFlags(): void { qwenWarningShown = false; thresholdWarningShown = false; }
 
 const clampPct = (n: number): number => Math.max(0, Math.min(100, n));
+
+const clampInt = (n: number, min: number, max: number): number => {
+  const i = Math.trunc(n);
+  return Math.max(min, Math.min(max, i));
+};
+
+/**
+ * Parse and validate the `customCommands` config block (issue #143).
+ * Drops invalid commands silently, clamps numerics to documented bounds,
+ * defaults missing optional fields, and preserves first-occurrence on
+ * duplicate `id`. Always returns a fresh object (no shared references).
+ */
+function parseCustomCommands(raw: unknown): CustomCommandsConfig {
+  const empty: CustomCommandsConfig = { enabled: false, commands: [] };
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return empty;
+  const obj = raw as Record<string, unknown>;
+  const enabled = typeof obj.enabled === 'boolean' ? obj.enabled : false;
+  if (!Array.isArray(obj.commands)) return { enabled, commands: [] };
+
+  const seenIds = new Set<string>();
+  const commands: CustomCommand[] = [];
+
+  for (const entry of obj.commands) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const e = entry as Record<string, unknown>;
+
+    // id — non-empty string, unique
+    if (typeof e.id !== 'string' || e.id.length === 0) continue;
+    if (seenIds.has(e.id)) continue;
+
+    // command — non-empty array of non-empty strings (no shell-string form)
+    if (!Array.isArray(e.command) || e.command.length === 0) continue;
+    if (!e.command.every((s: unknown) => typeof s === 'string' && s.length > 0)) continue;
+
+    // line — must be one of {1,2,3,4}
+    if (typeof e.line !== 'number' || !CUSTOM_COMMAND_VALID_LINES.includes(e.line as 1 | 2 | 3 | 4)) continue;
+
+    // From here on the entry is valid; default optional fields.
+    const refreshMs = typeof e.refreshMs === 'number' && Number.isFinite(e.refreshMs)
+      ? Math.max(CUSTOM_COMMAND_MIN_REFRESH_MS, Math.trunc(e.refreshMs))
+      : 5000;
+    const timeoutMs = typeof e.timeoutMs === 'number' && Number.isFinite(e.timeoutMs)
+      ? clampInt(e.timeoutMs, 100, CUSTOM_COMMAND_MAX_TIMEOUT_MS)
+      : 1500;
+    const maxBytes = typeof e.maxBytes === 'number' && Number.isFinite(e.maxBytes)
+      ? clampInt(e.maxBytes, 16, CUSTOM_COMMAND_MAX_BYTES)
+      : 256;
+
+    const onError: OnErrorBehavior = CUSTOM_COMMAND_ERROR_BEHAVIORS.includes(e.onError as OnErrorBehavior)
+      ? (e.onError as OnErrorBehavior)
+      : 'hide';
+    const onTimeout: OnErrorBehavior = CUSTOM_COMMAND_ERROR_BEHAVIORS.includes(e.onTimeout as OnErrorBehavior)
+      ? (e.onTimeout as OnErrorBehavior)
+      : 'stale';
+    const ansi = typeof e.ansi === 'boolean' ? e.ansi : false;
+
+    const cmd: CustomCommand = {
+      id: e.id,
+      command: e.command.slice() as string[],
+      line: e.line as 1 | 2 | 3 | 4,
+      refreshMs,
+      timeoutMs,
+      maxBytes,
+      onError,
+      onTimeout,
+      ansi,
+    };
+
+    if (typeof e.label === 'string') cmd.label = e.label;
+    if (typeof e.cwd === 'string') cmd.cwd = e.cwd;
+    if (CUSTOM_COMMAND_COLORS.includes(e.color as never)) {
+      cmd.color = e.color as CustomCommand['color'];
+    }
+
+    // env — record of string→string, truncated to CUSTOM_COMMAND_MAX_ENV_ENTRIES
+    if (e.env && typeof e.env === 'object' && !Array.isArray(e.env)) {
+      const envOut: Record<string, string> = {};
+      let count = 0;
+      for (const [k, v] of Object.entries(e.env)) {
+        if (count >= CUSTOM_COMMAND_MAX_ENV_ENTRIES) break;
+        if (typeof k !== 'string' || k.length === 0) continue;
+        if (typeof v !== 'string') continue;
+        envOut[k] = v;
+        count++;
+      }
+      if (count > 0) cmd.env = envOut;
+    }
+
+    seenIds.add(cmd.id);
+    commands.push(cmd);
+  }
+
+  return { enabled, commands };
+}
 
 /**
  * Validate context-bar threshold pair. Clamps each to [0, 100]. If `warning`
@@ -45,12 +158,12 @@ function resolveThresholds(
 
 export function loadConfig(configDir: string = join(homedir(), '.config', 'lumira')): HudConfig {
   const p = join(configDir, 'config.json');
-  if (!existsSync(p)) return { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } };
+  if (!existsSync(p)) return { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY }, customCommands: { enabled: false, commands: [] } };
   try {
     const raw = JSON.parse(readFileSync(p, 'utf8'));
-    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } };
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY }, customCommands: { enabled: false, commands: [] } };
     return mergeConfig(raw);
-  } catch { return { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } }; }
+  } catch { return { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY }, customCommands: { enabled: false, commands: [] } }; }
 }
 
 function mergeConfig(rawIn: Record<string, unknown>): HudConfig {
@@ -68,7 +181,13 @@ function mergeConfig(rawIn: Record<string, unknown>): HudConfig {
     const m = (raw.colors as Record<string, unknown>).mode;
     if (['auto', 'named', '256', 'truecolor'].includes(m as string)) colors.mode = m as ColorConfig['mode'];
   }
-  const result: HudConfig = { layout, gsd: typeof raw.gsd === 'boolean' ? raw.gsd : DEFAULT_CONFIG.gsd, display: { ...DEFAULT_DISPLAY }, colors };
+  const result: HudConfig = {
+    layout,
+    gsd: typeof raw.gsd === 'boolean' ? raw.gsd : DEFAULT_CONFIG.gsd,
+    display: { ...DEFAULT_DISPLAY },
+    colors,
+    customCommands: parseCustomCommands(raw.customCommands),
+  };
 
   // Apply preset FIRST (sets layout + display defaults)
   const validPresets = ['full', 'balanced', 'minimal'] as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { getTokenSpeed } from './parsers/token-speed.js';
 import { getMemoryInfo } from './parsers/memory.js';
 import { getGsdInfo } from './parsers/gsd.js';
 import { getMcpInfo } from './parsers/mcp.js';
+import { getCustomCommandOutputs } from './parsers/custom-commands.js';
 import { getLayoutCols, getTermCols } from './utils/terminal.js';
 import { loadConfig, mergeCliFlags } from './config.js';
 import { render } from './render/index.js';
@@ -18,7 +19,8 @@ import { install, uninstall } from './installer.js';
 import { runThemesCommand } from './commands/themes.js';
 import { runStatsCommand } from './commands/stats.js';
 import { runCustomRefreshFromStdin } from './commands/custom-refresh.js';
-import type { Dependencies } from './types.js';
+import type { Dependencies, RawInput } from './types.js';
+import type { NormalizedInput } from './normalize.js';
 import { EMPTY_TRANSCRIPT } from './types.js';
 import { normalize } from './normalize.js';
 
@@ -32,6 +34,27 @@ const defaultDeps: Dependencies = {
   getMcpInfo: (cwd) => getMcpInfo(cwd),
   getTermCols: () => getTermCols(),
 };
+
+/**
+ * Build the stdin envelope passed to user-written custom commands (issue #143).
+ *
+ * Keep this contract minimal and forward-compatible: the `lumira.version`
+ * field is the API version a user-script can branch on, and only fields with
+ * a stable meaning are exposed. Anything more would couple user scripts to
+ * lumira's internal normalisation. Documented as the user-facing contract
+ * for the Custom Command widget.
+ */
+function buildStdinEnvelope(input: RawInput, n: NormalizedInput): string {
+  const envelope = {
+    lumira: { version: 1, platform: n.platform },
+    model: n.model,
+    cwd: n.cwd,
+    context_window: input.context_window ?? null,
+    cost: 'cost' in input ? input.cost ?? null : null,
+    git: { branch: n.gitBranch ?? null },
+  };
+  return JSON.stringify(envelope);
+}
 
 export async function main(overrides: Partial<Dependencies> = {}): Promise<string> {
   const deps = { ...defaultDeps, ...overrides };
@@ -55,7 +78,20 @@ export async function main(overrides: Partial<Dependencies> = {}): Promise<strin
   const cols = getLayoutCols(rawCols, isTTY);
   const icons = resolveIcons(config.icons);
   const normalizedInput = normalize(input);
-  return render({ input: normalizedInput, git, transcript, tokenSpeed, memory, gsd, mcp, cols, config, icons });
+
+  // Custom command outputs (issue #143). The parser is async because it reads
+  // the on-disk cache + may spawn a detached refresh helper, but it is
+  // designed to return immediately (no network or process waits). Defensive
+  // catch: any unexpected error degrades to no custom segments rather than
+  // breaking the entire statusline render.
+  const configFilePath = join(homedir(), '.config', 'lumira', 'config.json');
+  const customCommands = await getCustomCommandOutputs({
+    config: config.customCommands,
+    stdin: buildStdinEnvelope(input, normalizedInput),
+    configFilePath,
+  }).catch(() => []);
+
+  return render({ input: normalizedInput, git, transcript, tokenSpeed, memory, gsd, mcp, cols, config, icons, customCommands });
 }
 
 // Run when invoked directly.

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { resolveIcons } from './render/icons.js';
 import { install, uninstall } from './installer.js';
 import { runThemesCommand } from './commands/themes.js';
 import { runStatsCommand } from './commands/stats.js';
+import { runCustomRefreshFromStdin } from './commands/custom-refresh.js';
 import type { Dependencies } from './types.js';
 import { EMPTY_TRANSCRIPT } from './types.js';
 import { normalize } from './normalize.js';
@@ -92,6 +93,11 @@ if (isDirectRun()) {
       process.stderr.write(`Stats error: ${e.message}\n`);
       process.exit(1);
     });
+  } else if (cmd === '__custom-refresh') {
+    // Internal: invoked by the renderer as a detached child to refresh a
+    // single custom command's cache entry without keeping the renderer's
+    // event loop refed. Reads the spec JSON from its own stdin.
+    runCustomRefreshFromStdin().then(() => process.exit(0)).catch(() => process.exit(0));
   } else {
     main().then(o => process.stdout.write(o)).catch(e => { if (!(e instanceof StdinParseError)) process.stderr.write(`Statusline error: ${e.message}\n`); });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { install, uninstall } from './installer.js';
 import { runThemesCommand } from './commands/themes.js';
 import { runStatsCommand } from './commands/stats.js';
 import { runCustomRefreshFromStdin } from './commands/custom-refresh.js';
+import { runCustomCommand } from './commands/custom.js';
 import type { Dependencies, RawInput } from './types.js';
 import type { NormalizedInput } from './normalize.js';
 import { EMPTY_TRANSCRIPT } from './types.js';
@@ -127,6 +128,14 @@ if (isDirectRun()) {
       if (r.exitCode !== 0) process.exit(r.exitCode);
     }).catch(e => {
       process.stderr.write(`Stats error: ${e.message}\n`);
+      process.exit(1);
+    });
+  } else if (cmd === 'custom') {
+    runCustomCommand(process.argv).then(r => {
+      if (r.output) process.stdout.write(r.output);
+      if (r.exitCode !== 0) process.exit(r.exitCode);
+    }).catch(e => {
+      process.stderr.write(`Custom command error: ${e.message}\n`);
       process.exit(1);
     });
   } else if (cmd === '__custom-refresh') {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -109,6 +109,7 @@ function emitFooter(lines: string[], homeOverride?: string): void {
     lines.push('  ℹ Qwen Code detected — in Qwen sessions, lumira renders');
     lines.push('    single-line automatically. Your preset above applies to Claude Code.');
   }
+  lines.push(`  ${DIM}Tip: lumira custom enable to add user-defined statusline segments${RST}`);
   lines.push(`\n  Restart Claude Code to see your statusline.\n`);
 }
 

--- a/src/parsers/custom-commands.ts
+++ b/src/parsers/custom-commands.ts
@@ -9,6 +9,7 @@ import {
   unlinkSync,
 } from 'node:fs';
 import { dirname } from 'node:path';
+import { randomBytes } from 'node:crypto';
 import type {
   CustomCommand,
   CustomCommandsConfig,
@@ -95,7 +96,12 @@ function readCacheFile(path: string): CacheMap {
 function writeCacheFile(path: string, data: CacheMap): void {
   try {
     mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-    const tmp = `${path}.${process.pid}.tmp`;
+    // Random suffix (vs. process.pid) defeats symlink TOCTOU: an attacker can
+    // no longer pre-create a symlink at a predictable path. `wx` open already
+    // refuses to open existing files, but it follows pre-existing symlinks; a
+    // random unguessable name keeps the attacker from creating the symlink in
+    // the first place.
+    const tmp = `${path}.${randomBytes(8).toString('hex')}.tmp`;
     try { unlinkSync(tmp); } catch { /* not present */ }
     const fd = openSync(tmp, 'wx', 0o600);
     try {

--- a/src/parsers/custom-commands.ts
+++ b/src/parsers/custom-commands.ts
@@ -47,8 +47,14 @@ export interface GetCustomCommandOutputsInput {
   stdin: string;
   /** Path to the cache file. Defaults to ~/.cache/lumira/custom-commands.json. */
   cachePath?: string;
-  /** Path to the user's lumira config — used for the world-writable safety check. */
-  configFilePath?: string;
+  /**
+   * Path to the user's lumira config — required for the world-writable
+   * safety gate. Required (not optional) so that no caller can accidentally
+   * bypass the security check by forgetting to pass the path. If you truly
+   * have no config file path (e.g. config came from defaults), pass an empty
+   * string; the parser will fail-closed and return [].
+   */
+  configFilePath: string;
   /** Now override for deterministic tests. Defaults to Date.now(). */
   now?: number;
 }
@@ -259,8 +265,11 @@ export async function getCustomCommandOutputs(
   // Security gate #1: opt-in required.
   if (!config || config.enabled !== true) return [];
 
-  // Security gate #2: refuse to run if config file is world-writable.
-  if (input.configFilePath && isWorldWritable(input.configFilePath)) return [];
+  // Security gate #2: refuse to run if no config path was supplied (callers
+  // must explicitly pass one — bypassing the gate by omission is not OK)
+  // or if the supplied config file is world-writable.
+  if (typeof input.configFilePath !== 'string' || input.configFilePath.length === 0) return [];
+  if (isWorldWritable(input.configFilePath)) return [];
 
   if (!Array.isArray(config.commands) || config.commands.length === 0) return [];
 

--- a/src/parsers/custom-commands.ts
+++ b/src/parsers/custom-commands.ts
@@ -2,22 +2,16 @@ import {
   readFileSync,
   statSync,
   lstatSync,
-  openSync,
-  writeSync,
-  closeSync,
-  renameSync,
-  mkdirSync,
-  unlinkSync,
 } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { homedir } from 'node:os';
-import { randomBytes } from 'node:crypto';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import type {
   CustomCommand,
   CustomCommandsConfig,
   OnErrorBehavior,
 } from '../types.js';
-import { execBg } from '../utils/exec-bg.js';
 
 /**
  * Parser orchestrator for the Custom Command widget (issue #143).
@@ -137,33 +131,9 @@ function readCacheFile(path: string): CacheMap {
   }
 }
 
-/**
- * Write the cache atomically: dump to a temp file with mode 0600 + exclusive
- * open, then rename into place. The exclusive open (`wx`) prevents racing
- * symlink-following attacks on the temp file. We swallow all errors — a
- * failed cache write must NEVER affect the renderer.
- */
-function writeCacheFile(path: string, data: CacheMap): void {
-  try {
-    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-    // Random suffix (vs. process.pid) defeats symlink TOCTOU: an attacker can
-    // no longer pre-create a symlink at a predictable path. `wx` open already
-    // refuses to open existing files, but it follows pre-existing symlinks; a
-    // random unguessable name keeps the attacker from creating the symlink in
-    // the first place.
-    const tmp = `${path}.${randomBytes(8).toString('hex')}.tmp`;
-    try { unlinkSync(tmp); } catch { /* not present */ }
-    const fd = openSync(tmp, 'wx', 0o600);
-    try {
-      writeSync(fd, JSON.stringify(data));
-    } finally {
-      closeSync(fd);
-    }
-    renameSync(tmp, path);
-  } catch {
-    /* cache write best-effort */
-  }
-}
+// Cache writes happen exclusively in the detached refresh helper (see
+// src/commands/custom-refresh.ts) so the renderer process never has to
+// wait on disk IO. This parser only ever reads.
 
 /** Stat-based world-writable check. Returns true ⇒ unsafe, caller aborts. */
 function isWorldWritable(path: string): boolean {
@@ -174,14 +144,6 @@ function isWorldWritable(path: string): boolean {
     // File missing → treat as safe (config layer wouldn't have parsed it).
     return false;
   }
-}
-
-/** Extract the last non-empty line of stderr, capped to N chars, for the
- * `output` fallback behavior. */
-function lastStderrLine(stderr: string, cap = 120): string {
-  const lines = stderr.split(/\r?\n/).map((l) => l.trim()).filter((l) => l.length > 0);
-  const last = lines.length === 0 ? '' : lines[lines.length - 1];
-  return last.length > cap ? last.slice(0, cap) : last;
 }
 
 /**
@@ -265,65 +227,113 @@ function markStale(out: CustomCommandOutput): CustomCommandOutput {
 }
 
 /**
- * Fire-and-forget background refresh. Spawns the command, writes the result
- * into the cache file. Errors are swallowed — the renderer doesn't care.
- *
- * `inFlightKey` prevents the same id from racing itself if the renderer is
- * invoked twice within a single Node process before the first refresh lands.
+ * Spec sent to the detached refresh helper (must match the helper's
+ * RefreshSpec exactly — see src/commands/custom-refresh.ts).
+ */
+interface RefreshSpec {
+  id: string;
+  command: string[];
+  timeoutMs: number;
+  maxBytes: number;
+  env?: Record<string, string>;
+  cwd?: string;
+  onError: OnErrorBehavior;
+  cachePath: string;
+  stdin?: string;
+}
+
+function buildSpec(cmd: CustomCommand, stdin: string, cachePath: string): RefreshSpec {
+  const spec: RefreshSpec = {
+    id: cmd.id,
+    command: cmd.command,
+    timeoutMs: cmd.timeoutMs,
+    maxBytes: cmd.maxBytes,
+    onError: cmd.onError,
+    cachePath,
+    stdin,
+  };
+  if (cmd.env) spec.env = cmd.env;
+  if (cmd.cwd) spec.cwd = cmd.cwd;
+  return spec;
+}
+
+/**
+ * Refresh strategy — how to actually kick off the background work for a
+ * stale command. Default strategy spawns a detached lumira sub-process
+ * running the `__custom-refresh` helper so that this Node process can
+ * exit immediately (B1). Tests inject an in-process strategy that
+ * awaits execBg directly for deterministic assertions.
+ */
+export type RefreshStrategy = (spec: RefreshSpec) => void;
+
+/**
+ * Default strategy: spawn `node <lumira-entry> __custom-refresh`, write the
+ * spec to its stdin, then detach so the renderer's event loop unrefs the
+ * child immediately. The helper runs the user command, writes the cache,
+ * and exits — but the renderer no longer waits on any of that work.
+ */
+function defaultRefreshStrategy(spec: RefreshSpec): void {
+  try {
+    // The renderer is normally lumira's compiled entry (dist/index.js). When
+    // run from tests/dev we are likely executing TS via tsx/loaders; the env
+    // var lets the test harness override the entry it points to.
+    const entry = process.env.LUMIRA_CUSTOM_REFRESH_ENTRY
+      ?? fileURLToPath(new URL('../index.js', import.meta.url));
+    const child = spawn(process.execPath, [entry, '__custom-refresh'], {
+      detached: true,
+      // stdin pipes the spec; stdout/stderr discarded so we don't keep the
+      // event loop refed waiting on output from the helper.
+      stdio: ['pipe', 'ignore', 'ignore'],
+      windowsHide: true,
+    });
+    // Unref so the parent process can exit while the helper continues.
+    child.unref();
+    if (child.stdin) {
+      child.stdin.on('error', () => { /* helper may exit before we finish writing */ });
+      try { child.stdin.write(JSON.stringify(spec)); } catch { /* ignore */ }
+      try { child.stdin.end(); } catch { /* ignore */ }
+    }
+  } catch {
+    /* swallow — render must never break because a helper failed to spawn */
+  }
+}
+
+let activeRefreshStrategy: RefreshStrategy = defaultRefreshStrategy;
+
+/**
+ * Test-only: swap the refresh strategy. Pass `undefined` to restore the
+ * default detached-spawn behavior. Use the in-process strategy in tests
+ * that need to observe cache writes deterministically.
+ */
+export function _setRefreshStrategy(strategy: RefreshStrategy | undefined): void {
+  activeRefreshStrategy = strategy ?? defaultRefreshStrategy;
+}
+
+/**
+ * Fire-and-forget background refresh. Delegates to the active strategy.
+ * `refreshInFlight` prevents the same id from racing itself if the
+ * renderer is invoked twice within one Node process.
  */
 function fireRefresh(
   cmd: CustomCommand,
   stdin: string,
   cachePath: string,
-  now: () => number,
 ): void {
   if (refreshInFlight.has(cmd.id)) return;
   refreshInFlight.add(cmd.id);
-
-  // Detached from the call site — we don't await this and we don't surface errors.
-  void (async (): Promise<void> => {
-    try {
-      const result = await execBg({
-        command: cmd.command,
-        timeoutMs: cmd.timeoutMs,
-        maxBytes: cmd.maxBytes,
-        env: cmd.env,
-        cwd: cmd.cwd,
-        stdin,
-      });
-
-      let entry: CacheEntry;
-      switch (result.kind) {
-        case 'ok':
-          entry = { text: result.stdout, capturedAt: now(), state: 'ok' };
-          break;
-        case 'timeout':
-          entry = { text: result.stdout, capturedAt: now(), state: 'timeout' };
-          break;
-        case 'nonzero': {
-          // Honor onError: 'output' by storing the last stderr line; other
-          // behaviors will still see this entry as `nonzero` and choose to
-          // hide / placeholder / use stale, but `output` will surface text.
-          const text = cmd.onError === 'output' ? lastStderrLine(result.stderr) : result.stdout;
-          entry = { text, capturedAt: now(), state: 'nonzero' };
-          break;
-        }
-        case 'spawn-error':
-          entry = { text: '', capturedAt: now(), state: 'nonzero' };
-          break;
-      }
-
-      // Read-modify-write the cache so concurrent commands don't clobber each
-      // other's entries. The renamesync at the end is atomic on POSIX.
-      const current = readCacheFile(cachePath);
-      current[cmd.id] = entry;
-      writeCacheFile(cachePath, current);
-    } catch {
-      /* swallow — render must never break */
-    } finally {
-      refreshInFlight.delete(cmd.id);
-    }
-  })();
+  try {
+    activeRefreshStrategy(buildSpec(cmd, stdin, cachePath));
+  } catch {
+    /* defensive */
+  } finally {
+    // Note: detached strategy completes the work asynchronously in another
+    // process, so refreshInFlight is cleared as soon as the spawn has been
+    // dispatched. The cross-process semantics mean we no longer "know" when
+    // the helper finishes — but that's fine: stale-while-refreshing is the
+    // designed behavior, and the next render that sees a fresh cache entry
+    // will switch from `stale` back to `ok`.
+    refreshInFlight.delete(cmd.id);
+  }
 }
 
 export async function getCustomCommandOutputs(
@@ -350,7 +360,6 @@ export async function getCustomCommandOutputs(
 
   const cache = readCacheFile(cachePath);
   const now = typeof input.now === 'number' ? input.now : Date.now();
-  const nowFn = (): number => (typeof input.now === 'number' ? input.now : Date.now());
 
   const outputs: CustomCommandOutput[] = [];
   for (const cmd of config.commands) {
@@ -368,7 +377,7 @@ export async function getCustomCommandOutputs(
     outputs.push(isStale ? markStale(base) : base);
 
     if (isStale) {
-      fireRefresh(cmd, input.stdin, cachePath, nowFn);
+      fireRefresh(cmd, input.stdin, cachePath);
     }
   }
 

--- a/src/parsers/custom-commands.ts
+++ b/src/parsers/custom-commands.ts
@@ -1,6 +1,7 @@
 import {
   readFileSync,
   statSync,
+  lstatSync,
   openSync,
   writeSync,
   closeSync,
@@ -8,7 +9,8 @@ import {
   mkdirSync,
   unlinkSync,
 } from 'node:fs';
-import { dirname } from 'node:path';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
 import { randomBytes } from 'node:crypto';
 import type {
   CustomCommand,
@@ -72,8 +74,24 @@ type CacheMap = Record<string, CacheEntry>;
  * the renderer firing N parallel refreshes when called in a tight loop. */
 const refreshInFlight = new Set<string>();
 
+/** Default cache file location when caller doesn't supply one. */
+function defaultCachePath(): string {
+  return join(homedir(), '.cache', 'lumira', 'custom-commands.json');
+}
+
 function readCacheFile(path: string): CacheMap {
   try {
+    // Symlink-safe: lstat first and refuse to read if the cache path itself
+    // is a symlink. Otherwise an attacker who can write into the cache dir
+    // could redirect our read to a file they control, then watch the cache
+    // contents leak into the rendered statusline.
+    try {
+      const st = lstatSync(path);
+      if (st.isSymbolicLink()) return {};
+    } catch {
+      // File does not exist (or stat failed) — fall through; readFileSync
+      // below will return an empty cache via its catch block.
+    }
     const raw = readFileSync(path, 'utf8');
     const parsed: unknown = JSON.parse(raw);
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
@@ -273,12 +291,12 @@ export async function getCustomCommandOutputs(
 
   if (!Array.isArray(config.commands) || config.commands.length === 0) return [];
 
-  const cachePath = input.cachePath;
-  if (typeof cachePath !== 'string' || cachePath.length === 0) {
-    // Without a cache path we can't store anything. Return never-ran outputs
-    // per command without spawning (no place to write the result).
-    return config.commands.map((cmd) => applyFallback(cmd, undefined));
-  }
+  // M1: apply the documented default when the caller omits cachePath, rather
+  // than silently degrading to never-ran for every command. The default
+  // matches the JSDoc on cachePath: ~/.cache/lumira/custom-commands.json.
+  const cachePath = typeof input.cachePath === 'string' && input.cachePath.length > 0
+    ? input.cachePath
+    : defaultCachePath();
 
   const cache = readCacheFile(cachePath);
   const now = typeof input.now === 'number' ? input.now : Date.now();
@@ -287,7 +305,12 @@ export async function getCustomCommandOutputs(
   const outputs: CustomCommandOutput[] = [];
   for (const cmd of config.commands) {
     const entry = cache[cmd.id];
-    const isStale = !entry || now - entry.capturedAt >= cmd.refreshMs;
+    // M2: clamp age to 0. If the system clock skews backwards (NTP correction,
+    // suspend/resume, manual change), `now - capturedAt` could be negative and
+    // the entry would look fresh forever. Math.max guarantees we only ever
+    // treat past-captured entries as having age >= 0.
+    const age = entry ? Math.max(0, now - entry.capturedAt) : Infinity;
+    const isStale = !entry || age >= cmd.refreshMs;
 
     outputs.push(applyFallback(cmd, entry));
 

--- a/src/parsers/custom-commands.ts
+++ b/src/parsers/custom-commands.ts
@@ -32,15 +32,41 @@ import { execBg } from '../utils/exec-bg.js';
  * - World-writable config file aborts (someone could have injected commands).
  */
 
+/**
+ * State emitted to the renderer.
+ *  - `ok`      — cached output present and within refreshMs.
+ *  - `stale`   — cached output present but past refreshMs; a background
+ *                refresh has just been kicked off. Renderer can dim the
+ *                text or render the previous value unchanged.
+ *  - `timeout` — last run hit wall-clock timeout (onTimeout governs text).
+ *  - `error`   — last run exited non-zero, spawn failed, or never-ran with
+ *                onError != 'hide' (onError governs text).
+ *  - `hidden`  — nothing should be rendered (empty text). Either explicit
+ *                onError/onTimeout = 'hide', or no cached entry + onError =
+ *                'hide' (collapses the old 'never-ran' state — same UI).
+ */
+export type CustomCommandState = 'ok' | 'stale' | 'timeout' | 'error' | 'hidden';
+
 export interface CustomCommandOutput {
   /** Matches CustomCommand.id from the config. */
   id: string;
   /** Text to render (may be empty when state = 'hidden'). */
   text: string;
   /** State the command is in — drives renderer styling. */
-  state: 'ok' | 'stale' | 'timeout' | 'error' | 'never-ran' | 'hidden';
-  /** When the cached output was captured (ms epoch); absent for never-ran/hidden. */
+  state: CustomCommandState;
+  /** When the cached output was captured (ms epoch); absent when no cache entry. */
   capturedAt?: number;
+  // ── Rendering metadata (copied from the CustomCommand config) ─────
+  // These are propagated here so renderers don't have to maintain a
+  // separate id→cmd lookup just to know which line / color / glyph to use.
+  /** Which statusline line to render on. */
+  line: 1 | 2 | 3 | 4;
+  /** Optional prefix label/glyph. */
+  label?: string;
+  /** Optional color (applied only when ansi = false). */
+  color?: CustomCommand['color'];
+  /** True if the command's stdout already contains ANSI escapes. */
+  ansi: boolean;
 }
 
 export interface GetCustomCommandOutputsInput {
@@ -158,18 +184,34 @@ function lastStderrLine(stderr: string, cap = 120): string {
   return last.length > cap ? last.slice(0, cap) : last;
 }
 
+/**
+ * Build the base render-metadata fields common to every output. Renderers
+ * consume these directly instead of joining the output back against the
+ * CustomCommand list — keeps the contract self-contained.
+ */
+function renderMeta(cmd: CustomCommand): Pick<CustomCommandOutput, 'line' | 'label' | 'color' | 'ansi'> {
+  const meta: Pick<CustomCommandOutput, 'line' | 'label' | 'color' | 'ansi'> = {
+    line: cmd.line,
+    ansi: cmd.ansi,
+  };
+  if (cmd.label !== undefined) meta.label = cmd.label;
+  if (cmd.color !== undefined) meta.color = cmd.color;
+  return meta;
+}
+
 /** Map a cached entry into the render-facing output, applying onError/onTimeout. */
 function applyFallback(
   cmd: CustomCommand,
   entry: CacheEntry | undefined,
 ): CustomCommandOutput {
   if (!entry) {
-    // No cache. Surface the never-ran state mapped through onError so the
-    // renderer knows what to draw on the first render after enabling.
-    return mapBehavior(cmd, cmd.onError, undefined, 'never-ran');
+    // No cache entry. The "never-ran" state is collapsed into the regular
+    // error/hidden mapping per onError — the renderer just sees `hidden`
+    // or `error` and renders accordingly (drops the dead `never-ran` arm).
+    return mapBehavior(cmd, cmd.onError, undefined, 'error');
   }
   if (entry.state === 'ok') {
-    return { id: cmd.id, text: entry.text, state: 'ok', capturedAt: entry.capturedAt };
+    return { ...renderMeta(cmd), id: cmd.id, text: entry.text, state: 'ok', capturedAt: entry.capturedAt };
   }
   if (entry.state === 'timeout') {
     return mapBehavior(cmd, cmd.onTimeout, entry, 'timeout');
@@ -182,36 +224,44 @@ function mapBehavior(
   cmd: CustomCommand,
   behavior: OnErrorBehavior,
   entry: CacheEntry | undefined,
-  failureState: 'timeout' | 'error' | 'never-ran',
+  failureState: 'timeout' | 'error',
 ): CustomCommandOutput {
+  const meta = renderMeta(cmd);
   switch (behavior) {
     case 'hide':
-      return { id: cmd.id, text: '', state: 'hidden' };
+      return { ...meta, id: cmd.id, text: '', state: 'hidden' };
     case 'placeholder': {
       const text = failureState === 'timeout' ? '…' : '?';
-      return { id: cmd.id, text, state: failureState === 'never-ran' ? 'error' : failureState };
+      return { ...meta, id: cmd.id, text, state: failureState };
     }
     case 'stale':
-      if (entry && entry.text.length > 0) {
-        return {
-          id: cmd.id,
-          text: entry.text,
-          state: failureState === 'never-ran' ? 'error' : failureState,
-          capturedAt: entry.capturedAt,
-        };
-      }
-      return { id: cmd.id, text: '', state: 'hidden' };
     case 'output':
+      // `stale` and `output` differ semantically but produce the same
+      // render: previous cached text if any, otherwise hidden. Keeping
+      // them in one arm avoids the dead `failureState === 'stale'` ===
+      // failureState pun the old code accidentally relied on.
       if (entry && entry.text.length > 0) {
         return {
+          ...meta,
           id: cmd.id,
           text: entry.text,
-          state: failureState === 'never-ran' ? 'error' : failureState,
+          state: failureState,
           capturedAt: entry.capturedAt,
         };
       }
-      return { id: cmd.id, text: '', state: 'hidden' };
+      return { ...meta, id: cmd.id, text: '', state: 'hidden' };
   }
+}
+
+/**
+ * Promote an `ok` output to `stale` when the cache entry is past refreshMs.
+ * Renderers can dim or annotate stale entries while a background refresh
+ * is in flight. `hidden` / `timeout` / `error` are left alone — their
+ * staleness is governed by the user's onError/onTimeout choice, not here.
+ */
+function markStale(out: CustomCommandOutput): CustomCommandOutput {
+  if (out.state !== 'ok') return out;
+  return { ...out, state: 'stale' };
 }
 
 /**
@@ -312,7 +362,10 @@ export async function getCustomCommandOutputs(
     const age = entry ? Math.max(0, now - entry.capturedAt) : Infinity;
     const isStale = !entry || age >= cmd.refreshMs;
 
-    outputs.push(applyFallback(cmd, entry));
+    const base = applyFallback(cmd, entry);
+    // Promote `ok` to `stale` when a refresh is about to fire — the renderer
+    // can then dim the entry while the new value lands on disk.
+    outputs.push(isStale ? markStale(base) : base);
 
     if (isStale) {
       fireRefresh(cmd, input.stdin, cachePath, nowFn);

--- a/src/parsers/custom-commands.ts
+++ b/src/parsers/custom-commands.ts
@@ -1,0 +1,290 @@
+import {
+  readFileSync,
+  statSync,
+  openSync,
+  writeSync,
+  closeSync,
+  renameSync,
+  mkdirSync,
+  unlinkSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+import type {
+  CustomCommand,
+  CustomCommandsConfig,
+  OnErrorBehavior,
+} from '../types.js';
+import { execBg } from '../utils/exec-bg.js';
+
+/**
+ * Parser orchestrator for the Custom Command widget (issue #143).
+ *
+ * Render contract: this function MUST behave synchronously from the
+ * renderer's perspective. It reads the on-disk cache, returns whatever it
+ * has for each configured command, and triggers a fire-and-forget refresh
+ * when an entry is stale. The renderer never waits on a child process.
+ *
+ * Security gates (defense in depth, beyond what config validation does):
+ * - `enabled !== true` short-circuits everything (no spawn, no FS access).
+ * - World-writable config file aborts (someone could have injected commands).
+ */
+
+export interface CustomCommandOutput {
+  /** Matches CustomCommand.id from the config. */
+  id: string;
+  /** Text to render (may be empty when state = 'hidden'). */
+  text: string;
+  /** State the command is in — drives renderer styling. */
+  state: 'ok' | 'stale' | 'timeout' | 'error' | 'never-ran' | 'hidden';
+  /** When the cached output was captured (ms epoch); absent for never-ran/hidden. */
+  capturedAt?: number;
+}
+
+export interface GetCustomCommandOutputsInput {
+  config: CustomCommandsConfig;
+  /** Lumira normalized envelope (JSON) to pipe via child stdin. */
+  stdin: string;
+  /** Path to the cache file. Defaults to ~/.cache/lumira/custom-commands.json. */
+  cachePath?: string;
+  /** Path to the user's lumira config — used for the world-writable safety check. */
+  configFilePath?: string;
+  /** Now override for deterministic tests. Defaults to Date.now(). */
+  now?: number;
+}
+
+/** Persisted cache entry. `state` captures the prior run's outcome. */
+interface CacheEntry {
+  text: string;
+  capturedAt: number;
+  state: 'ok' | 'nonzero' | 'timeout';
+}
+
+type CacheMap = Record<string, CacheEntry>;
+
+/** Tracks which commands are currently being refreshed in-process. Prevents
+ * the renderer firing N parallel refreshes when called in a tight loop. */
+const refreshInFlight = new Set<string>();
+
+function readCacheFile(path: string): CacheMap {
+  try {
+    const raw = readFileSync(path, 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const out: CacheMap = {};
+    for (const [id, entry] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+      const e = entry as Record<string, unknown>;
+      if (typeof e.text !== 'string') continue;
+      if (typeof e.capturedAt !== 'number' || !Number.isFinite(e.capturedAt)) continue;
+      const s = e.state;
+      if (s !== 'ok' && s !== 'nonzero' && s !== 'timeout') continue;
+      out[id] = { text: e.text, capturedAt: e.capturedAt, state: s };
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Write the cache atomically: dump to a temp file with mode 0600 + exclusive
+ * open, then rename into place. The exclusive open (`wx`) prevents racing
+ * symlink-following attacks on the temp file. We swallow all errors — a
+ * failed cache write must NEVER affect the renderer.
+ */
+function writeCacheFile(path: string, data: CacheMap): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    const tmp = `${path}.${process.pid}.tmp`;
+    try { unlinkSync(tmp); } catch { /* not present */ }
+    const fd = openSync(tmp, 'wx', 0o600);
+    try {
+      writeSync(fd, JSON.stringify(data));
+    } finally {
+      closeSync(fd);
+    }
+    renameSync(tmp, path);
+  } catch {
+    /* cache write best-effort */
+  }
+}
+
+/** Stat-based world-writable check. Returns true ⇒ unsafe, caller aborts. */
+function isWorldWritable(path: string): boolean {
+  try {
+    const s = statSync(path);
+    return (s.mode & 0o002) !== 0;
+  } catch {
+    // File missing → treat as safe (config layer wouldn't have parsed it).
+    return false;
+  }
+}
+
+/** Extract the last non-empty line of stderr, capped to N chars, for the
+ * `output` fallback behavior. */
+function lastStderrLine(stderr: string, cap = 120): string {
+  const lines = stderr.split(/\r?\n/).map((l) => l.trim()).filter((l) => l.length > 0);
+  const last = lines.length === 0 ? '' : lines[lines.length - 1];
+  return last.length > cap ? last.slice(0, cap) : last;
+}
+
+/** Map a cached entry into the render-facing output, applying onError/onTimeout. */
+function applyFallback(
+  cmd: CustomCommand,
+  entry: CacheEntry | undefined,
+): CustomCommandOutput {
+  if (!entry) {
+    // No cache. Surface the never-ran state mapped through onError so the
+    // renderer knows what to draw on the first render after enabling.
+    return mapBehavior(cmd, cmd.onError, undefined, 'never-ran');
+  }
+  if (entry.state === 'ok') {
+    return { id: cmd.id, text: entry.text, state: 'ok', capturedAt: entry.capturedAt };
+  }
+  if (entry.state === 'timeout') {
+    return mapBehavior(cmd, cmd.onTimeout, entry, 'timeout');
+  }
+  // nonzero exit
+  return mapBehavior(cmd, cmd.onError, entry, 'error');
+}
+
+function mapBehavior(
+  cmd: CustomCommand,
+  behavior: OnErrorBehavior,
+  entry: CacheEntry | undefined,
+  failureState: 'timeout' | 'error' | 'never-ran',
+): CustomCommandOutput {
+  switch (behavior) {
+    case 'hide':
+      return { id: cmd.id, text: '', state: 'hidden' };
+    case 'placeholder': {
+      const text = failureState === 'timeout' ? '…' : '?';
+      return { id: cmd.id, text, state: failureState === 'never-ran' ? 'error' : failureState };
+    }
+    case 'stale':
+      if (entry && entry.text.length > 0) {
+        return {
+          id: cmd.id,
+          text: entry.text,
+          state: failureState === 'never-ran' ? 'error' : failureState,
+          capturedAt: entry.capturedAt,
+        };
+      }
+      return { id: cmd.id, text: '', state: 'hidden' };
+    case 'output':
+      if (entry && entry.text.length > 0) {
+        return {
+          id: cmd.id,
+          text: entry.text,
+          state: failureState === 'never-ran' ? 'error' : failureState,
+          capturedAt: entry.capturedAt,
+        };
+      }
+      return { id: cmd.id, text: '', state: 'hidden' };
+  }
+}
+
+/**
+ * Fire-and-forget background refresh. Spawns the command, writes the result
+ * into the cache file. Errors are swallowed — the renderer doesn't care.
+ *
+ * `inFlightKey` prevents the same id from racing itself if the renderer is
+ * invoked twice within a single Node process before the first refresh lands.
+ */
+function fireRefresh(
+  cmd: CustomCommand,
+  stdin: string,
+  cachePath: string,
+  now: () => number,
+): void {
+  if (refreshInFlight.has(cmd.id)) return;
+  refreshInFlight.add(cmd.id);
+
+  // Detached from the call site — we don't await this and we don't surface errors.
+  void (async (): Promise<void> => {
+    try {
+      const result = await execBg({
+        command: cmd.command,
+        timeoutMs: cmd.timeoutMs,
+        maxBytes: cmd.maxBytes,
+        env: cmd.env,
+        cwd: cmd.cwd,
+        stdin,
+      });
+
+      let entry: CacheEntry;
+      switch (result.kind) {
+        case 'ok':
+          entry = { text: result.stdout, capturedAt: now(), state: 'ok' };
+          break;
+        case 'timeout':
+          entry = { text: result.stdout, capturedAt: now(), state: 'timeout' };
+          break;
+        case 'nonzero': {
+          // Honor onError: 'output' by storing the last stderr line; other
+          // behaviors will still see this entry as `nonzero` and choose to
+          // hide / placeholder / use stale, but `output` will surface text.
+          const text = cmd.onError === 'output' ? lastStderrLine(result.stderr) : result.stdout;
+          entry = { text, capturedAt: now(), state: 'nonzero' };
+          break;
+        }
+        case 'spawn-error':
+          entry = { text: '', capturedAt: now(), state: 'nonzero' };
+          break;
+      }
+
+      // Read-modify-write the cache so concurrent commands don't clobber each
+      // other's entries. The renamesync at the end is atomic on POSIX.
+      const current = readCacheFile(cachePath);
+      current[cmd.id] = entry;
+      writeCacheFile(cachePath, current);
+    } catch {
+      /* swallow — render must never break */
+    } finally {
+      refreshInFlight.delete(cmd.id);
+    }
+  })();
+}
+
+export async function getCustomCommandOutputs(
+  input: GetCustomCommandOutputsInput,
+): Promise<CustomCommandOutput[]> {
+  const { config } = input;
+  // Security gate #1: opt-in required.
+  if (!config || config.enabled !== true) return [];
+
+  // Security gate #2: refuse to run if config file is world-writable.
+  if (input.configFilePath && isWorldWritable(input.configFilePath)) return [];
+
+  if (!Array.isArray(config.commands) || config.commands.length === 0) return [];
+
+  const cachePath = input.cachePath;
+  if (typeof cachePath !== 'string' || cachePath.length === 0) {
+    // Without a cache path we can't store anything. Return never-ran outputs
+    // per command without spawning (no place to write the result).
+    return config.commands.map((cmd) => applyFallback(cmd, undefined));
+  }
+
+  const cache = readCacheFile(cachePath);
+  const now = typeof input.now === 'number' ? input.now : Date.now();
+  const nowFn = (): number => (typeof input.now === 'number' ? input.now : Date.now());
+
+  const outputs: CustomCommandOutput[] = [];
+  for (const cmd of config.commands) {
+    const entry = cache[cmd.id];
+    const isStale = !entry || now - entry.capturedAt >= cmd.refreshMs;
+
+    outputs.push(applyFallback(cmd, entry));
+
+    if (isStale) {
+      fireRefresh(cmd, input.stdin, cachePath, nowFn);
+    }
+  }
+
+  return outputs;
+}
+
+/** Test-only — clears the in-process refresh-in-flight tracker. */
+export function _resetRefreshState(): void {
+  refreshInFlight.clear();
+}

--- a/src/parsers/custom-commands.ts
+++ b/src/parsers/custom-commands.ts
@@ -1,7 +1,5 @@
 import {
-  readFileSync,
   statSync,
-  lstatSync,
 } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
@@ -11,7 +9,9 @@ import type {
   CustomCommand,
   CustomCommandsConfig,
   OnErrorBehavior,
+  RefreshSpec,
 } from '../types.js';
+import { readCacheFile, type CacheEntry, type CacheMap } from '../utils/custom-cache.js';
 
 /**
  * Parser orchestrator for the Custom Command widget (issue #143).
@@ -81,15 +81,6 @@ export interface GetCustomCommandOutputsInput {
   now?: number;
 }
 
-/** Persisted cache entry. `state` captures the prior run's outcome. */
-interface CacheEntry {
-  text: string;
-  capturedAt: number;
-  state: 'ok' | 'nonzero' | 'timeout';
-}
-
-type CacheMap = Record<string, CacheEntry>;
-
 /** Tracks which commands are currently being refreshed in-process. Prevents
  * the renderer firing N parallel refreshes when called in a tight loop. */
 const refreshInFlight = new Set<string>();
@@ -97,38 +88,6 @@ const refreshInFlight = new Set<string>();
 /** Default cache file location when caller doesn't supply one. */
 function defaultCachePath(): string {
   return join(homedir(), '.cache', 'lumira', 'custom-commands.json');
-}
-
-function readCacheFile(path: string): CacheMap {
-  try {
-    // Symlink-safe: lstat first and refuse to read if the cache path itself
-    // is a symlink. Otherwise an attacker who can write into the cache dir
-    // could redirect our read to a file they control, then watch the cache
-    // contents leak into the rendered statusline.
-    try {
-      const st = lstatSync(path);
-      if (st.isSymbolicLink()) return {};
-    } catch {
-      // File does not exist (or stat failed) — fall through; readFileSync
-      // below will return an empty cache via its catch block.
-    }
-    const raw = readFileSync(path, 'utf8');
-    const parsed: unknown = JSON.parse(raw);
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
-    const out: CacheMap = {};
-    for (const [id, entry] of Object.entries(parsed as Record<string, unknown>)) {
-      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
-      const e = entry as Record<string, unknown>;
-      if (typeof e.text !== 'string') continue;
-      if (typeof e.capturedAt !== 'number' || !Number.isFinite(e.capturedAt)) continue;
-      const s = e.state;
-      if (s !== 'ok' && s !== 'nonzero' && s !== 'timeout') continue;
-      out[id] = { text: e.text, capturedAt: e.capturedAt, state: s };
-    }
-    return out;
-  } catch {
-    return {};
-  }
 }
 
 // Cache writes happen exclusively in the detached refresh helper (see
@@ -224,22 +183,6 @@ function mapBehavior(
 function markStale(out: CustomCommandOutput): CustomCommandOutput {
   if (out.state !== 'ok') return out;
   return { ...out, state: 'stale' };
-}
-
-/**
- * Spec sent to the detached refresh helper (must match the helper's
- * RefreshSpec exactly — see src/commands/custom-refresh.ts).
- */
-interface RefreshSpec {
-  id: string;
-  command: string[];
-  timeoutMs: number;
-  maxBytes: number;
-  env?: Record<string, string>;
-  cwd?: string;
-  onError: OnErrorBehavior;
-  cachePath: string;
-  stdin?: string;
 }
 
 function buildSpec(cmd: CustomCommand, stdin: string, cachePath: string): RefreshSpec {

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -29,6 +29,15 @@ export function render(ctx: RenderContext): string {
   lines.push(wantsPowerline ? renderPowerlineLine2(ctx, colorMode, theme, c) : renderLine2(ctx, c));
   const l3 = wantsPowerline ? renderPowerlineLine3(ctx, colorMode, theme) : renderLine3(ctx, c);
   if (l3) lines.push(l3);
-  if (ctx.config.gsd) { const l4 = renderLine4(ctx, c); if (l4) lines.push(l4); }
+
+  // Line 4 renders when either GSD is on OR a custom command targets line 4.
+  // The renderer short-circuits to '' when both are absent, so this gate just
+  // avoids invoking the renderer when we know it has nothing to do — keeping
+  // the previous behaviour for users without either feature configured.
+  const hasL4CustomCmds = (ctx.customCommands ?? []).some(o => o.line === 4 && o.state !== 'hidden');
+  if (ctx.config.gsd || hasL4CustomCmds) {
+    const l4 = renderLine4(ctx, c);
+    if (l4) lines.push(l4);
+  }
   return lines.filter(Boolean).join('\n');
 }

--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -1,7 +1,7 @@
 import { basename } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { fitSegments, truncField } from './text.js';
-import { formatGitChanges, getActiveTodo, SEP } from './shared.js';
+import { formatGitChanges, getActiveTodo, getCustomCommandsForLine, renderCustomCommand, SEP } from './shared.js';
 import { hyperlink } from './hyperlink.js';
 import { formatDuration } from '../utils/format.js';
 import { isNamedAgentType } from '../parsers/subagents.js';
@@ -115,6 +115,14 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
       `https://www.npmjs.com/package/@anthropic-ai/claude-code/v/${encodeURIComponent(input.version)}`,
       c.dim(`v${input.version}`),
     ));
+  }
+
+  // Custom commands (issue #143 phase 3) — appended last on the left so they
+  // sit after core widgets and evict first under fitSegments' narrow-cols
+  // pressure. Filtered to line === 1 and non-hidden state.
+  for (const out of getCustomCommandsForLine(ctx.customCommands, 1)) {
+    const seg = renderCustomCommand(out, c);
+    if (seg) left.push(seg);
   }
 
   if (left.length === 0 && right.length === 0) return '';

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -2,7 +2,7 @@ import { fitSegments, displayWidth } from './text.js';
 import { getQuotaColor, getPaceColor, getCacheHitColor, getApiLatencyColor, detectColorMode, type Colors } from './colors.js';
 import { QUOTA_CRITICAL } from '../types.js';
 import { computeApiLatency, formatApiLatency } from './api-latency.js';
-import { buildContextBar, formatQwenMetrics, SEP } from './shared.js';
+import { buildContextBar, formatQwenMetrics, getCustomCommandsForLine, renderCustomCommand, SEP } from './shared.js';
 import { formatTokens, formatCost, formatBurnRate } from '../utils/format.js';
 import { getConfigHealth } from '../parsers/config-health.js';
 import { computePaceDelta, formatPaceDelta } from './pace.js';
@@ -266,6 +266,14 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
         projectedW += addW;
       }
     }
+  }
+
+  // Custom commands (issue #143 phase 3) — appended last on the left so they
+  // sit after rate-limit/pace clusters and evict first under fitSegments'
+  // narrow-cols pressure. Filtered to line === 2 and non-hidden state.
+  for (const out of getCustomCommandsForLine(ctx.customCommands, 2)) {
+    const seg = renderCustomCommand(out, c);
+    if (seg) leftParts.push(seg);
   }
 
   if (leftParts.length === 0 && rightParts.length === 0) return '';

--- a/src/render/line3.ts
+++ b/src/render/line3.ts
@@ -1,5 +1,5 @@
 import { truncField } from './text.js';
-import { SEP, EXCLUDED_TOOLS } from './shared.js';
+import { SEP, EXCLUDED_TOOLS, getCustomCommandsForLine, renderCustomCommand } from './shared.js';
 import type { IconSet } from './icons.js';
 import type { Colors } from './colors.js';
 import type { RenderContext, ToolEntry, TodoEntry } from '../types.js';
@@ -67,5 +67,14 @@ export function renderLine3(ctx: RenderContext, c: Colors): string {
   const todosPart = display.todos === false ? '' : buildTodosPart(todos, c, icons);
 
   const parts = [toolsPart, agentsPart, todosPart].filter(Boolean);
+
+  // Custom commands (issue #143 phase 3) — appended after the core line3
+  // widgets so they sit at the end of the line and are visible without
+  // disrupting the tools/agents/todos cluster.
+  for (const out of getCustomCommandsForLine(ctx.customCommands, 3)) {
+    const seg = renderCustomCommand(out, c);
+    if (seg) parts.push(seg);
+  }
+
   return parts.join(SEP);
 }

--- a/src/render/line4.ts
+++ b/src/render/line4.ts
@@ -1,20 +1,31 @@
 import { truncField } from './text.js';
+import { getCustomCommandsForLine, renderCustomCommand } from './shared.js';
 import type { Colors } from './colors.js';
 import type { RenderContext } from '../types.js';
 
 export function renderLine4(ctx: RenderContext, c: Colors): string {
   const { gsd, icons } = ctx;
-  if (!gsd) return '';
-  if (!gsd.currentTask && !gsd.updateAvailable) return '';
+  const parts: string[] = [];
 
-  const parts: string[] = [c.dim('GSD')];
-
-  if (gsd.currentTask) {
-    parts.push(c.bold(`${icons.hammer} ${truncField(gsd.currentTask, 40)}`));
+  // GSD widget — only emit when GSD has something to display.
+  if (gsd && (gsd.currentTask || gsd.updateAvailable)) {
+    parts.push(c.dim('GSD'));
+    if (gsd.currentTask) {
+      parts.push(c.bold(`${icons.hammer} ${truncField(gsd.currentTask, 40)}`));
+    }
+    if (gsd.updateAvailable) {
+      parts.push(c.yellow(`${icons.warning} GSD update available`));
+    }
   }
 
-  if (gsd.updateAvailable) {
-    parts.push(c.yellow(`${icons.warning} GSD update available`));
+  // Custom commands (issue #143 phase 3) — line 4 is the lowest-priority line
+  // and previously empty when GSD is absent. Custom commands declared with
+  // line: 4 now surface here so users can pin their own widgets on a quiet
+  // line. If neither GSD nor custom commands have content, line returns ''
+  // and is omitted by the line-joiner upstream.
+  for (const out of getCustomCommandsForLine(ctx.customCommands, 4)) {
+    const seg = renderCustomCommand(out, c);
+    if (seg) parts.push(seg);
   }
 
   return parts.join(' ');

--- a/src/render/minimal.ts
+++ b/src/render/minimal.ts
@@ -118,8 +118,14 @@ export function renderMinimal(ctx: RenderContext, c: Colors): string {
 
   const mainLine = parts.join(SEP_MINIMAL);
 
-  // Append tools/todos as extra line
-  const l3 = renderLine3(ctx, c);
+  // Append tools/todos as extra line. Custom commands are intentionally NOT
+  // surfaced in minimal mode — the preset targets tight single-line terminals
+  // and arbitrary user widgets would fight every other widget for space.
+  // Users who want custom commands should switch to full or balanced.
+  // We strip customCommands from the ctx before delegating so line3's own
+  // custom-command handling never fires here.
+  const minimalCtx = ctx.customCommands ? { ...ctx, customCommands: undefined } : ctx;
+  const l3 = renderLine3(minimalCtx, c);
   if (l3) return mainLine + '\n' + l3;
   return mainLine;
 }

--- a/src/render/powerline-line1.ts
+++ b/src/render/powerline-line1.ts
@@ -1,7 +1,7 @@
 import { basename } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { truncField } from './text.js';
-import { getActiveTodo } from './shared.js';
+import { getActiveTodo, getCustomCommandsForLine, renderCustomCommand } from './shared.js';
 import { formatDuration } from '../utils/format.js';
 import { hyperlink } from './hyperlink.js';
 import { isNamedAgentType } from '../parsers/subagents.js';
@@ -11,7 +11,7 @@ import {
   type PowerlineSegment,
   type PowerlineStyleName,
 } from './powerline.js';
-import type { ColorMode } from './colors.js';
+import { createColors, type ColorMode } from './colors.js';
 import type { RenderContext } from '../types.js';
 import {
   type PowerlinePalette,
@@ -37,7 +37,7 @@ import {
  *   version:       20
  *   style:         18  (dropped first)
  */
-function buildSegments(ctx: RenderContext, palette: PowerlinePalette): PowerlineSegment[] {
+function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: import('./colors.js').Colors): PowerlineSegment[] {
   const { input, git, transcript, config: { display }, icons, memory, tokenSpeed } = ctx;
   const segments: PowerlineSegment[] = [];
 
@@ -205,6 +205,18 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette): Powerline
     });
   }
 
+  // Custom commands (issue #143 phase 3) — neutral bg (dirBg) so user-defined
+  // segments don't collide with the semantic bg slots (modelBg, taskBg, etc.).
+  // Priority 15 sits below all built-in segments so custom commands evict
+  // first under narrow-cols pressure — keeps lumira's own widgets visible
+  // when space is tight, treating user widgets as additive overlay.
+  for (const out of getCustomCommandsForLine(ctx.customCommands, 1)) {
+    const text = renderCustomCommand(out, c);
+    if (text) {
+      segments.push({ text, bg: palette.dirBg, fg: palette.fg, priority: 15 });
+    }
+  }
+
   return segments;
 }
 
@@ -216,7 +228,11 @@ export function renderPowerlineLine1(ctx: RenderContext, mode: ColorMode, theme:
   const styleName = (ctx.config.powerline?.style ?? 'auto') as PowerlineStyleName;
   const hasNerdFont = (ctx.config.icons ?? 'nerd') === 'nerd';
   const style = resolveStyle(styleName, hasNerdFont);
-  const segments = buildSegments(ctx, palette);
+  // Custom command segments need a Colors instance to apply inline fg styling
+  // inside the segment text (mirroring how pace/quota colour their bodies).
+  // Built with the same (mode, theme) the dispatcher uses for classic mode.
+  const c = createColors(mode, theme);
+  const segments = buildSegments(ctx, palette, c);
   if (segments.length === 0) return '';
   return renderPowerline(segments, style, mode, ctx.cols);
 }

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -5,7 +5,7 @@ import {
   type PowerlineStyleName,
 } from './powerline.js';
 import { QUOTA_CRITICAL } from '../types.js';
-import { buildContextBar, formatQwenMetrics } from './shared.js';
+import { buildContextBar, formatQwenMetrics, getCustomCommandsForLine, renderCustomCommand } from './shared.js';
 import { formatTokens, formatCost, formatBurnRate } from '../utils/format.js';
 import { detectColorMode, getCacheHitTier, getApiLatencyTier, getPaceColor, type ColorMode, type Colors } from './colors.js';
 import { computeApiLatency, formatApiLatency } from './api-latency.js';
@@ -261,6 +261,16 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
     for (const h of hints) {
       const prefix = h.severity === 'warn' ? '⚠ ' : 'ℹ ';
       segments.push({ text: `${prefix}${h.hint}`, bg: palette.versionBg, fg: palette.fg, priority: 10 });
+    }
+  }
+
+  // Custom commands (issue #143 phase 3) — neutral dirBg, priority 15 so user
+  // widgets evict before lumira's own line2 metrics. Inline fg color/dim from
+  // renderCustomCommand renders on top of the segment bg.
+  for (const out of getCustomCommandsForLine(ctx.customCommands, 2)) {
+    const text = renderCustomCommand(out, c);
+    if (text) {
+      segments.push({ text, bg: palette.dirBg, fg: palette.fg, priority: 15 });
     }
   }
 

--- a/src/render/powerline-line3.ts
+++ b/src/render/powerline-line3.ts
@@ -5,8 +5,8 @@ import {
   type PowerlineStyleName,
 } from './powerline.js';
 import { truncField } from './text.js';
-import { EXCLUDED_TOOLS } from './shared.js';
-import type { ColorMode } from './colors.js';
+import { EXCLUDED_TOOLS, getCustomCommandsForLine, renderCustomCommand } from './shared.js';
+import { createColors, type ColorMode } from './colors.js';
 import type { RenderContext, ToolEntry } from '../types.js';
 import {
   type PowerlinePalette,
@@ -15,7 +15,7 @@ import {
   type ThemePalette,
 } from '../themes.js';
 
-function buildSegments(ctx: RenderContext, palette: PowerlinePalette): PowerlineSegment[] {
+function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: import('./colors.js').Colors): PowerlineSegment[] {
   const { transcript: { tools, todos }, config: { display }, icons } = ctx;
   const segments: PowerlineSegment[] = [];
 
@@ -74,6 +74,15 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette): Powerline
     segments.push({ text: label, bg: palette.branchCleanBg, fg: palette.fg, priority: 80 });
   }
 
+  // Custom commands (issue #143 phase 3) — neutral dirBg, lowest priority so
+  // they evict before tools/agents/todos when line3 is space-constrained.
+  for (const out of getCustomCommandsForLine(ctx.customCommands, 3)) {
+    const text = renderCustomCommand(out, c);
+    if (text) {
+      segments.push({ text, bg: palette.dirBg, fg: palette.fg, priority: 15 });
+    }
+  }
+
   return segments;
 }
 
@@ -85,7 +94,10 @@ export function renderPowerlineLine3(ctx: RenderContext, mode: ColorMode, theme:
   const styleName = (ctx.config.powerline?.style ?? 'auto') as PowerlineStyleName;
   const hasNerdFont = (ctx.config.icons ?? 'nerd') === 'nerd';
   const style = resolveStyle(styleName, hasNerdFont);
-  const segments = buildSegments(ctx, palette);
+  // Colors instance for custom-command inline styling — consistent with the
+  // (mode, theme) the renderer dispatcher uses for the classic path.
+  const c = createColors(mode, theme);
+  const segments = buildSegments(ctx, palette, c);
   if (segments.length === 0) return '';
   return renderPowerline(segments, style, mode, ctx.cols);
 }

--- a/src/render/shared.ts
+++ b/src/render/shared.ts
@@ -1,8 +1,9 @@
 import { NERD_ICONS, type IconSet } from './icons.js';
-import { getContextColor, type Colors } from './colors.js';
+import { getContextColor, stripAnsi, type Colors } from './colors.js';
 import { formatTokens } from '../utils/format.js';
 import { DEFAULT_CONTEXT_WARNING_THRESHOLD, DEFAULT_CONTEXT_CRITICAL_THRESHOLD, type GitStatus, type TranscriptData } from '../types.js';
 import type { NormalizedInput } from '../normalize.js';
+import type { CustomCommandOutput } from '../parsers/custom-commands.js';
 
 export const SEP = ` \x1b[90m\u2502\x1b[0m `;
 export const SEP_MINIMAL = ` \x1b[90m|\x1b[0m `;
@@ -116,6 +117,67 @@ export function formatGitChanges(git: GitStatus, c: Colors): string[] {
   if (git.modified > 0) parts.push(c.yellow(`!${git.modified}`));
   if (git.untracked > 0) parts.push(c.gray(`?${git.untracked}`));
   return parts;
+}
+
+/**
+ * Filter custom command outputs to those that should render on the given line.
+ * Hidden-state outputs are dropped — they exist in the parser result so the
+ * caller has full visibility, but renderers MUST treat them as if they were
+ * absent. `undefined` ctx input is normalized to an empty array so test
+ * fixtures without customCommands continue to work.
+ */
+export function getCustomCommandsForLine(
+  outputs: CustomCommandOutput[] | undefined,
+  line: 1 | 2 | 3 | 4,
+): CustomCommandOutput[] {
+  if (!outputs) return [];
+  return outputs.filter(o => o.line === line && o.state !== 'hidden');
+}
+
+/**
+ * Render a single CustomCommandOutput into a styled segment string.
+ *
+ * - `hidden`           → '' (caller should also have filtered via
+ *                        getCustomCommandsForLine, but defensive empty here).
+ * - `ansi: false`      → ANSI sequences are stripped from the raw text and the
+ *                        configured `color` is applied. Default.
+ * - `ansi: true`       → user-supplied ANSI is passed through verbatim;
+ *                        `color` is intentionally NOT applied (we'd be
+ *                        layering escapes over the user's existing ones).
+ * - `state: 'stale'`   → entire rendered output is dimmed *after* any color
+ *                        is applied. Mirrors the parser contract: stale means
+ *                        a refresh is in flight and the value displayed may
+ *                        be one tick old.
+ * - `label`            → prepended with a single-space separator. Useful for
+ *                        glyph prefixes (e.g. " " or "[ci]").
+ *
+ * Defensive about the color attr: when the parser emits an unrecognised value
+ * (shouldn't happen given config validation, but the type isn't load-bearing
+ * enough to assert at runtime), we fall through to no color rather than
+ * throwing — the renderer must never crash on user data.
+ */
+export function renderCustomCommand(output: CustomCommandOutput, c: Colors): string {
+  if (output.state === 'hidden') return '';
+
+  // Strip ANSI from user output unless explicitly opted in. Stripping happens
+  // *before* label concatenation so the label can't end up sandwiched inside
+  // an unclosed escape sequence.
+  let text = output.ansi ? output.text : stripAnsi(output.text);
+  if (output.label) text = `${output.label} ${text}`;
+
+  // Color is only applied when ansi=false; otherwise we'd be wrapping the
+  // user's escapes in another escape, which most terminals render as garbage.
+  let result = text;
+  if (!output.ansi && output.color) {
+    const fn = (c as unknown as Record<string, (s: string) => string>)[output.color];
+    if (typeof fn === 'function') result = fn(text);
+  }
+
+  // Stale dimming is the last transform — it must wrap the colored result so
+  // the "in-flight refresh" signal is visible regardless of the base color.
+  if (output.state === 'stale') result = c.dim(result);
+
+  return result;
 }
 
 export function formatQwenMetrics(n: NormalizedInput, c: Colors, icons: IconSet): string[] {

--- a/src/render/shared.ts
+++ b/src/render/shared.ts
@@ -1,7 +1,7 @@
 import { NERD_ICONS, type IconSet } from './icons.js';
 import { getContextColor, stripAnsi, type Colors } from './colors.js';
 import { formatTokens } from '../utils/format.js';
-import { DEFAULT_CONTEXT_WARNING_THRESHOLD, DEFAULT_CONTEXT_CRITICAL_THRESHOLD, type GitStatus, type TranscriptData } from '../types.js';
+import { DEFAULT_CONTEXT_WARNING_THRESHOLD, DEFAULT_CONTEXT_CRITICAL_THRESHOLD, type GitStatus, type TranscriptData, type CustomCommand } from '../types.js';
 import type { NormalizedInput } from '../normalize.js';
 import type { CustomCommandOutput } from '../parsers/custom-commands.js';
 
@@ -169,7 +169,11 @@ export function renderCustomCommand(output: CustomCommandOutput, c: Colors): str
   // user's escapes in another escape, which most terminals render as garbage.
   let result = text;
   if (!output.ansi && output.color) {
-    const fn = (c as unknown as Record<string, (s: string) => string>)[output.color];
+    const colorMap: Record<NonNullable<CustomCommand['color']>, (s: string) => string> = {
+      dim: c.dim, green: c.green, yellow: c.yellow, orange: c.orange,
+      red: c.red, cyan: c.cyan, magenta: c.magenta,
+    };
+    const fn = colorMap[output.color];
     if (typeof fn === 'function') result = fn(text);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -473,3 +473,20 @@ export interface QwenInput {
 
 /** Union of all supported platform input types */
 export type RawInput = ClaudeCodeInput | QwenInput;
+
+/**
+ * Spec sent to the detached refresh helper (src/commands/custom-refresh.ts).
+ * Shared between the parser (which builds and sends it) and the helper (which
+ * receives and validates it).
+ */
+export interface RefreshSpec {
+  id: string;
+  command: string[];
+  timeoutMs: number;
+  maxBytes: number;
+  env?: Record<string, string>;
+  cwd?: string;
+  onError: OnErrorBehavior;
+  cachePath: string;
+  stdin?: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -242,6 +242,10 @@ export const CUSTOM_COMMAND_MAX_BYTES = 4096;
 export const CUSTOM_COMMAND_MAX_ENV_ENTRIES = 32;
 /** Lower bound on refresh interval (ms) to prevent thrashing the renderer. */
 export const CUSTOM_COMMAND_MIN_REFRESH_MS = 500;
+/** Upper bound on refresh interval (ms) — 24h. Anything larger is almost
+ * certainly a typo (e.g. "5000000" meant "5000"). Clamping prevents an
+ * effectively-once-per-process command from being accidentally configured. */
+export const CUSTOM_COMMAND_MAX_REFRESH_MS = 86_400_000;
 
 /** Valid `line` values for CustomCommand. */
 export const CUSTOM_COMMAND_VALID_LINES = [1, 2, 3, 4] as const;

--- a/src/types.ts
+++ b/src/types.ts
@@ -150,6 +150,13 @@ export interface RenderContext {
   cols: number;
   config: HudConfig;
   icons: import('./render/icons.js').IconSet;
+  /**
+   * Custom command outputs from the Phase 2 parser (issue #143). Optional for
+   * backward compat with test fixtures that don't construct it — renderers
+   * MUST treat `undefined` as an empty array. Each output already carries its
+   * own `line` + render metadata; per-line filtering happens at render time.
+   */
+  customCommands?: import('./parsers/custom-commands.js').CustomCommandOutput[];
 }
 
 // ── Config ──────────────────────────────────────────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -179,7 +179,78 @@ export interface HudConfig {
     /** Separator glyph preset. Defaults to 'auto' (nerd font → arrow, else compatible). */
     style?: PowerlineStyleName;
   };
+  /**
+   * Custom Command widget (issue #143). Allows users to embed the output of
+   * arbitrary commands in the statusline. Security gate: `enabled` defaults
+   * to `false` and the renderer must short-circuit on `enabled: false` so an
+   * accidentally-shipped command never executes without explicit opt-in.
+   */
+  customCommands: CustomCommandsConfig;
 }
+
+// ── Custom Command widget (issue #143) ─────────────────────────────
+
+/**
+ * Behavior when a custom command errors or times out.
+ *   hide        → render nothing
+ *   placeholder → render a static placeholder glyph
+ *   output      → render last known output (if any), otherwise hide
+ *   stale       → keep the previous successful output until the next refresh
+ */
+export type OnErrorBehavior = 'hide' | 'placeholder' | 'output' | 'stale';
+
+export interface CustomCommand {
+  /** Unique id within the customCommands.commands array. Duplicates are dropped. */
+  id: string;
+  /** argv form (no shell strings). First element is the executable, rest are args. */
+  command: string[];
+  /** Optional prefix glyph or text rendered before the command output. */
+  label?: string;
+  /** Which statusline line to render on (1–4). */
+  line: 1 | 2 | 3 | 4;
+  /** Cache TTL — how often to re-run. Clamped to >= CUSTOM_COMMAND_MIN_REFRESH_MS. Default 5000. */
+  refreshMs: number;
+  /** Max wall time before the command is killed. Clamped to [100, CUSTOM_COMMAND_MAX_TIMEOUT_MS]. Default 1500. */
+  timeoutMs: number;
+  /** Stdout cap. Clamped to [16, CUSTOM_COMMAND_MAX_BYTES]. Default 256. */
+  maxBytes: number;
+  /** Optional env vars. Truncated to CUSTOM_COMMAND_MAX_ENV_ENTRIES. */
+  env?: Record<string, string>;
+  /** Optional cwd override. Defaults to lumira's cwd. */
+  cwd?: string;
+  /** Behavior on non-zero exit / spawn error. Default 'hide'. */
+  onError: OnErrorBehavior;
+  /** Behavior on wall-time timeout. Default 'stale'. */
+  onTimeout: OnErrorBehavior;
+  /** Pass through ANSI escapes in stdout? Default false (strip + optionally apply `color`). */
+  ansi: boolean;
+  /** Optional color applied only when ansi is false. */
+  color?: 'dim' | 'green' | 'yellow' | 'orange' | 'red' | 'cyan' | 'magenta';
+}
+
+export interface CustomCommandsConfig {
+  /** Security gate — must be true (explicitly opted in) before any command runs. */
+  enabled: boolean;
+  commands: CustomCommand[];
+}
+
+/** Hard cap on per-command wall time (ms). */
+export const CUSTOM_COMMAND_MAX_TIMEOUT_MS = 2000;
+/** Hard cap on captured stdout (bytes). */
+export const CUSTOM_COMMAND_MAX_BYTES = 4096;
+/** Hard cap on env vars passed to a command. */
+export const CUSTOM_COMMAND_MAX_ENV_ENTRIES = 32;
+/** Lower bound on refresh interval (ms) to prevent thrashing the renderer. */
+export const CUSTOM_COMMAND_MIN_REFRESH_MS = 500;
+
+/** Valid `line` values for CustomCommand. */
+export const CUSTOM_COMMAND_VALID_LINES = [1, 2, 3, 4] as const;
+
+/** Valid `onError` / `onTimeout` values. */
+export const CUSTOM_COMMAND_ERROR_BEHAVIORS = ['hide', 'placeholder', 'output', 'stale'] as const;
+
+/** Valid `color` values for CustomCommand. */
+export const CUSTOM_COMMAND_COLORS = ['dim', 'green', 'yellow', 'orange', 'red', 'cyan', 'magenta'] as const;
 
 /**
  * Single source of truth for valid powerline style names. Imported by
@@ -321,6 +392,7 @@ export const DEFAULT_CONFIG: HudConfig = {
   gsd: false,
   display: { ...DEFAULT_DISPLAY },
   colors: { mode: 'auto' },
+  customCommands: { enabled: false, commands: [] },
 };
 
 // ── Dependency injection ────────────────────────────────────────────

--- a/src/utils/custom-cache.ts
+++ b/src/utils/custom-cache.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared cache IO for the Custom Command widget (issue #143).
+ *
+ * Both the parser (src/parsers/custom-commands.ts, read-only) and the
+ * refresh helper (src/commands/custom-refresh.ts, read+write) used to
+ * duplicate these types and functions verbatim. This module is the single
+ * source of truth.
+ */
+
+import { lstatSync, readFileSync, mkdirSync, openSync, writeSync, closeSync, renameSync, unlinkSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { randomBytes } from 'node:crypto';
+
+export interface CacheEntry {
+  text: string;
+  capturedAt: number;
+  state: 'ok' | 'nonzero' | 'timeout';
+}
+
+export type CacheMap = Record<string, CacheEntry>;
+
+/**
+ * Symlink-safe cache read. Returns an empty map when the file is missing,
+ * is a symlink (security guard), or contains malformed JSON.
+ */
+export function readCacheFile(path: string): CacheMap {
+  try {
+    // Symlink-safe: lstat first and refuse to read if the cache path itself
+    // is a symlink. Otherwise an attacker who can write into the cache dir
+    // could redirect our read to a file they control, then watch the cache
+    // contents leak into the rendered statusline.
+    try {
+      const st = lstatSync(path);
+      if (st.isSymbolicLink()) return {};
+    } catch {
+      // File does not exist (or stat failed) — fall through; readFileSync
+      // below will return an empty cache via its catch block.
+    }
+    const raw = readFileSync(path, 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const out: CacheMap = {};
+    for (const [id, entry] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+      const e = entry as Record<string, unknown>;
+      if (typeof e.text !== 'string') continue;
+      if (typeof e.capturedAt !== 'number' || !Number.isFinite(e.capturedAt)) continue;
+      const s = e.state;
+      if (s !== 'ok' && s !== 'nonzero' && s !== 'timeout') continue;
+      out[id] = { text: e.text, capturedAt: e.capturedAt, state: s };
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/** Atomic cache write with random temp-file name. */
+export function writeCacheFile(path: string, data: CacheMap): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    const tmp = `${path}.${randomBytes(8).toString('hex')}.tmp`;
+    try { unlinkSync(tmp); } catch { /* not present */ }
+    const fd = openSync(tmp, 'wx', 0o600);
+    try {
+      writeSync(fd, JSON.stringify(data));
+    } finally {
+      closeSync(fd);
+    }
+    renameSync(tmp, path);
+  } catch {
+    /* cache write best-effort */
+  }
+}

--- a/src/utils/exec-bg.ts
+++ b/src/utils/exec-bg.ts
@@ -1,0 +1,203 @@
+import { spawn } from 'node:child_process';
+
+/**
+ * Background command execution helper for the Custom Command widget (#143).
+ *
+ * Design constraints:
+ * - `child_process.spawn` only (no shell strings) — argv form prevents shell
+ *   injection at the lumira boundary.
+ * - `detached: true` so we own a process group and can `process.kill(-pid, ...)`
+ *   on timeout / byte cap — kills any grandchildren the command spawned.
+ * - Curated minimum env by default; user env merges on top. Prevents leaking
+ *   arbitrary parent vars (NODE_OPTIONS, AWS_*, etc.) into user commands.
+ * - Stdout streaming with hard byte cap; the moment we cross `maxBytes` we
+ *   group-kill so a runaway `cat /dev/urandom` doesn't OOM the renderer.
+ * - Never throws. The renderer must NEVER crash because a user command did.
+ */
+
+export interface ExecBgInput {
+  /** argv form, length >= 1. command[0] = executable, rest = args. */
+  command: string[];
+  /** ms wall-clock cap (already clamped by config layer to <= 2000). */
+  timeoutMs: number;
+  /** stdout byte cap (already clamped by config layer to <= 4096). */
+  maxBytes: number;
+  /** Optional env merged on top of the curated minimum. */
+  env?: Record<string, string>;
+  /** Optional cwd; defaults to process.cwd(). */
+  cwd?: string;
+  /** Optional stdin string (lumira JSON envelope, etc.). */
+  stdin?: string;
+}
+
+export type ExecBgResult =
+  | { kind: 'ok'; stdout: string; truncated: boolean; exitCode: 0; durationMs: number }
+  | { kind: 'nonzero'; stdout: string; stderr: string; exitCode: number; durationMs: number }
+  | { kind: 'timeout'; stdout: string; durationMs: number }
+  | { kind: 'spawn-error'; message: string; durationMs: number };
+
+/** Pass-through env keys that should remain available to user commands. */
+const CURATED_ENV_KEYS = ['PATH', 'HOME', 'USER', 'LANG', 'LC_ALL', 'TZ', 'TERM'] as const;
+
+/** Grace window between SIGTERM and SIGKILL when force-killing on timeout. */
+const SIGKILL_GRACE_MS = 200;
+
+/** Max stderr we retain — keep it small; renderer only shows tail. */
+const STDERR_CAP_BYTES = 1024;
+
+function buildEnv(userEnv: Record<string, string> | undefined): NodeJS.ProcessEnv {
+  const out: Record<string, string> = {};
+  for (const key of CURATED_ENV_KEYS) {
+    const v = process.env[key];
+    if (typeof v === 'string') out[key] = v;
+  }
+  if (userEnv) {
+    for (const [k, v] of Object.entries(userEnv)) {
+      if (typeof k === 'string' && k.length > 0 && typeof v === 'string') {
+        out[k] = v;
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Best-effort group kill. We rely on `detached: true` at spawn so the child
+ * leads its own process group; `process.kill(-pid, sig)` then reaches every
+ * descendant. If the negative-pid form fails (process already gone or we're
+ * on a platform that rejects it), fall back to the direct pid as a courtesy.
+ */
+function groupKill(pid: number | undefined, signal: NodeJS.Signals): void {
+  if (typeof pid !== 'number' || !Number.isFinite(pid)) return;
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+export async function execBg(input: ExecBgInput): Promise<ExecBgResult> {
+  const start = Date.now();
+  const elapsed = (): number => Date.now() - start;
+
+  if (!Array.isArray(input.command) || input.command.length === 0) {
+    return { kind: 'spawn-error', message: 'empty command', durationMs: elapsed() };
+  }
+
+  const [cmd, ...args] = input.command;
+  const env = buildEnv(input.env);
+  const cwd = input.cwd ?? process.cwd();
+
+  return new Promise<ExecBgResult>((resolve) => {
+    let settled = false;
+    let stdout = '';
+    let stdoutBytes = 0;
+    let stderr = '';
+    let stderrBytes = 0;
+    let truncated = false;
+    let timedOut = false;
+    let timeoutTimer: NodeJS.Timeout | null = null;
+    let killTimer: NodeJS.Timeout | null = null;
+
+    const settle = (result: ExecBgResult): void => {
+      if (settled) return;
+      settled = true;
+      if (timeoutTimer) { clearTimeout(timeoutTimer); timeoutTimer = null; }
+      if (killTimer) { clearTimeout(killTimer); killTimer = null; }
+      resolve(result);
+    };
+
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(cmd, args, {
+        cwd,
+        env,
+        detached: true,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'spawn failed';
+      settle({ kind: 'spawn-error', message, durationMs: elapsed() });
+      return;
+    }
+
+    // Pipe stdin if provided. Swallow EPIPE — the child may have exited
+    // before consuming everything.
+    if (child.stdin) {
+      child.stdin.on('error', () => { /* EPIPE etc. — ignore */ });
+      if (typeof input.stdin === 'string') {
+        try { child.stdin.write(input.stdin); } catch { /* ignore */ }
+      }
+      try { child.stdin.end(); } catch { /* ignore */ }
+    }
+
+    if (child.stdout) {
+      child.stdout.on('data', (chunk: Buffer) => {
+        if (truncated) return;
+        const remaining = input.maxBytes - stdoutBytes;
+        if (chunk.length <= remaining) {
+          stdout += chunk.toString('utf8');
+          stdoutBytes += chunk.length;
+          if (stdoutBytes >= input.maxBytes) {
+            truncated = true;
+            groupKill(child.pid, 'SIGTERM');
+            killTimer = setTimeout(() => groupKill(child.pid, 'SIGKILL'), SIGKILL_GRACE_MS);
+          }
+        } else {
+          stdout += chunk.slice(0, remaining).toString('utf8');
+          stdoutBytes = input.maxBytes;
+          truncated = true;
+          groupKill(child.pid, 'SIGTERM');
+          killTimer = setTimeout(() => groupKill(child.pid, 'SIGKILL'), SIGKILL_GRACE_MS);
+        }
+      });
+      child.stdout.on('error', () => { /* ignore */ });
+    }
+
+    if (child.stderr) {
+      child.stderr.on('data', (chunk: Buffer) => {
+        if (stderrBytes >= STDERR_CAP_BYTES) return;
+        const remaining = STDERR_CAP_BYTES - stderrBytes;
+        const slice = chunk.length <= remaining ? chunk : chunk.slice(0, remaining);
+        stderr += slice.toString('utf8');
+        stderrBytes += slice.length;
+      });
+      child.stderr.on('error', () => { /* ignore */ });
+    }
+
+    // Wall-clock timeout — group-kill then SIGKILL after grace.
+    timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      groupKill(child.pid, 'SIGTERM');
+      killTimer = setTimeout(() => groupKill(child.pid, 'SIGKILL'), SIGKILL_GRACE_MS);
+    }, input.timeoutMs);
+
+    child.on('error', (err: Error & { code?: string }) => {
+      // Spawn-level failure (ENOENT, EACCES, ...). Only treat as spawn-error
+      // before exit fires; after exit, errors are usually post-close noise.
+      if (settled) return;
+      settle({ kind: 'spawn-error', message: err.message || String(err.code ?? 'spawn error'), durationMs: elapsed() });
+    });
+
+    child.on('close', (code: number | null) => {
+      if (settled) return;
+      if (timedOut) {
+        settle({ kind: 'timeout', stdout, durationMs: elapsed() });
+        return;
+      }
+      if (code === 0) {
+        settle({ kind: 'ok', stdout, truncated, exitCode: 0, durationMs: elapsed() });
+        return;
+      }
+      // Non-zero or killed-by-signal (code === null) → treat as non-zero with
+      // best-effort exit code. -1 signals "killed without numeric exit".
+      const exitCode = typeof code === 'number' ? code : -1;
+      settle({ kind: 'nonzero', stdout, stderr, exitCode, durationMs: elapsed() });
+    });
+  });
+}

--- a/src/utils/exec-bg.ts
+++ b/src/utils/exec-bg.ts
@@ -136,6 +136,15 @@ export async function execBg(input: ExecBgInput): Promise<ExecBgResult> {
       try { child.stdin.end(); } catch { /* ignore */ }
     }
 
+    // Schedule SIGKILL after SIGTERM grace, clearing any previously scheduled
+    // SIGKILL first. Without the clear, a byte-cap kill followed by a wall-time
+    // kill (or vice versa) orphans the earlier timer — the SIGKILL we lose
+    // reference to fires unconditionally and can't be cancelled by settle().
+    const scheduleSigkill = (): void => {
+      if (killTimer) clearTimeout(killTimer);
+      killTimer = setTimeout(() => groupKill(child.pid, 'SIGKILL'), SIGKILL_GRACE_MS);
+    };
+
     if (child.stdout) {
       child.stdout.on('data', (chunk: Buffer) => {
         if (truncated) return;
@@ -146,14 +155,14 @@ export async function execBg(input: ExecBgInput): Promise<ExecBgResult> {
           if (stdoutBytes >= input.maxBytes) {
             truncated = true;
             groupKill(child.pid, 'SIGTERM');
-            killTimer = setTimeout(() => groupKill(child.pid, 'SIGKILL'), SIGKILL_GRACE_MS);
+            scheduleSigkill();
           }
         } else {
           stdout += chunk.slice(0, remaining).toString('utf8');
           stdoutBytes = input.maxBytes;
           truncated = true;
           groupKill(child.pid, 'SIGTERM');
-          killTimer = setTimeout(() => groupKill(child.pid, 'SIGKILL'), SIGKILL_GRACE_MS);
+          scheduleSigkill();
         }
       });
       child.stdout.on('error', () => { /* ignore */ });
@@ -174,7 +183,7 @@ export async function execBg(input: ExecBgInput): Promise<ExecBgResult> {
     timeoutTimer = setTimeout(() => {
       timedOut = true;
       groupKill(child.pid, 'SIGTERM');
-      killTimer = setTimeout(() => groupKill(child.pid, 'SIGKILL'), SIGKILL_GRACE_MS);
+      scheduleSigkill();
     }, input.timeoutMs);
 
     child.on('error', (err: Error & { code?: string }) => {

--- a/tests/commands/custom.test.ts
+++ b/tests/commands/custom.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Tests for `lumira custom` subcommand (issue #143 phase 4).
+ *
+ * Covers:
+ *   - enable / disable: config file read-modify-write
+ *   - enable on missing file: creates default config
+ *   - list: no commands → helpful message; with commands → table
+ *   - test: unknown id → exitCode 1; known id → execBg called, output printed
+ *   - logs: no cache file → message; with entries → formatted output
+ *
+ * All FS access is mocked so tests never touch the real filesystem.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock node modules BEFORE importing the module under test.
+vi.mock('node:fs');
+vi.mock('node:os');
+
+import * as fsMod from 'node:fs';
+import * as osMod from 'node:os';
+
+// We also need to mock execBg — import after vi.mock declarations.
+vi.mock('../../src/utils/exec-bg.js', () => ({
+  execBg: vi.fn(),
+}));
+
+import { execBg } from '../../src/utils/exec-bg.js';
+// @ts-expect-error — module may not exist yet (red phase)
+import { runCustomCommand } from '../../src/commands/custom.js';
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+const HOME = '/home/testuser';
+const CONFIG_PATH = `${HOME}/.config/lumira/config.json`;
+const CACHE_PATH = `${HOME}/.cache/lumira/custom-commands.json`;
+
+const argv = (...rest: string[]) => ['node', 'lumira', 'custom', ...rest];
+
+function makeFs(files: Record<string, string | null>) {
+  const readFileSync = vi.mocked(fsMod.readFileSync);
+  const writeFileSync = vi.mocked(fsMod.writeFileSync);
+  const mkdirSync = vi.mocked(fsMod.mkdirSync);
+  const existsSync = vi.mocked(fsMod.existsSync);
+
+  existsSync.mockImplementation((p: unknown) => {
+    return typeof p === 'string' && p in files && files[p] !== null;
+  });
+
+  readFileSync.mockImplementation((p: unknown, _enc?: unknown) => {
+    if (typeof p !== 'string') throw new Error('ENOENT');
+    if (!(p in files) || files[p] === null) {
+      const e = Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' });
+      throw e;
+    }
+    return files[p] as string;
+  });
+
+  const written: Record<string, string> = {};
+  writeFileSync.mockImplementation((p: unknown, data: unknown) => {
+    if (typeof p === 'string' && typeof data === 'string') {
+      written[p] = data;
+    }
+  });
+
+  mkdirSync.mockImplementation(() => undefined);
+
+  return { readFileSync, writeFileSync, mkdirSync, existsSync, written };
+}
+
+// ── setup ──────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.mocked(osMod.homedir).mockReturnValue(HOME);
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── enable ─────────────────────────────────────────────────────────────────
+
+describe('lumira custom enable', () => {
+  it('sets enabled:true in existing config and prints confirmation', async () => {
+    const existingConfig = JSON.stringify({ customCommands: { enabled: false, commands: [] } });
+    const { written } = makeFs({ [CONFIG_PATH]: existingConfig });
+
+    const result = await runCustomCommand(argv('enable'));
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toMatch(/enabled/i);
+
+    // Written config must have enabled: true
+    const written_config = written[CONFIG_PATH];
+    expect(written_config).toBeDefined();
+    const parsed = JSON.parse(written_config);
+    expect(parsed.customCommands.enabled).toBe(true);
+  });
+
+  it('merges into existing config without destroying other keys', async () => {
+    const existingConfig = JSON.stringify({
+      theme: 'dracula',
+      customCommands: { enabled: false, commands: [{ id: 'foo', command: ['echo', 'hi'], line: 1 }] },
+    });
+    const { written } = makeFs({ [CONFIG_PATH]: existingConfig });
+
+    await runCustomCommand(argv('enable'));
+
+    const parsed = JSON.parse(written[CONFIG_PATH]);
+    expect(parsed.theme).toBe('dracula');
+    expect(parsed.customCommands.enabled).toBe(true);
+    expect(parsed.customCommands.commands).toHaveLength(1);
+  });
+
+  it('creates config file with enabled:true when file does not exist', async () => {
+    const { written } = makeFs({});
+
+    const result = await runCustomCommand(argv('enable'));
+
+    expect(result.exitCode).toBe(0);
+    const written_config = written[CONFIG_PATH];
+    expect(written_config).toBeDefined();
+    const parsed = JSON.parse(written_config);
+    expect(parsed.customCommands.enabled).toBe(true);
+    expect(parsed.customCommands.commands).toEqual([]);
+  });
+
+  it('pretty-prints JSON (indented)', async () => {
+    makeFs({});
+
+    await runCustomCommand(argv('enable'));
+
+    // Cannot inspect written directly without capturing — covered above.
+    // This test verifies the output includes confirmation text.
+    const result = await runCustomCommand(argv('enable'));
+    expect(result.output).toMatch(/custom command/i);
+  });
+});
+
+// ── disable ────────────────────────────────────────────────────────────────
+
+describe('lumira custom disable', () => {
+  it('sets enabled:false in existing config and prints confirmation', async () => {
+    const existingConfig = JSON.stringify({ customCommands: { enabled: true, commands: [] } });
+    const { written } = makeFs({ [CONFIG_PATH]: existingConfig });
+
+    const result = await runCustomCommand(argv('disable'));
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toMatch(/disabled/i);
+
+    const parsed = JSON.parse(written[CONFIG_PATH]);
+    expect(parsed.customCommands.enabled).toBe(false);
+  });
+
+  it('creates config with enabled:false when file does not exist', async () => {
+    const { written } = makeFs({});
+
+    const result = await runCustomCommand(argv('disable'));
+
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(written[CONFIG_PATH]);
+    expect(parsed.customCommands.enabled).toBe(false);
+    expect(parsed.customCommands.commands).toEqual([]);
+  });
+});
+
+// ── list ───────────────────────────────────────────────────────────────────
+
+describe('lumira custom list', () => {
+  it('prints helpful message when no commands are configured', async () => {
+    const configJson = JSON.stringify({ customCommands: { enabled: true, commands: [] } });
+    makeFs({ [CONFIG_PATH]: configJson });
+
+    const result = await runCustomCommand(argv('list'));
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toMatch(/no custom commands/i);
+  });
+
+  it('prints helpful message when config file does not exist', async () => {
+    makeFs({});
+
+    const result = await runCustomCommand(argv('list'));
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toMatch(/no custom commands/i);
+  });
+
+  it('shows enabled status header in output', async () => {
+    const configJson = JSON.stringify({ customCommands: { enabled: true, commands: [] } });
+    makeFs({ [CONFIG_PATH]: configJson });
+
+    const result = await runCustomCommand(argv('list'));
+    expect(result.output).toMatch(/enabled/i);
+  });
+
+  it('shows disabled status header when disabled', async () => {
+    const configJson = JSON.stringify({ customCommands: { enabled: false, commands: [] } });
+    makeFs({ [CONFIG_PATH]: configJson });
+
+    const result = await runCustomCommand(argv('list'));
+    expect(result.output).toMatch(/disabled/i);
+  });
+
+  it('prints table row for each configured command', async () => {
+    const configJson = JSON.stringify({
+      customCommands: {
+        enabled: true,
+        commands: [
+          { id: 'my-cmd', command: ['echo', 'hello'], line: 1, refreshMs: 5000 },
+          { id: 'other-cmd', command: ['date'], line: 2, refreshMs: 10000 },
+        ],
+      },
+    });
+    makeFs({ [CONFIG_PATH]: configJson });
+
+    const result = await runCustomCommand(argv('list'));
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toMatch(/my-cmd/);
+    expect(result.output).toMatch(/other-cmd/);
+    expect(result.output).toMatch(/echo/);
+  });
+});
+
+// ── test ───────────────────────────────────────────────────────────────────
+
+describe('lumira custom test', () => {
+  it('returns exitCode 1 when id is not found', async () => {
+    const configJson = JSON.stringify({ customCommands: { enabled: true, commands: [] } });
+    makeFs({ [CONFIG_PATH]: configJson });
+
+    const result = await runCustomCommand(argv('test', 'nonexistent-id'));
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toMatch(/not found/i);
+  });
+
+  it('returns exitCode 1 when no id argument is provided', async () => {
+    const configJson = JSON.stringify({ customCommands: { enabled: true, commands: [] } });
+    makeFs({ [CONFIG_PATH]: configJson });
+
+    const result = await runCustomCommand(argv('test'));
+
+    expect(result.exitCode).toBe(1);
+  });
+
+  it('calls execBg and prints output + timing when id is found', async () => {
+    const configJson = JSON.stringify({
+      customCommands: {
+        enabled: true,
+        commands: [
+          { id: 'greet', command: ['echo', 'hello'], line: 1, refreshMs: 5000 },
+        ],
+      },
+    });
+    makeFs({ [CONFIG_PATH]: configJson });
+
+    vi.mocked(execBg).mockResolvedValueOnce({
+      kind: 'ok',
+      stdout: 'hello\n',
+      truncated: false,
+      exitCode: 0,
+      durationMs: 42,
+    });
+
+    const result = await runCustomCommand(argv('test', 'greet'));
+
+    expect(result.exitCode).toBe(0);
+    expect(vi.mocked(execBg)).toHaveBeenCalledOnce();
+    expect(result.output).toMatch(/hello/);
+    expect(result.output).toMatch(/42/); // duration
+  });
+
+  it('prints error details when execBg returns non-zero', async () => {
+    const configJson = JSON.stringify({
+      customCommands: {
+        enabled: true,
+        commands: [
+          { id: 'failing', command: ['false'], line: 1, refreshMs: 5000 },
+        ],
+      },
+    });
+    makeFs({ [CONFIG_PATH]: configJson });
+
+    vi.mocked(execBg).mockResolvedValueOnce({
+      kind: 'nonzero',
+      stdout: '',
+      stderr: 'command failed',
+      exitCode: 1,
+      durationMs: 10,
+    });
+
+    const result = await runCustomCommand(argv('test', 'failing'));
+
+    // Non-zero exit from user command — lumira reports it but exitCode is 0
+    // (we successfully ran the test, the user cmd just failed)
+    expect(result.output).toMatch(/nonzero|exit|failed/i);
+  });
+});
+
+// ── logs ───────────────────────────────────────────────────────────────────
+
+describe('lumira custom logs', () => {
+  it('prints message when cache file does not exist', async () => {
+    makeFs({});
+
+    const result = await runCustomCommand(argv('logs'));
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toMatch(/no cache|not found|cache.*does not/i);
+  });
+
+  it('formats cache entries with id, state, capturedAt, and text', async () => {
+    const cacheData = JSON.stringify({
+      'my-widget': {
+        text: 'hello world',
+        capturedAt: 1716500000000,
+        state: 'ok',
+      },
+    });
+    makeFs({ [CACHE_PATH]: cacheData });
+
+    const result = await runCustomCommand(argv('logs'));
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toMatch(/my-widget/);
+    expect(result.output).toMatch(/hello world/);
+    expect(result.output).toMatch(/ok/);
+  });
+
+  it('truncates long text to 100 chars in logs output', async () => {
+    const longText = 'A'.repeat(200);
+    const cacheData = JSON.stringify({
+      'verbose-cmd': {
+        text: longText,
+        capturedAt: 1716500000000,
+        state: 'ok',
+      },
+    });
+    makeFs({ [CACHE_PATH]: cacheData });
+
+    const result = await runCustomCommand(argv('logs'));
+
+    expect(result.exitCode).toBe(0);
+    // Full 200-char text should NOT appear; truncated version (100 chars) should
+    expect(result.output).not.toContain(longText);
+    expect(result.output).toContain('A'.repeat(100));
+  });
+
+  it('shows multiple cache entries', async () => {
+    const cacheData = JSON.stringify({
+      'cmd-a': { text: 'output-a', capturedAt: 1716500000000, state: 'ok' },
+      'cmd-b': { text: 'output-b', capturedAt: 1716500001000, state: 'nonzero' },
+    });
+    makeFs({ [CACHE_PATH]: cacheData });
+
+    const result = await runCustomCommand(argv('logs'));
+
+    expect(result.output).toMatch(/cmd-a/);
+    expect(result.output).toMatch(/cmd-b/);
+    expect(result.output).toMatch(/output-a/);
+    expect(result.output).toMatch(/output-b/);
+  });
+});
+
+// ── unknown subcommand ─────────────────────────────────────────────────────
+
+describe('lumira custom unknown subcommand', () => {
+  it('prints help/usage and returns exitCode 1 for unknown subcommand', async () => {
+    makeFs({});
+
+    const result = await runCustomCommand(argv('frobnicate'));
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toMatch(/usage|unknown|help/i);
+  });
+
+  it('prints usage when no subcommand is given', async () => {
+    makeFs({});
+
+    const result = await runCustomCommand(argv());
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toMatch(/usage|help|list|enable|disable/i);
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -219,6 +219,160 @@ describe('loadConfig', () => {
       expect(c.display.contextCriticalThreshold).toBe(78);
     });
   });
+
+  // Issue #143 phase 1 — Custom Command widget config schema. Validates
+  // user-supplied commands at load time, drops invalid entries silently
+  // (same pattern as other config sections), clamps numeric fields, and
+  // gates the whole feature behind `enabled: false` by default.
+  describe('customCommands', () => {
+    it('defaults to { enabled: false, commands: [] } when omitted', () => {
+      expect(loadConfig(join(dir, 'nope')).customCommands).toEqual({ enabled: false, commands: [] });
+    });
+
+    it('parses a fully-specified command with all defaults applied to omitted fields', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: {
+          enabled: true,
+          commands: [
+            { id: 'k8s', command: ['kubectl', 'config', 'current-context'], line: 2 },
+          ],
+        },
+      }));
+      const c = loadConfig(dir);
+      expect(c.customCommands.enabled).toBe(true);
+      expect(c.customCommands.commands).toHaveLength(1);
+      const cmd = c.customCommands.commands[0];
+      expect(cmd.id).toBe('k8s');
+      expect(cmd.command).toEqual(['kubectl', 'config', 'current-context']);
+      expect(cmd.line).toBe(2);
+      // Defaults
+      expect(cmd.refreshMs).toBe(5000);
+      expect(cmd.timeoutMs).toBe(1500);
+      expect(cmd.maxBytes).toBe(256);
+      expect(cmd.onError).toBe('hide');
+      expect(cmd.onTimeout).toBe('stale');
+      expect(cmd.ansi).toBe(false);
+      expect(cmd.label).toBeUndefined();
+      expect(cmd.env).toBeUndefined();
+      expect(cmd.cwd).toBeUndefined();
+      expect(cmd.color).toBeUndefined();
+    });
+
+    it('clamps timeoutMs above 2000 to 2000', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [{ id: 'a', command: ['echo'], line: 1, timeoutMs: 5000 }] },
+      }));
+      expect(loadConfig(dir).customCommands.commands[0].timeoutMs).toBe(2000);
+    });
+
+    it('clamps maxBytes above 4096 to 4096', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [{ id: 'a', command: ['echo'], line: 1, maxBytes: 100000 }] },
+      }));
+      expect(loadConfig(dir).customCommands.commands[0].maxBytes).toBe(4096);
+    });
+
+    it('clamps refreshMs below 500 to 500', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [{ id: 'a', command: ['echo'], line: 1, refreshMs: 100 }] },
+      }));
+      expect(loadConfig(dir).customCommands.commands[0].refreshMs).toBe(500);
+    });
+
+    it('truncates env to 32 entries', () => {
+      mkdirSync(dir, { recursive: true });
+      const env: Record<string, string> = {};
+      for (let i = 0; i < 50; i++) env[`KEY_${i}`] = `v${i}`;
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [{ id: 'a', command: ['echo'], line: 1, env }] },
+      }));
+      const cmd = loadConfig(dir).customCommands.commands[0];
+      expect(Object.keys(cmd.env ?? {}).length).toBe(32);
+    });
+
+    it('drops command with empty command array', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [{ id: 'a', command: [], line: 1 }] },
+      }));
+      expect(loadConfig(dir).customCommands.commands).toEqual([]);
+    });
+
+    it('allows command: ["sh", "-c", "ls"] (we do not ban shell wrappers)', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [{ id: 'shellish', command: ['sh', '-c', 'ls'], line: 1 }] },
+      }));
+      const cmds = loadConfig(dir).customCommands.commands;
+      expect(cmds).toHaveLength(1);
+      expect(cmds[0].command).toEqual(['sh', '-c', 'ls']);
+    });
+
+    it('rejects command as a single string (must be array)', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [{ id: 'a', command: 'ls', line: 1 }] },
+      }));
+      expect(loadConfig(dir).customCommands.commands).toEqual([]);
+    });
+
+    it('drops duplicate id (second wins-policy = keep first, drop later duplicates)', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [
+          { id: 'dup', command: ['echo', 'one'], line: 1 },
+          { id: 'dup', command: ['echo', 'two'], line: 2 },
+        ] },
+      }));
+      const cmds = loadConfig(dir).customCommands.commands;
+      expect(cmds).toHaveLength(1);
+      expect(cmds[0].command).toEqual(['echo', 'one']);
+    });
+
+    it('accepts enabled: true with empty commands array', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [] },
+      }));
+      expect(loadConfig(dir).customCommands).toEqual({ enabled: true, commands: [] });
+    });
+
+    it('defaults enabled to false when omitted', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { commands: [{ id: 'a', command: ['echo'], line: 1 }] },
+      }));
+      expect(loadConfig(dir).customCommands.enabled).toBe(false);
+    });
+
+    it('falls back to onError default ("hide") when value is invalid', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [{ id: 'a', command: ['echo'], line: 1, onError: 'explode' }] },
+      }));
+      expect(loadConfig(dir).customCommands.commands[0].onError).toBe('hide');
+    });
+
+    it('drops command with invalid line value (e.g. 5)', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [{ id: 'a', command: ['echo'], line: 5 }] },
+      }));
+      expect(loadConfig(dir).customCommands.commands).toEqual([]);
+    });
+
+    it('drops command with non-numeric line value', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [{ id: 'a', command: ['echo'], line: 'a' }] },
+      }));
+      expect(loadConfig(dir).customCommands.commands).toEqual([]);
+    });
+  });
 });
 
 describe('mergeCliFlags', () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -372,6 +372,77 @@ describe('loadConfig', () => {
       }));
       expect(loadConfig(dir).customCommands.commands).toEqual([]);
     });
+
+    // I5: cwd must be absolute. Relative paths like '../../etc' would silently
+    // escape the renderer's cwd to attacker-controlled locations.
+    it('drops cwd when not an absolute path (relative paths rejected)', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [{ id: 'rel', command: ['echo'], line: 1, cwd: '../../etc' }] },
+      }));
+      expect(loadConfig(dir).customCommands.commands[0].cwd).toBeUndefined();
+    });
+
+    it('accepts cwd when absolute', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [{ id: 'abs', command: ['echo'], line: 1, cwd: '/tmp' }] },
+      }));
+      expect(loadConfig(dir).customCommands.commands[0].cwd).toBe('/tmp');
+    });
+
+    // I6: refreshMs has an upper bound now (24h). Larger values clamp.
+    it('clamps refreshMs above 86_400_000 (24h) down to 86_400_000', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [{ id: 'a', command: ['echo'], line: 1, refreshMs: 100_000_000 }] },
+      }));
+      expect(loadConfig(dir).customCommands.commands[0].refreshMs).toBe(86_400_000);
+    });
+
+    // I7: reject ids containing path separators (slash/backslash).
+    it('drops command with id containing slash', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [{ id: 'bad/id', command: ['echo'], line: 1 }] },
+      }));
+      expect(loadConfig(dir).customCommands.commands).toEqual([]);
+    });
+
+    it('drops command with id containing backslash', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [{ id: 'bad\\id', command: ['echo'], line: 1 }] },
+      }));
+      expect(loadConfig(dir).customCommands.commands).toEqual([]);
+    });
+
+    // I7: reject reserved Object.prototype-shadowing ids.
+    it('drops command with id === "__proto__" (prototype pollution guard)', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [{ id: '__proto__', command: ['echo'], line: 1 }] },
+      }));
+      expect(loadConfig(dir).customCommands.commands).toEqual([]);
+    });
+
+    it('drops command with id === "constructor"', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [{ id: 'constructor', command: ['echo'], line: 1 }] },
+      }));
+      expect(loadConfig(dir).customCommands.commands).toEqual([]);
+    });
+
+    // I8: cast-after-guard means malformed (non-string) onError doesn't sneak
+    // through. The guard now also rejects non-string values cleanly.
+    it('falls back to onError default when value is not a string', () => {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({
+        customCommands: { enabled: true, commands: [{ id: 'a', command: ['echo'], line: 1, onError: 42 }] },
+      }));
+      expect(loadConfig(dir).customCommands.commands[0].onError).toBe('hide');
+    });
   });
 });
 

--- a/tests/parsers/custom-commands.test.ts
+++ b/tests/parsers/custom-commands.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync, chmodSync, existsSync, readFileSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { getCustomCommandOutputs } from '../../src/parsers/custom-commands.js';
+import {
+  getCustomCommandOutputs,
+  _setRefreshStrategy,
+  _resetRefreshState,
+} from '../../src/parsers/custom-commands.js';
+import { runCustomRefresh } from '../../src/commands/custom-refresh.js';
 import type { CustomCommand, CustomCommandsConfig } from '../../src/types.js';
 
 const FIXED_NOW = 1_700_000_000_000;
@@ -40,13 +45,36 @@ describe('getCustomCommandOutputs', () => {
   let cachePath: string;
   let configPath: string;
 
+  // Track in-flight in-process refreshes so tests can wait on them. The
+  // production strategy spawns a detached child process, which is great for
+  // the renderer's exit time but lousy for deterministic test assertions —
+  // we swap in an in-process strategy that drives runCustomRefresh directly
+  // and records the resulting Promise so tests can await completion.
+  const pendingRefreshes: Promise<void>[] = [];
+
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'lumira-custom-cmds-'));
     cachePath = join(dir, 'custom-commands.json');
     configPath = join(dir, 'config.json');
     writeFileSync(configPath, '{}', { mode: 0o600 });
+
+    // I4: reset module-level state so tests don't leak refresh-in-flight
+    // markers between cases.
+    _resetRefreshState();
+    pendingRefreshes.length = 0;
+
+    _setRefreshStrategy((spec) => {
+      // Serialize the spec exactly like the production strategy would, then
+      // hand it to runCustomRefresh in-process. We don't await here (caller
+      // is fire-and-forget) but we DO record the promise so tests that
+      // care about completion can await it.
+      const p = runCustomRefresh(JSON.stringify(spec)).catch(() => {});
+      pendingRefreshes.push(p);
+    });
   });
-  afterEach(() => {
+  afterEach(async () => {
+    await Promise.all(pendingRefreshes).catch(() => {});
+    _setRefreshStrategy(undefined);
     rmSync(dir, { recursive: true, force: true });
   });
 

--- a/tests/parsers/custom-commands.test.ts
+++ b/tests/parsers/custom-commands.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, chmodSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { getCustomCommandOutputs } from '../../src/parsers/custom-commands.js';
+import type { CustomCommand, CustomCommandsConfig } from '../../src/types.js';
+
+const FIXED_NOW = 1_700_000_000_000;
+
+function makeCmd(overrides: Partial<CustomCommand> = {}): CustomCommand {
+  return {
+    id: 'test-cmd',
+    command: ['node', '-e', "process.stdout.write('hello')"],
+    line: 1,
+    refreshMs: 5000,
+    timeoutMs: 1500,
+    maxBytes: 256,
+    onError: 'hide',
+    onTimeout: 'stale',
+    ansi: false,
+    ...overrides,
+  };
+}
+
+function makeConfig(commands: CustomCommand[], enabled = true): CustomCommandsConfig {
+  return { enabled, commands };
+}
+
+/** Wait briefly while polling a predicate. Used to wait for fire-and-forget refresh. */
+async function waitFor(pred: () => boolean, timeoutMs = 2500): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (pred()) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+
+describe('getCustomCommandOutputs', () => {
+  let dir: string;
+  let cachePath: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'lumira-custom-cmds-'));
+    cachePath = join(dir, 'custom-commands.json');
+    configPath = join(dir, 'config.json');
+    writeFileSync(configPath, '{}', { mode: 0o600 });
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns [] when disabled (no spawn, no file access)', async () => {
+    const cmd = makeCmd();
+    const result = await getCustomCommandOutputs({
+      config: makeConfig([cmd], false),
+      stdin: '{}',
+      cachePath,
+      configFilePath: configPath,
+      now: FIXED_NOW,
+    });
+    expect(result).toEqual([]);
+    expect(existsSync(cachePath)).toBe(false);
+  });
+
+  it('returns cached entry without spawning when within refreshMs', async () => {
+    const cmd = makeCmd({ refreshMs: 5000 });
+    writeFileSync(cachePath, JSON.stringify({
+      [cmd.id]: { text: 'cached-text', capturedAt: FIXED_NOW - 1000, state: 'ok' },
+    }), { mode: 0o600 });
+
+    const result = await getCustomCommandOutputs({
+      config: makeConfig([cmd]),
+      stdin: '{}',
+      cachePath,
+      configFilePath: configPath,
+      now: FIXED_NOW,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(cmd.id);
+    expect(result[0].text).toBe('cached-text');
+    expect(result[0].state).toBe('ok');
+  }, 5000);
+
+  it('returns stale entry and triggers background refresh when refreshMs exceeded', async () => {
+    const cmd = makeCmd({
+      id: 'refresh-me',
+      command: ['node', '-e', "process.stdout.write('fresh')"],
+      refreshMs: 5000,
+    });
+    writeFileSync(cachePath, JSON.stringify({
+      [cmd.id]: { text: 'old-text', capturedAt: FIXED_NOW - 10_000, state: 'ok' },
+    }), { mode: 0o600 });
+
+    const result = await getCustomCommandOutputs({
+      config: makeConfig([cmd]),
+      stdin: '{}',
+      cachePath,
+      configFilePath: configPath,
+      now: FIXED_NOW,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe('old-text');
+
+    // Wait for fire-and-forget refresh to land on disk.
+    await waitFor(() => {
+      try {
+        const raw = JSON.parse(readFileSync(cachePath, 'utf8'));
+        return raw[cmd.id]?.text === 'fresh';
+      } catch { return false; }
+    });
+    const final = JSON.parse(readFileSync(cachePath, 'utf8'));
+    expect(final[cmd.id].text).toBe('fresh');
+    expect(final[cmd.id].state).toBe('ok');
+  }, 5000);
+
+  it('maps never-ran to placeholder when onError = placeholder', async () => {
+    const cmd = makeCmd({ id: 'no-cache', onError: 'placeholder' });
+    const result = await getCustomCommandOutputs({
+      config: makeConfig([cmd]),
+      stdin: '{}',
+      cachePath,
+      configFilePath: configPath,
+      now: FIXED_NOW,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].state).toBe('error');
+    expect(result[0].text).toBe('?');
+  }, 5000);
+
+  it('maps never-ran to hidden when onError = hide', async () => {
+    const cmd = makeCmd({ id: 'no-cache-hide', onError: 'hide' });
+    const result = await getCustomCommandOutputs({
+      config: makeConfig([cmd]),
+      stdin: '{}',
+      cachePath,
+      configFilePath: configPath,
+      now: FIXED_NOW,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].state).toBe('hidden');
+    expect(result[0].text).toBe('');
+  }, 5000);
+
+  it('returns [] when config file is world-writable', async () => {
+    chmodSync(configPath, 0o666);
+    try {
+      const result = await getCustomCommandOutputs({
+        config: makeConfig([makeCmd()]),
+        stdin: '{}',
+        cachePath,
+        configFilePath: configPath,
+        now: FIXED_NOW,
+      });
+      expect(result).toEqual([]);
+    } finally {
+      chmodSync(configPath, 0o600);
+    }
+  });
+
+  it('respects onTimeout=stale — returns cached text from previous timeout entry', async () => {
+    const cmd = makeCmd({ id: 'timeout-cmd', onTimeout: 'stale', refreshMs: 5000 });
+    writeFileSync(cachePath, JSON.stringify({
+      [cmd.id]: { text: 'last-good', capturedAt: FIXED_NOW - 1000, state: 'timeout' },
+    }), { mode: 0o600 });
+
+    const result = await getCustomCommandOutputs({
+      config: makeConfig([cmd]),
+      stdin: '{}',
+      cachePath,
+      configFilePath: configPath,
+      now: FIXED_NOW,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe('last-good');
+    // state should reflect timeout
+    expect(result[0].state).toBe('timeout');
+  }, 5000);
+
+  it('respects onTimeout=hide on cached timeout entry', async () => {
+    const cmd = makeCmd({ id: 'timeout-hide', onTimeout: 'hide', refreshMs: 5000 });
+    writeFileSync(cachePath, JSON.stringify({
+      [cmd.id]: { text: 'last-good', capturedAt: FIXED_NOW - 1000, state: 'timeout' },
+    }), { mode: 0o600 });
+
+    const result = await getCustomCommandOutputs({
+      config: makeConfig([cmd]),
+      stdin: '{}',
+      cachePath,
+      configFilePath: configPath,
+      now: FIXED_NOW,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].state).toBe('hidden');
+    expect(result[0].text).toBe('');
+  }, 5000);
+
+  it('preserves declared order across mixed fresh/stale/never-ran states', async () => {
+    const fresh = makeCmd({ id: 'a-fresh', refreshMs: 5000 });
+    const stale = makeCmd({ id: 'b-stale', refreshMs: 5000 });
+    const newCmd = makeCmd({ id: 'c-new', refreshMs: 5000, onError: 'placeholder' });
+
+    writeFileSync(cachePath, JSON.stringify({
+      [fresh.id]: { text: 'aaa', capturedAt: FIXED_NOW - 500, state: 'ok' },
+      [stale.id]: { text: 'bbb', capturedAt: FIXED_NOW - 10_000, state: 'ok' },
+    }), { mode: 0o600 });
+
+    const result = await getCustomCommandOutputs({
+      config: makeConfig([fresh, stale, newCmd]),
+      stdin: '{}',
+      cachePath,
+      configFilePath: configPath,
+      now: FIXED_NOW,
+    });
+
+    expect(result.map((r) => r.id)).toEqual(['a-fresh', 'b-stale', 'c-new']);
+    expect(result[0].text).toBe('aaa');
+    expect(result[1].text).toBe('bbb'); // stale returned immediately
+    expect(result[2].text).toBe('?'); // never-ran + placeholder
+  }, 5000);
+
+  it('background refresh writes cache after spawn completes', async () => {
+    const cmd = makeCmd({
+      id: 'bg-refresh',
+      command: ['node', '-e', "process.stdout.write('hello')"],
+    });
+    expect(existsSync(cachePath)).toBe(false);
+
+    const first = await getCustomCommandOutputs({
+      config: makeConfig([cmd]),
+      stdin: '{}',
+      cachePath,
+      configFilePath: configPath,
+      now: FIXED_NOW,
+    });
+    // No cache → never-ran (hide by default since onError defaults to 'hide').
+    expect(first).toHaveLength(1);
+    expect(first[0].state).toBe('hidden');
+
+    await waitFor(() => {
+      try {
+        const raw = JSON.parse(readFileSync(cachePath, 'utf8'));
+        return raw[cmd.id]?.text === 'hello';
+      } catch { return false; }
+    });
+    const written = JSON.parse(readFileSync(cachePath, 'utf8'));
+    expect(written[cmd.id].text).toBe('hello');
+    expect(written[cmd.id].state).toBe('ok');
+    expect(typeof written[cmd.id].capturedAt).toBe('number');
+  }, 5000);
+
+  it('treats malformed cache file as empty (no crash)', async () => {
+    writeFileSync(cachePath, 'not-json-at-all', { mode: 0o600 });
+    const cmd = makeCmd({ id: 'garbage-cache', onError: 'placeholder' });
+    const result = await getCustomCommandOutputs({
+      config: makeConfig([cmd]),
+      stdin: '{}',
+      cachePath,
+      configFilePath: configPath,
+      now: FIXED_NOW,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].state).toBe('error');
+    expect(result[0].text).toBe('?');
+  });
+});

--- a/tests/parsers/custom-commands.test.ts
+++ b/tests/parsers/custom-commands.test.ts
@@ -103,6 +103,9 @@ describe('getCustomCommandOutputs', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].text).toBe('old-text');
+    // H1: a past-refreshMs `ok` entry serves cached text but with state =
+    // 'stale' (not 'ok') so the renderer can dim it while the bg refresh runs.
+    expect(result[0].state).toBe('stale');
 
     // Wait for fire-and-forget refresh to land on disk.
     await waitFor(() => {
@@ -302,6 +305,55 @@ describe('getCustomCommandOutputs', () => {
     expect(result[0].text).toBe('cached-during-skew');
     expect(result[0].state).toBe('ok');
     // No crash, no weird state — just treats it as fresh.
+  });
+
+  // H2: each output carries renderer-facing metadata (line/label/color/ansi)
+  // copied from the source CustomCommand. Phase 3 renderers need this and
+  // shouldn't have to maintain a separate id→cmd map.
+  it('propagates line / label / color / ansi from CustomCommand onto every output', async () => {
+    const okCmd = makeCmd({
+      id: 'ok-meta',
+      command: ['node', '-e', "process.stdout.write('hi')"],
+      line: 3,
+      label: 'k8s:',
+      color: 'cyan',
+      ansi: true,
+      refreshMs: 5000,
+    });
+    const hiddenCmd = makeCmd({
+      id: 'hidden-meta',
+      line: 2,
+      label: 'gone',
+      color: 'red',
+      ansi: false,
+      onError: 'hide',
+    });
+    writeFileSync(cachePath, JSON.stringify({
+      [okCmd.id]: { text: 'cached', capturedAt: FIXED_NOW - 100, state: 'ok' },
+    }), { mode: 0o600 });
+
+    const result = await getCustomCommandOutputs({
+      config: makeConfig([okCmd, hiddenCmd]),
+      stdin: '{}',
+      cachePath,
+      configFilePath: configPath,
+      now: FIXED_NOW,
+    });
+    expect(result).toHaveLength(2);
+    // ok entry — full metadata
+    expect(result[0].id).toBe('ok-meta');
+    expect(result[0].state).toBe('ok');
+    expect(result[0].line).toBe(3);
+    expect(result[0].label).toBe('k8s:');
+    expect(result[0].color).toBe('cyan');
+    expect(result[0].ansi).toBe(true);
+    // hidden entry — metadata still populated even when text is empty
+    expect(result[1].id).toBe('hidden-meta');
+    expect(result[1].state).toBe('hidden');
+    expect(result[1].line).toBe(2);
+    expect(result[1].label).toBe('gone');
+    expect(result[1].color).toBe('red');
+    expect(result[1].ansi).toBe(false);
   });
 
   // M4: symlink-safe cache read. If an attacker can write into the cache dir

--- a/tests/parsers/custom-commands.test.ts
+++ b/tests/parsers/custom-commands.test.ts
@@ -384,6 +384,85 @@ describe('getCustomCommandOutputs', () => {
     expect(result[1].ansi).toBe(false);
   });
 
+  // B1 regression: the renderer's process must exit immediately after
+  // getCustomCommandOutputs returns, even if a refresh has just been
+  // dispatched for a slow command. The earlier "void async-IIFE" version
+  // kept the event loop refed until execBg's child exited (+ cache write
+  // completed) — measured at ~2s for a 1.5s-timeout command. The detached
+  // helper subprocess design must keep the parent's exit-to-return time
+  // independent of the user command's wall time.
+  //
+  // We exercise this by spawning a sub-Node process that:
+  //  1. invokes getCustomCommandOutputs with a 5s-sleep command
+  //  2. immediately returns (no explicit process.exit, no awaits left)
+  //  3. lets the Node event loop unref naturally
+  // and measure how long it takes the sub-process to exit.
+  it('B1 — renderer process exits within 500ms even when a slow refresh was just dispatched', async () => {
+    const { spawn } = await import('node:child_process');
+    const distEntry = join(process.cwd(), 'dist', 'index.js');
+    const distParser = join(process.cwd(), 'dist', 'parsers', 'custom-commands.js');
+    // Skip if the dist build isn't available — this regression test depends
+    // on the production strategy, which spawns 'node dist/index.js'.
+    if (!existsSync(distEntry) || !existsSync(distParser)) {
+      console.warn('[B1 test] skipped: dist build not present (run `npm run build`)');
+      return;
+    }
+
+    const slowCachePath = join(dir, 'b1-cache.json');
+    const script = `
+      import('${distParser.replace(/\\/g, '\\\\')}').then(async (m) => {
+        await m.getCustomCommandOutputs({
+          config: {
+            enabled: true,
+            commands: [{
+              id: 'slow',
+              command: ['node', '-e', 'setInterval(() => {}, 1000)'],
+              line: 1,
+              refreshMs: 100,
+              timeoutMs: 1500,
+              maxBytes: 256,
+              onError: 'hide',
+              onTimeout: 'stale',
+              ansi: false,
+            }],
+          },
+          stdin: '{}',
+          cachePath: ${JSON.stringify(slowCachePath)},
+          configFilePath: ${JSON.stringify(configPath)},
+        });
+      });
+    `;
+
+    const start = Date.now();
+    const result = await new Promise<{ elapsed: number; signal: NodeJS.Signals | null }>((resolve, reject) => {
+      const child = spawn(process.execPath, ['--input-type=module', '-e', script], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, LUMIRA_CUSTOM_REFRESH_ENTRY: distEntry },
+      });
+      const killTimer = setTimeout(() => {
+        // If exit doesn't happen in time, kill it so the test fails cleanly.
+        try { child.kill('SIGKILL'); } catch { /* gone */ }
+        reject(new Error('child did not exit within 3s'));
+      }, 3000);
+      child.on('exit', (_code, signal) => {
+        clearTimeout(killTimer);
+        resolve({ elapsed: Date.now() - start, signal });
+      });
+      child.on('error', (err) => {
+        clearTimeout(killTimer);
+        reject(err);
+      });
+    });
+
+    // The whole point of B1 is that exit time is INDEPENDENT of the user
+    // command's wall time (1500ms here). 500ms gives plenty of headroom
+    // for Node startup + module imports without crossing into "we're
+    // waiting on execBg" territory.
+    expect(result.elapsed).toBeLessThan(1500);
+    // No signal — clean exit, not a kill.
+    expect(result.signal).toBeNull();
+  }, 10_000);
+
   // M4: symlink-safe cache read. If an attacker can write into the cache dir
   // they could replace our cache file with a symlink targeting attacker-
   // controlled content. We refuse to read symlinked cache files.

--- a/tests/parsers/custom-commands.test.ts
+++ b/tests/parsers/custom-commands.test.ts
@@ -160,6 +160,20 @@ describe('getCustomCommandOutputs', () => {
     }
   });
 
+  // I3: fail-closed if configFilePath is missing/empty so a caller can never
+  // accidentally evaporate the world-writable safety gate by omission.
+  it('returns [] when configFilePath is the empty string (fail-closed)', async () => {
+    const result = await getCustomCommandOutputs({
+      config: makeConfig([makeCmd()]),
+      stdin: '{}',
+      cachePath,
+      configFilePath: '',
+      now: FIXED_NOW,
+    });
+    expect(result).toEqual([]);
+    expect(existsSync(cachePath)).toBe(false);
+  });
+
   it('respects onTimeout=stale — returns cached text from previous timeout entry', async () => {
     const cmd = makeCmd({ id: 'timeout-cmd', onTimeout: 'stale', refreshMs: 5000 });
     writeFileSync(cachePath, JSON.stringify({

--- a/tests/parsers/custom-commands.test.ts
+++ b/tests/parsers/custom-commands.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, chmodSync, existsSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, chmodSync, existsSync, readFileSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { getCustomCommandOutputs } from '../../src/parsers/custom-commands.js';
@@ -278,5 +278,55 @@ describe('getCustomCommandOutputs', () => {
     expect(result).toHaveLength(1);
     expect(result[0].state).toBe('error');
     expect(result[0].text).toBe('?');
+  });
+
+  // M2: clock-skew defensive clamp. If the system clock jumps backwards (NTP
+  // correction, suspend/resume, manual change), `now - capturedAt` becomes a
+  // large negative number. The clamp ensures we treat it as age=0 (still
+  // fresh) rather than negative — no negative durations leaking into renderer
+  // metadata, no weird isStale semantics. The entry is returned cleanly.
+  it('does not crash or misbehave on future capturedAt (clock-skew clamp)', async () => {
+    const cmd = makeCmd({ id: 'skew', refreshMs: 5000 });
+    writeFileSync(cachePath, JSON.stringify({
+      [cmd.id]: { text: 'cached-during-skew', capturedAt: FIXED_NOW + 60_000, state: 'ok' },
+    }), { mode: 0o600 });
+
+    const result = await getCustomCommandOutputs({
+      config: makeConfig([cmd]),
+      stdin: '{}',
+      cachePath,
+      configFilePath: configPath,
+      now: FIXED_NOW, // "earlier" than capturedAt → would compute negative age without clamp
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe('cached-during-skew');
+    expect(result[0].state).toBe('ok');
+    // No crash, no weird state — just treats it as fresh.
+  });
+
+  // M4: symlink-safe cache read. If an attacker can write into the cache dir
+  // they could replace our cache file with a symlink targeting attacker-
+  // controlled content. We refuse to read symlinked cache files.
+  it('returns no cached data when cache file is a symlink (refuses to follow)', async () => {
+    const cmd = makeCmd({ id: 'symlink-target', onError: 'placeholder' });
+    // Create the real file with what would look like a cached entry…
+    const realPath = join(dir, 'real-cache.json');
+    writeFileSync(realPath, JSON.stringify({
+      [cmd.id]: { text: 'leaked', capturedAt: FIXED_NOW, state: 'ok' },
+    }), { mode: 0o600 });
+    // …then symlink cachePath at it. The parser must refuse to follow.
+    symlinkSync(realPath, cachePath);
+
+    const result = await getCustomCommandOutputs({
+      config: makeConfig([cmd]),
+      stdin: '{}',
+      cachePath,
+      configFilePath: configPath,
+      now: FIXED_NOW,
+    });
+    expect(result).toHaveLength(1);
+    // No entry surfaced (symlink read aborts → never-ran path).
+    expect(result[0].text).toBe('?');
+    expect(result[0].state).toBe('error');
   });
 });

--- a/tests/render/line1.test.ts
+++ b/tests/render/line1.test.ts
@@ -198,4 +198,91 @@ describe('renderLine1', () => {
       expect(out).not.toContain(cube);
     });
   });
+
+  // ── Custom commands (issue #143 phase 3) ─────────────────────────
+  describe('custom commands', () => {
+    it('renders a single ok command on line 1', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'CI', state: 'ok', line: 1, ansi: false }],
+      });
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out).toContain('CI');
+    });
+
+    it('does not render a command targeting a different line', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'OTHER', state: 'ok', line: 2, ansi: false }],
+      });
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out).not.toContain('OTHER');
+    });
+
+    it('drops hidden state outputs', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'GONE', state: 'hidden', line: 1, ansi: false }],
+      });
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out).not.toContain('GONE');
+    });
+
+    it('renders multiple commands in order', () => {
+      const ctx = makeCtx({
+        customCommands: [
+          { id: 'a', text: 'FIRST', state: 'ok', line: 1, ansi: false },
+          { id: 'b', text: 'SECOND', state: 'ok', line: 1, ansi: false },
+        ],
+      });
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out.indexOf('FIRST')).toBeGreaterThan(-1);
+      expect(out.indexOf('SECOND')).toBeGreaterThan(out.indexOf('FIRST'));
+    });
+
+    it('applies label prefix', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'a', text: 'green', label: '◆', state: 'ok', line: 1, ansi: false }],
+      });
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out).toContain('◆ green');
+    });
+
+    it('strips embedded ANSI when ansi:false (default)', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'a', text: '\x1b[31mraw\x1b[0m', state: 'ok', line: 1, ansi: false }],
+      });
+      const out = renderLine1(ctx, c);
+      // The fg red escape should not leak through.
+      expect(out).not.toMatch(/\x1b\[31mraw/);
+      expect(stripAnsi(out)).toContain('raw');
+    });
+
+    it('passes ANSI through when ansi:true', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'a', text: '\x1b[31mraw\x1b[0m', state: 'ok', line: 1, ansi: true }],
+      });
+      const out = renderLine1(ctx, c);
+      expect(out).toContain('\x1b[31m');
+    });
+
+    it('dims a stale command', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'a', text: 'fading', state: 'stale', line: 1, ansi: false }],
+      });
+      const out = renderLine1(ctx, c);
+      expect(out).toContain('\x1b[2m');
+    });
+
+    it('renders error-state text verbatim (parser already remapped)', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'a', text: '?', state: 'error', line: 1, ansi: false }],
+      });
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out).toContain('?');
+    });
+
+    it('no change to output when customCommands is undefined', () => {
+      const without = stripAnsi(renderLine1(makeCtx(), c));
+      const withEmpty = stripAnsi(renderLine1(makeCtx({ customCommands: [] }), c));
+      expect(withEmpty).toBe(without);
+    });
+  });
 });

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -800,6 +800,76 @@ describe('renderLine2', () => {
       expect(out).toMatch(/\x1b\[(?!0m)[\d;]+m⚠ ~24h/u);
     });
   });
+
+  // ── Custom commands (issue #143 phase 3) ─────────────────────────
+  describe('custom commands', () => {
+    it('renders a single ok command on line 2', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'BUILD', state: 'ok', line: 2, ansi: false }],
+      });
+      const out = stripAnsi(renderLine2(ctx, c));
+      expect(out).toContain('BUILD');
+    });
+
+    it('does not render commands targeting a different line', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'ELSEWHERE', state: 'ok', line: 1, ansi: false }],
+      });
+      const out = stripAnsi(renderLine2(ctx, c));
+      expect(out).not.toContain('ELSEWHERE');
+    });
+
+    it('drops hidden state outputs', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'NOPE', state: 'hidden', line: 2, ansi: false }],
+      });
+      const out = stripAnsi(renderLine2(ctx, c));
+      expect(out).not.toContain('NOPE');
+    });
+
+    it('renders multiple commands in declared order', () => {
+      const ctx = makeCtx({
+        customCommands: [
+          { id: 'a', text: 'ALPHA', state: 'ok', line: 2, ansi: false },
+          { id: 'b', text: 'BETA', state: 'ok', line: 2, ansi: false },
+        ],
+      });
+      const out = stripAnsi(renderLine2(ctx, c));
+      expect(out.indexOf('ALPHA')).toBeLessThan(out.indexOf('BETA'));
+    });
+
+    it('dims stale outputs', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'a', text: 'fading', state: 'stale', line: 2, ansi: false }],
+      });
+      const out = renderLine2(ctx, c);
+      expect(out).toContain('\x1b[2m');
+    });
+
+    it('strips embedded ANSI by default and passes through when ansi:true', () => {
+      const stripped = renderLine2(makeCtx({
+        customCommands: [{ id: 'a', text: '\x1b[31mraw\x1b[0m', state: 'ok', line: 2, ansi: false }],
+      }), c);
+      expect(stripped).not.toMatch(/\x1b\[31mraw/);
+
+      const through = renderLine2(makeCtx({
+        customCommands: [{ id: 'a', text: '\x1b[31mraw\x1b[0m', state: 'ok', line: 2, ansi: true }],
+      }), c);
+      expect(through).toContain('\x1b[31m');
+    });
+
+    it('renders timeout/error placeholder text verbatim', () => {
+      const ctx = makeCtx({
+        customCommands: [
+          { id: 'a', text: '…', state: 'timeout', line: 2, ansi: false },
+          { id: 'b', text: '?', state: 'error', line: 2, ansi: false },
+        ],
+      });
+      const out = stripAnsi(renderLine2(ctx, c));
+      expect(out).toContain('…');
+      expect(out).toContain('?');
+    });
+  });
 });
 
 describe('apiLatency widget', () => {

--- a/tests/render/line3.test.ts
+++ b/tests/render/line3.test.ts
@@ -153,4 +153,42 @@ describe('renderLine3 — agent count', () => {
     const out = stripAnsi(renderLine3(makeCtx({ transcript, config }), c));
     expect(out).not.toContain('agent');
   });
+
+  // ── Custom commands (issue #143 phase 3) ─────────────────────────
+  describe('custom commands', () => {
+    it('renders a single ok command on line 3', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'CUSTOM3', state: 'ok', line: 3, ansi: false }],
+      });
+      const out = stripAnsi(renderLine3(ctx, c));
+      expect(out).toContain('CUSTOM3');
+    });
+
+    it('does not render commands for other lines', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'OTHER', state: 'ok', line: 2, ansi: false }],
+      });
+      const out = stripAnsi(renderLine3(ctx, c));
+      expect(out).not.toContain('OTHER');
+    });
+
+    it('drops hidden state outputs', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'GONE', state: 'hidden', line: 3, ansi: false }],
+      });
+      const out = stripAnsi(renderLine3(ctx, c));
+      expect(out).not.toContain('GONE');
+    });
+
+    it('coexists with line3 core widgets (tools/todos)', () => {
+      const transcript = { ...EMPTY_TRANSCRIPT, tools: [runningTool('Bash')] };
+      const ctx = makeCtx({
+        transcript,
+        customCommands: [{ id: 'foo', text: 'MINE', state: 'ok', line: 3, ansi: false }],
+      });
+      const out = stripAnsi(renderLine3(ctx, c));
+      expect(out).toContain('Bash');
+      expect(out).toContain('MINE');
+    });
+  });
 });

--- a/tests/render/line4.test.ts
+++ b/tests/render/line4.test.ts
@@ -16,12 +16,13 @@ const baseInput: ClaudeCodeInput = {
   workspace: { current_dir: '/home/user/project' },
 };
 
-function makeCtx(gsd: GsdInfo | null): RenderContext {
+function makeCtx(gsd: GsdInfo | null, overrides: Partial<RenderContext> = {}): RenderContext {
   return {
     input: normalize(baseInput), git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
     tokenSpeed: null, memory: null, gsd, mcp: null, cols: 120,
     config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
     icons: NERD_ICONS,
+    ...overrides,
   };
 }
 
@@ -49,5 +50,44 @@ describe('renderLine4', () => {
     const out = stripAnsi(renderLine4(makeCtx({ currentTask: 'My task', updateAvailable: true }), c));
     expect(out).toContain('My task');
     expect(out).toContain('GSD update available');
+  });
+
+  // ── Custom commands (issue #143 phase 3) ─────────────────────────
+  describe('custom commands', () => {
+    it('renders custom commands on line 4 even when GSD is null', () => {
+      const ctx = makeCtx(null, {
+        customCommands: [{ id: 'foo', text: 'WIDGET4', state: 'ok', line: 4, ansi: false }],
+      });
+      const out = stripAnsi(renderLine4(ctx, c));
+      expect(out).toContain('WIDGET4');
+    });
+
+    it('renders custom commands alongside GSD task', () => {
+      const ctx = makeCtx({ currentTask: 'task' }, {
+        customCommands: [{ id: 'foo', text: 'BOTH', state: 'ok', line: 4, ansi: false }],
+      });
+      const out = stripAnsi(renderLine4(ctx, c));
+      expect(out).toContain('task');
+      expect(out).toContain('BOTH');
+    });
+
+    it('ignores commands for other lines', () => {
+      const ctx = makeCtx(null, {
+        customCommands: [{ id: 'foo', text: 'WRONG', state: 'ok', line: 1, ansi: false }],
+      });
+      expect(renderLine4(ctx, c)).toBe('');
+    });
+
+    it('drops hidden state outputs', () => {
+      const ctx = makeCtx(null, {
+        customCommands: [{ id: 'foo', text: 'GONE', state: 'hidden', line: 4, ansi: false }],
+      });
+      expect(renderLine4(ctx, c)).toBe('');
+    });
+
+    it('returns empty string when neither GSD nor custom commands have content', () => {
+      const ctx = makeCtx(null, { customCommands: [] });
+      expect(renderLine4(ctx, c)).toBe('');
+    });
   });
 });

--- a/tests/render/minimal.test.ts
+++ b/tests/render/minimal.test.ts
@@ -94,4 +94,26 @@ describe('renderMinimal', () => {
     const out = stripAnsi(renderMinimal(makeCtx({ cols: 50 }), c));
     expect(out).not.toContain('$1.31');
   });
+
+  // ── Custom commands (issue #143 phase 3) ─────────────────────────
+  // Minimal preset is intentionally opinionated: it targets tight single-line
+  // terminals where every char counts. User-defined widgets are not surfaced
+  // here. Users who want them should pick the full or balanced preset.
+  describe('custom commands', () => {
+    it('does not render custom commands declared on any line', () => {
+      const ctx = makeCtx({
+        customCommands: [
+          { id: 'a', text: 'CUSTOM1', state: 'ok', line: 1, ansi: false },
+          { id: 'b', text: 'CUSTOM2', state: 'ok', line: 2, ansi: false },
+          { id: 'c', text: 'CUSTOM3', state: 'ok', line: 3, ansi: false },
+          { id: 'd', text: 'CUSTOM4', state: 'ok', line: 4, ansi: false },
+        ],
+      });
+      const out = stripAnsi(renderMinimal(ctx, c));
+      expect(out).not.toContain('CUSTOM1');
+      expect(out).not.toContain('CUSTOM2');
+      expect(out).not.toContain('CUSTOM3');
+      expect(out).not.toContain('CUSTOM4');
+    });
+  });
 });

--- a/tests/render/powerline-line1.test.ts
+++ b/tests/render/powerline-line1.test.ts
@@ -758,4 +758,39 @@ describe('renderPowerlineLine1', () => {
       expect(out).toContain('jarvis');
     });
   });
+
+  // ── Custom commands (issue #143 phase 3) ─────────────────────────
+  describe('custom commands', () => {
+    it('renders an ok line-1 command as a powerline segment', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'CUSTOM', state: 'ok', line: 1, ansi: false }],
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).toContain('CUSTOM');
+    });
+
+    it('ignores hidden state outputs', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'GONE', state: 'hidden', line: 1, ansi: false }],
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).not.toContain('GONE');
+    });
+
+    it('does not render commands targeting other lines', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'OTHER', state: 'ok', line: 2, ansi: false }],
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).not.toContain('OTHER');
+    });
+
+    it('dims a stale command', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'fading', state: 'stale', line: 1, ansi: false }],
+      });
+      const raw = renderPowerlineLine1(ctx, 'truecolor', null);
+      expect(raw).toContain('\x1b[2m');
+    });
+  });
 });

--- a/tests/render/powerline-line2.test.ts
+++ b/tests/render/powerline-line2.test.ts
@@ -712,4 +712,55 @@ describe('renderPowerlineLine2', () => {
       expect(stripAnsi(raw)).toContain('API ');
     });
   });
+
+  // ── Custom commands (issue #143 phase 3) ─────────────────────────
+  describe('custom commands', () => {
+    it('renders an ok command on line 2 as a powerline segment', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'BUILD', state: 'ok', line: 2, ansi: false }],
+      });
+      const raw = renderPowerlineLine2(ctx, 'truecolor', null, c);
+      // Segment text should appear; bg escapes also present (truecolor mode).
+      expect(stripAnsi(raw)).toContain('BUILD');
+      expect(raw).toContain('\x1b[48;2;');
+    });
+
+    it('does not render a command for a different line', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'NOTHERE', state: 'ok', line: 1, ansi: false }],
+      });
+      const raw = renderPowerlineLine2(ctx, 'truecolor', null, c);
+      expect(stripAnsi(raw)).not.toContain('NOTHERE');
+    });
+
+    it('drops hidden state outputs', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'GONE', state: 'hidden', line: 2, ansi: false }],
+      });
+      const raw = renderPowerlineLine2(ctx, 'truecolor', null, c);
+      expect(stripAnsi(raw)).not.toContain('GONE');
+    });
+
+    it('dims a stale command (inline dim escape)', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'fading', state: 'stale', line: 2, ansi: false }],
+      });
+      const raw = renderPowerlineLine2(ctx, 'truecolor', null, c);
+      expect(raw).toContain('\x1b[2m');
+      expect(stripAnsi(raw)).toContain('fading');
+    });
+
+    it('powerline rendering does not crash on multiple custom commands', () => {
+      const ctx = makeCtx({
+        customCommands: [
+          { id: 'a', text: 'ONE', state: 'ok', line: 2, ansi: false, color: 'green' },
+          { id: 'b', text: 'TWO', state: 'ok', line: 2, ansi: false, color: 'yellow' },
+        ],
+      });
+      const raw = renderPowerlineLine2(ctx, 'truecolor', null, c);
+      const plain = stripAnsi(raw);
+      expect(plain).toContain('ONE');
+      expect(plain).toContain('TWO');
+    });
+  });
 });

--- a/tests/render/powerline-line3.test.ts
+++ b/tests/render/powerline-line3.test.ts
@@ -149,4 +149,29 @@ describe('renderPowerlineLine3 — agent count', () => {
     });
     expect(stripAnsi(renderPowerlineLine3(ctx, 'truecolor', null))).not.toContain('agent');
   });
+
+  // ── Custom commands (issue #143 phase 3) ─────────────────────────
+  describe('custom commands', () => {
+    it('renders an ok line-3 command as a powerline segment', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'L3', state: 'ok', line: 3, ansi: false }],
+      });
+      const out = stripAnsi(renderPowerlineLine3(ctx, 'truecolor', null));
+      expect(out).toContain('L3');
+    });
+
+    it('drops hidden outputs', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'GONE', state: 'hidden', line: 3, ansi: false }],
+      });
+      expect(stripAnsi(renderPowerlineLine3(ctx, 'truecolor', null))).not.toContain('GONE');
+    });
+
+    it('does not render commands for other lines', () => {
+      const ctx = makeCtx({
+        customCommands: [{ id: 'foo', text: 'WRONG', state: 'ok', line: 1, ansi: false }],
+      });
+      expect(stripAnsi(renderPowerlineLine3(ctx, 'truecolor', null))).not.toContain('WRONG');
+    });
+  });
 });

--- a/tests/render/shared.test.ts
+++ b/tests/render/shared.test.ts
@@ -1,8 +1,16 @@
 import { describe, it, expect } from 'vitest';
-import { buildContextBar, formatGitChanges, SEP, SEP_MINIMAL } from '../../src/render/shared.js';
+import {
+  buildContextBar,
+  formatGitChanges,
+  getCustomCommandsForLine,
+  renderCustomCommand,
+  SEP,
+  SEP_MINIMAL,
+} from '../../src/render/shared.js';
 import { createColors, stripAnsi } from '../../src/render/colors.js';
 import { NERD_ICONS, EMOJI_ICONS, NO_ICONS } from '../../src/render/icons.js';
 import type { GitStatus } from '../../src/types.js';
+import type { CustomCommandOutput } from '../../src/parsers/custom-commands.js';
 
 const c = createColors('named');
 
@@ -324,5 +332,142 @@ describe('SEP constants', () => {
   it('SEP_MINIMAL uses ASCII pipe', () => {
     expect(SEP_MINIMAL).toContain('|');
     expect(SEP_MINIMAL).not.toContain('\u2502');
+  });
+});
+
+// \u2500\u2500 Custom command render helpers (issue #143 phase 3) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+// Build a CustomCommandOutput with sane defaults; tests only override what
+// they care about. Keeps individual cases short and intent-focused.
+function mkOutput(overrides: Partial<CustomCommandOutput> = {}): CustomCommandOutput {
+  return {
+    id: 'test',
+    text: 'hello',
+    state: 'ok',
+    line: 1,
+    ansi: false,
+    ...overrides,
+  };
+}
+
+describe('getCustomCommandsForLine', () => {
+  it('returns [] for undefined input', () => {
+    expect(getCustomCommandsForLine(undefined, 1)).toEqual([]);
+  });
+
+  it('returns [] for empty input', () => {
+    expect(getCustomCommandsForLine([], 1)).toEqual([]);
+  });
+
+  it('filters to outputs matching the requested line', () => {
+    const outs = [
+      mkOutput({ id: 'a', line: 1 }),
+      mkOutput({ id: 'b', line: 2 }),
+      mkOutput({ id: 'c', line: 1 }),
+    ];
+    const filtered = getCustomCommandsForLine(outs, 1);
+    expect(filtered.map(o => o.id)).toEqual(['a', 'c']);
+  });
+
+  it('drops outputs in hidden state regardless of line match', () => {
+    const outs = [
+      mkOutput({ id: 'visible', line: 2, state: 'ok' }),
+      mkOutput({ id: 'gone', line: 2, state: 'hidden', text: '' }),
+    ];
+    const filtered = getCustomCommandsForLine(outs, 2);
+    expect(filtered.map(o => o.id)).toEqual(['visible']);
+  });
+
+  it('preserves insertion order', () => {
+    const outs = [
+      mkOutput({ id: 'first', line: 3 }),
+      mkOutput({ id: 'second', line: 3 }),
+      mkOutput({ id: 'third', line: 3 }),
+    ];
+    expect(getCustomCommandsForLine(outs, 3).map(o => o.id)).toEqual(['first', 'second', 'third']);
+  });
+});
+
+describe('renderCustomCommand', () => {
+  const colors = createColors('named');
+
+  it('renders plain ok output without color or label', () => {
+    const out = renderCustomCommand(mkOutput({ text: 'plain' }), colors);
+    expect(out).toBe('plain');
+  });
+
+  it('strips ANSI from text when ansi: false', () => {
+    // Embedded ANSI in user-provided text must not leak through when ansi is off.
+    const out = renderCustomCommand(
+      mkOutput({ text: '\x1b[31mred\x1b[0m text', ansi: false }),
+      colors,
+    );
+    expect(stripAnsi(out)).toBe('red text');
+    expect(out).not.toContain('\x1b[31m');
+  });
+
+  it('passes ANSI through when ansi: true', () => {
+    const out = renderCustomCommand(
+      mkOutput({ text: '\x1b[31mred\x1b[0m', ansi: true }),
+      colors,
+    );
+    expect(out).toContain('\x1b[31m');
+  });
+
+  it('prepends label with a single space when set', () => {
+    const out = renderCustomCommand(mkOutput({ text: 'value', label: '\u25c6' }), colors);
+    expect(stripAnsi(out)).toBe('\u25c6 value');
+  });
+
+  it('applies color when ansi: false and color set', () => {
+    const out = renderCustomCommand(mkOutput({ text: 'green', color: 'green' }), colors);
+    // Named-ANSI green is \x1b[32m
+    expect(out).toContain('\x1b[32m');
+    expect(stripAnsi(out)).toBe('green');
+  });
+
+  it('does NOT apply color when ansi: true (avoids nested escapes)', () => {
+    const out = renderCustomCommand(
+      mkOutput({ text: 'preset', color: 'green', ansi: true }),
+      colors,
+    );
+    // No wrapper escape \u2014 only the raw text comes through.
+    expect(out).toBe('preset');
+  });
+
+  it('returns empty string for hidden state', () => {
+    expect(renderCustomCommand(mkOutput({ state: 'hidden', text: '' }), colors)).toBe('');
+  });
+
+  it('dims output when state is stale', () => {
+    const out = renderCustomCommand(mkOutput({ text: 'fading', state: 'stale' }), colors);
+    // dim escape is \x1b[2m in named mode
+    expect(out).toContain('\x1b[2m');
+    expect(stripAnsi(out)).toBe('fading');
+  });
+
+  it('stale dim wraps a colored output (dim applied last)', () => {
+    const out = renderCustomCommand(
+      mkOutput({ text: 'x', state: 'stale', color: 'green' }),
+      colors,
+    );
+    // dim escape must be present somewhere outside the color escape.
+    expect(out).toContain('\x1b[2m');
+    expect(out).toContain('\x1b[32m');
+  });
+
+  it('renders timeout/error states with their text untouched (parser already remapped)', () => {
+    const timeout = renderCustomCommand(mkOutput({ text: '\u2026', state: 'timeout' }), colors);
+    expect(stripAnsi(timeout)).toBe('\u2026');
+    const error = renderCustomCommand(mkOutput({ text: '?', state: 'error' }), colors);
+    expect(stripAnsi(error)).toBe('?');
+  });
+
+  it('ignores unknown color names without throwing', () => {
+    const out = renderCustomCommand(
+      // Cast intentionally: simulate parser drift / mis-typed config.
+      mkOutput({ text: 'safe', color: 'nope' as unknown as CustomCommandOutput['color'] }),
+      colors,
+    );
+    expect(stripAnsi(out)).toBe('safe');
   });
 });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -4,6 +4,10 @@ import {
   DEFAULT_CONTEXT_CRITICAL_THRESHOLD,
   AUTO_COMPACT_THRESHOLD,
   AUTO_COMPACT_WARNING_GAP,
+  CUSTOM_COMMAND_MAX_TIMEOUT_MS,
+  CUSTOM_COMMAND_MAX_BYTES,
+  CUSTOM_COMMAND_MAX_ENV_ENTRIES,
+  CUSTOM_COMMAND_MIN_REFRESH_MS,
 } from '../src/types.js';
 
 // Issue #138: defaults lowered so the visible bar warns/criticals BEFORE the
@@ -31,5 +35,25 @@ describe('AUTO_COMPACT_THRESHOLD (issue #138)', () => {
 
   it('AUTO_COMPACT_WARNING_GAP === 5', () => {
     expect(AUTO_COMPACT_WARNING_GAP).toBe(5);
+  });
+});
+
+// Issue #143: hard caps for the Custom Command widget. These bound runtime
+// cost so a misconfigured command can never starve the statusline render.
+describe('custom command hard caps (issue #143)', () => {
+  it('CUSTOM_COMMAND_MAX_TIMEOUT_MS === 2000', () => {
+    expect(CUSTOM_COMMAND_MAX_TIMEOUT_MS).toBe(2000);
+  });
+
+  it('CUSTOM_COMMAND_MAX_BYTES === 4096', () => {
+    expect(CUSTOM_COMMAND_MAX_BYTES).toBe(4096);
+  });
+
+  it('CUSTOM_COMMAND_MAX_ENV_ENTRIES === 32', () => {
+    expect(CUSTOM_COMMAND_MAX_ENV_ENTRIES).toBe(32);
+  });
+
+  it('CUSTOM_COMMAND_MIN_REFRESH_MS === 500', () => {
+    expect(CUSTOM_COMMAND_MIN_REFRESH_MS).toBe(500);
   });
 });

--- a/tests/utils/exec-bg.test.ts
+++ b/tests/utils/exec-bg.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execBg } from '../../src/utils/exec-bg.js';
+
+describe('execBg', () => {
+  it('happy path — captures stdout and resolves ok', async () => {
+    const result = await execBg({
+      command: ['node', '-e', "process.stdout.write('hi')"],
+      timeoutMs: 1500,
+      maxBytes: 1024,
+    });
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.stdout).toBe('hi');
+      expect(result.truncated).toBe(false);
+      expect(result.exitCode).toBe(0);
+      expect(typeof result.durationMs).toBe('number');
+    }
+  }, 3000);
+
+  it('truncates stdout when exceeding maxBytes and kills process', async () => {
+    const result = await execBg({
+      command: ['node', '-e', "setInterval(() => process.stdout.write('x'.repeat(1000)), 5)"],
+      timeoutMs: 1500,
+      maxBytes: 100,
+    });
+    // We may either receive 'ok' (exit 0 after kill on some platforms) or 'nonzero'.
+    expect(['ok', 'nonzero']).toContain(result.kind);
+    if (result.kind === 'ok') {
+      expect(result.truncated).toBe(true);
+      expect(result.stdout.length).toBe(100);
+    } else if (result.kind === 'nonzero') {
+      expect(result.stdout.length).toBe(100);
+    }
+  }, 3000);
+
+  it('returns timeout when wall-clock exceeded', async () => {
+    const start = Date.now();
+    const result = await execBg({
+      command: ['node', '-e', 'setInterval(() => {}, 1000)'],
+      timeoutMs: 200,
+      maxBytes: 1024,
+    });
+    const elapsed = Date.now() - start;
+    expect(result.kind).toBe('timeout');
+    if (result.kind === 'timeout') {
+      expect(typeof result.durationMs).toBe('number');
+    }
+    expect(elapsed).toBeLessThan(1500);
+  }, 3000);
+
+  it('reports non-zero exit code', async () => {
+    const result = await execBg({
+      command: ['node', '-e', 'process.exit(42)'],
+      timeoutMs: 1500,
+      maxBytes: 1024,
+    });
+    expect(result.kind).toBe('nonzero');
+    if (result.kind === 'nonzero') {
+      expect(result.exitCode).toBe(42);
+    }
+  }, 3000);
+
+  it('reports spawn error for non-existent binary', async () => {
+    const result = await execBg({
+      command: ['/this/binary/does/not/exist/lumira-test'],
+      timeoutMs: 1500,
+      maxBytes: 1024,
+    });
+    expect(result.kind).toBe('spawn-error');
+    if (result.kind === 'spawn-error') {
+      expect(result.message.length).toBeGreaterThan(0);
+    }
+  }, 3000);
+
+  it('strips unwanted env vars by default — only curated set passes through', async () => {
+    // Set a custom var on the parent that should NOT leak unless explicitly forwarded.
+    process.env.LUMIRA_TEST_LEAK = 'should-not-be-visible';
+    try {
+      const result = await execBg({
+        command: ['node', '-e', "process.stdout.write(String(process.env.LUMIRA_TEST_LEAK || 'undef'))"],
+        timeoutMs: 1500,
+        maxBytes: 1024,
+      });
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        expect(result.stdout).toBe('undef');
+      }
+    } finally {
+      delete process.env.LUMIRA_TEST_LEAK;
+    }
+  }, 3000);
+
+  it('passes user env on top of curated minimum', async () => {
+    const result = await execBg({
+      command: ['node', '-e', "process.stdout.write(String(process.env.LUMIRA_CUSTOM || 'undef'))"],
+      timeoutMs: 1500,
+      maxBytes: 1024,
+      env: { LUMIRA_CUSTOM: 'visible' },
+    });
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.stdout).toBe('visible');
+    }
+  }, 3000);
+
+  it('pipes stdin to the child process', async () => {
+    const result = await execBg({
+      command: ['node', '-e', "let s=''; process.stdin.on('data', d => s+=d); process.stdin.on('end', () => process.stdout.write('got:' + s))"],
+      timeoutMs: 1500,
+      maxBytes: 1024,
+      stdin: 'hello',
+    });
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.stdout).toBe('got:hello');
+    }
+  }, 3000);
+
+  it('kills entire process group on timeout (child of child also gone)', async () => {
+    // Parent spawns a long-running detached child that writes its PID to a temp file.
+    const dir = mkdtempSync(join(tmpdir(), 'lumira-exec-bg-pgkill-'));
+    const pidFile = join(dir, 'child.pid');
+    try {
+      const script = `
+        const { spawn } = require('child_process');
+        const fs = require('fs');
+        const child = spawn('node', ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });
+        fs.writeFileSync(${JSON.stringify(pidFile)}, String(child.pid));
+        setInterval(() => {}, 1000);
+      `;
+      const result = await execBg({
+        command: ['node', '-e', script],
+        timeoutMs: 300,
+        maxBytes: 1024,
+      });
+      expect(result.kind).toBe('timeout');
+
+      // Give the kill propagation a moment.
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      expect(existsSync(pidFile)).toBe(true);
+      const { readFileSync } = await import('node:fs');
+      const childPid = parseInt(readFileSync(pidFile, 'utf8').trim(), 10);
+      expect(Number.isFinite(childPid)).toBe(true);
+
+      // Check whether the child PID is still alive.
+      let stillAlive = false;
+      try {
+        process.kill(childPid, 0);
+        stillAlive = true;
+      } catch {
+        stillAlive = false;
+      }
+      expect(stillAlive).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 3000);
+});


### PR DESCRIPTION
## Summary

Implements the Custom Commands widget (#143) — user-defined shell commands rendered as statusline segments on any of the 4 lines.

- **Config-driven**: define commands in `~/.config/lumira/config.json`, disabled by default
- **Secure**: argv-only (no shell expansion), world-writable config guard, curated env, hard caps (2s timeout, 4096 bytes, 32 env entries)
- **Non-blocking**: TTL file-cache with background orphan refresh — zero latency on the hot render path
- **Four error strategies**: `hide` (default), `placeholder`, `output`, `stale`
- **`lumira custom` CLI**: `enable`, `disable`, `list`, `test <id>`, `logs`
- **Full renderer coverage**: line1–4, powerline-line1–3, minimal (intentionally skipped with inline rationale)

## Changes

| Phase | What |
|---|---|
| 1 | Types, constants, `parseCustomCommands()` config validator |
| 2 | `execBg()` subprocess executor, `getCustomCommandOutputs()` parser, orphan refresh helper |
| 3 | Renderer integration — `renderCustomCommand`, `getCustomCommandsForLine`, all line/powerline renderers |
| 4 | `lumira custom` CLI subcommand |
| 5 | Installer tip, README section, CHANGELOG v1.6.0 |
| fix | Pre-PR review: `onError='output'` stdout bug, `isValidSpec` bounds + absolute-path guard, config file mode 0o600, README field table |

## Test plan

- [ ] `npm test` — 1133/1133 passing (was 1057 before this PR, +76 new tests)
- [ ] `npx tsc --noEmit` — clean
- [ ] `lumira custom enable` creates/updates config with mode 0o600
- [ ] `lumira custom list` shows table of configured commands
- [ ] `lumira custom test <id>` runs a command and shows output + timing
- [ ] `lumira custom logs` reads and formats the cache file
- [ ] Custom segment appears on the correct line in the statusline
- [ ] `onError: 'hide'` (default) hides segment on failure
- [ ] World-writable config file is rejected (fail-closed)