### PR TITLE
chore(release): v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-05-28
+
 ### Changed
 
 - **Smaller npm package** — source maps (`*.map`) and type declarations (`*.d.ts`) are now excluded from the published tarball via the `files` allowlist. They are build artifacts that `npx lumira` never loads. Unpacked install size drops ~50% (≈633 KB → ≈321 KB); the tarball shrinks from ~167 KB to ~99 KB.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lumira",
-  "version": "1.5.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lumira",
-      "version": "1.5.0",
+      "version": "1.6.1",
       "license": "MIT",
       "bin": {
         "lumira": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Real-time statusline HUD for Claude Code and Qwen Code. Includes session analytics CLI, API latency overhead widget, 7d quota projection, auto-compact proximity warnings, themes, and powerline. Zero deps.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Patch release. Packaging-only — no runtime/source changes.

- Excludes `*.map` and `*.d.ts` from the published npm package (PR #149).
- Bundle size guard now measures shipped `.js` only.

Tarball ~167 KB → ~99 KB; unpacked ~633 KB → ~321 KB.

## Release checklist

- [x] Version bumped to 1.6.1 in `package.json`
- [x] CHANGELOG `[Unreleased]` → `[1.6.1] - 2026-05-28`
- [ ] CI green → merge → tag `v1.6.1` → `release.yml` auto-publishes to npm