### PR TITLE
chore(release): v1.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,8 @@ jobs:
       - run: npm run build
       - name: Bundle size guard
         env:
-          CEILING: '512000'
+          # Currently ~590 KB after custom commands widget. Ceiling raised from 512 KB to 640 KB alongside PR #146.
+          CEILING: '655360'
         run: |
           SIZE=$(du -sb dist/ | cut -f1)
           echo "dist/ size: $SIZE bytes (ceiling: $CEILING)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Real-time statusline HUD for Claude Code and Qwen Code. Includes session analytics CLI, API latency overhead widget, 7d quota projection, auto-compact proximity warnings, themes, and powerline. Zero deps.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Bumps version to 1.6.0 and raises release.yml bundle ceiling to 640 KB. Ships Custom Commands widget (#143).