### PR TITLE
chore(packaging): trim published npm package, JS-only bundle guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,19 +26,20 @@ jobs:
       - run: npm run test:coverage
       - run: npm run lint
       - run: npm run build
-      # Bundle size guard: dist/ ships to npm. Currently ~590 KB after
-      # the custom commands widget (exec-bg, parser, refresh helper, CLI,
-      # cache util, renderer integration). Ceiling raised from 512 KB to
-      # 640 KB alongside PR #146. Raise alongside the corresponding PR if
-      # a feature genuinely needs the headroom.
+      # Bundle size guard: measures only the .js files that actually ship and
+      # execute (source maps + .d.ts are excluded from the npm package via the
+      # files allowlist in package.json, so they don't count). Currently ~285 KB
+      # of JS after the custom commands widget. Ceiling is 400 KB. Raise it
+      # alongside the corresponding PR — and in release.yml too — if a feature
+      # genuinely needs the headroom.
       - name: Bundle size guard
         env:
-          CEILING: '655360'
+          CEILING: '409600'
         run: |
-          SIZE=$(du -sb dist/ | cut -f1)
-          echo "dist/ size: $SIZE bytes (ceiling: $CEILING)"
+          SIZE=$(find dist -name '*.js' -type f -printf '%s\n' | awk '{s+=$1} END {print s+0}')
+          echo "dist/ JS size: $SIZE bytes (ceiling: $CEILING)"
           if [ "$SIZE" -gt "$CEILING" ]; then
-            echo "::error::dist/ exceeded ceiling — raise it in ci.yml if intentional"
+            echo "::error::dist/ JS exceeded ceiling — raise it in ci.yml + release.yml if intentional"
             exit 1
           fi
       # Theme contrast guard. Reads compiled THEMES from dist/, computes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,13 +34,14 @@ jobs:
       - run: npm run build
       - name: Bundle size guard
         env:
-          # Currently ~590 KB after custom commands widget. Ceiling raised from 512 KB to 640 KB alongside PR #146.
-          CEILING: '655360'
+          # Measures only shipped .js (maps + .d.ts excluded from the npm
+          # package via package.json files allowlist). ~285 KB JS; ceiling 400 KB.
+          CEILING: '409600'
         run: |
-          SIZE=$(du -sb dist/ | cut -f1)
-          echo "dist/ size: $SIZE bytes (ceiling: $CEILING)"
+          SIZE=$(find dist -name '*.js' -type f -printf '%s\n' | awk '{s+=$1} END {print s+0}')
+          echo "dist/ JS size: $SIZE bytes (ceiling: $CEILING)"
           if [ "$SIZE" -gt "$CEILING" ]; then
-            echo "::error::dist/ exceeded ceiling — raise it in ci.yml + release.yml if intentional"
+            echo "::error::dist/ JS exceeded ceiling — raise it in ci.yml + release.yml if intentional"
             exit 1
           fi
       - name: Theme contrast guard (WCAG AA)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Smaller npm package** — source maps (`*.map`) and type declarations (`*.d.ts`) are now excluded from the published tarball via the `files` allowlist. They are build artifacts that `npx lumira` never loads. Unpacked install size drops ~50% (≈633 KB → ≈321 KB); the tarball shrinks from ~167 KB to ~99 KB.
+- **Bundle size guard now measures shipped JS only** — the CI/release guard previously summed all of `dist/` (including maps and declarations); it now counts just the `.js` files that actually ship and execute, so the ceiling reflects what users download. Ceiling adjusted to 400 KB accordingly (≈285 KB of JS today).
+
 ## [1.6.0] - 2026-05-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
   ],
   "files": [
     "dist",
-    "skills"
+    "skills",
+    "!dist/**/*.map",
+    "!dist/**/*.d.ts"
   ]
 }


### PR DESCRIPTION
## Summary

Two related packaging quick wins (Tier 1 backlog). Both target the same problem: source maps and type declarations were bloating the published npm package and inflating the bundle-size guard, for zero consumer benefit. `lumira` ships as a `bin`/`npx` CLI — there is no `types` entry and nobody imports it as a typed library, so `.map` and `.d.ts` files are pure dead weight in the tarball.

### Changes

- **Exclude `*.map` and `*.d.ts` from the npm package** via negation patterns in the `files` allowlist in `package.json`.
  - A root `.npmignore` does **not** work here: when `files` is set, npm treats it as the authoritative allowlist and ignores `.npmignore` for those paths. Verified empirically with `npm pack --dry-run` before switching to `files` negations.
- **Bundle size guard now measures shipped `.js` only** (in both `ci.yml` and `release.yml`). Previously summed all of `dist/` including maps + declarations; now counts just the JS that runs. Ceiling adjusted 640 KB → 400 KB to reflect reality (~285 KB JS today, ~118 KB headroom).

### Measured impact (`npm pack --dry-run`)

| Metric | Before | After |
|---|---|---|
| tarball | 166.9 kB | **99.4 kB** |
| unpacked | 632.7 kB | **321.0 kB** |
| files | 187 | **65** |

`dist/index.js`, the `bin`, and `skills/` all remain present.

### What's NOT in this PR

- No source/runtime changes — packaging + CI config only.
- No version bump (release is a separate gated step).

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 1133/1133 passing
- [x] `npm pack --dry-run` confirms maps/d.ts excluded, `dist/index.js` + `skills/` retained
- [x] New guard command runs locally: 291552 bytes JS, under 400 KB ceiling
- [ ] CI green on PR