### PR TITLE
refactor(render): consolidate pace + projection burn-rate math

### DIFF
--- a/src/render/burn-math.ts
+++ b/src/render/burn-math.ts
@@ -1,0 +1,23 @@
+export interface BurnExtrapolation {
+  burnRateSec: number;
+  elapsedSec: number;
+  remainingSec: number;
+  delta: number;
+  timeToExhaustSec: number;
+  willExhaustBefore: boolean;
+}
+
+export function computeBurnExtrapolation(
+  usedPct: number,
+  elapsedSec: number,
+  remainingSec: number,
+): BurnExtrapolation {
+  const windowSec = elapsedSec + remainingSec;
+  const elapsedPct = (elapsedSec / windowSec) * 100;
+  const delta = usedPct - elapsedPct;
+  const burnRateSec = usedPct / elapsedSec;
+  const timeToExhaustSec = (100 - usedPct) / burnRateSec;
+  const willExhaustBefore = timeToExhaustSec < remainingSec;
+
+  return { burnRateSec, elapsedSec, remainingSec, delta, timeToExhaustSec, willExhaustBefore };
+}

--- a/src/render/pace.ts
+++ b/src/render/pace.ts
@@ -1,4 +1,5 @@
 import { debug } from '../utils/debug.js';
+import { computeBurnExtrapolation } from './burn-math.js';
 
 const log = debug('pace');
 
@@ -28,17 +29,13 @@ export function computePaceDelta(
     return null;
   }
 
-  const elapsedPct = (elapsedSec / totalWindowSec) * 100;
-  const delta = usedPercentage - elapsedPct;
-
-  let timeToExhaustion: number | null = null;
-  if (delta > 0 && usedPercentage > 0) {
-    // burn rate = usedPercentage / elapsedSec (pct per second)
-    // time to exhaust remaining (100 - usedPercentage) pct at that rate
-    timeToExhaustion = (100 - usedPercentage) / (usedPercentage / elapsedSec) / 60;
-  }
+  const burn = computeBurnExtrapolation(usedPercentage, elapsedSec, remainingSec);
+  const timeToExhaustion = burn.delta > 0 && usedPercentage > 0
+    ? burn.timeToExhaustSec / 60
+    : null;
 
   if (log.enabled) {
+    const elapsedPct = (elapsedSec / totalWindowSec) * 100;
     log({
       usedPercentage,
       resetsAt,
@@ -48,12 +45,12 @@ export function computePaceDelta(
       remainingSec: Math.round(remainingSec),
       remainingMin: Math.round(remainingSec / 60),
       elapsedPct: Math.round(elapsedPct * 10) / 10,
-      delta: Math.round(delta * 10) / 10,
+      delta: Math.round(burn.delta * 10) / 10,
       timeToExhaustionMin: timeToExhaustion != null ? Math.round(timeToExhaustion) : null,
     });
   }
 
-  return { delta, timeToExhaustion };
+  return { delta: burn.delta, timeToExhaustion };
 }
 
 export function formatPaceDelta(pace: PaceDelta): string {

--- a/src/render/quota-projection.ts
+++ b/src/render/quota-projection.ts
@@ -1,4 +1,5 @@
 import { debug } from '../utils/debug.js';
+import { computeBurnExtrapolation } from './burn-math.js';
 
 const log = debug('quota-projection');
 
@@ -44,23 +45,20 @@ export function computeQuotaProjection(
     return null;
   }
 
-  // burnRate is in pct-per-second
-  const burnRate = usedPct / elapsedSec;
-  const timeToExhaustSec = (100 - usedPct) / burnRate;
-  const willExhaustBefore = timeToExhaustSec < remainingSec;
+  const burn = computeBurnExtrapolation(usedPct, elapsedSec, remainingSec);
 
   if (log.enabled) {
     log({
       usedPct,
       elapsedSec: Math.round(elapsedSec),
       remainingSec: Math.round(remainingSec),
-      burnRate,
-      timeToExhaustSec: Math.round(timeToExhaustSec),
-      willExhaustBefore,
+      burnRate: burn.burnRateSec,
+      timeToExhaustSec: Math.round(burn.timeToExhaustSec),
+      willExhaustBefore: burn.willExhaustBefore,
     });
   }
 
-  return { timeToExhaustSec, willExhaustBefore };
+  return { timeToExhaustSec: burn.timeToExhaustSec, willExhaustBefore: burn.willExhaustBefore };
 }
 
 /**

--- a/tests/render/burn-math.test.ts
+++ b/tests/render/burn-math.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest';
+import { computeBurnExtrapolation } from '../../src/render/burn-math.js';
+
+const NOW = 1_000_000;
+const WINDOW_5H = 5 * 3600;  // 18000s
+const WINDOW_7D = 7 * 24 * 3600;  // 604800s
+
+describe('computeBurnExtrapolation', () => {
+  describe('basic math', () => {
+    it('computes burnRateSec as usedPct / elapsedSec', () => {
+      // 25% of 5h elapsed (4500s), 50% used → burnRate = 50/4500
+      const elapsedSec = WINDOW_5H * 0.25;
+      const result = computeBurnExtrapolation(50, elapsedSec, WINDOW_5H - elapsedSec);
+      expect(result.burnRateSec).toBeCloseTo(50 / 4500, 10);
+    });
+
+    it('returns elapsedSec and remainingSec unchanged', () => {
+      const elapsedSec = 3600;
+      const remainingSec = WINDOW_5H - elapsedSec;
+      const result = computeBurnExtrapolation(25, elapsedSec, remainingSec);
+      expect(result.elapsedSec).toBe(elapsedSec);
+      expect(result.remainingSec).toBe(remainingSec);
+    });
+
+    it('computes delta = usedPct - elapsedPct', () => {
+      // 25% elapsed of 5h, 50% used → elapsedPct = 25, delta = 25
+      const elapsedSec = WINDOW_5H * 0.25;
+      const remainingSec = WINDOW_5H - elapsedSec;
+      const result = computeBurnExtrapolation(50, elapsedSec, remainingSec);
+      expect(result.delta).toBeCloseTo(25, 5);
+    });
+
+    it('computes negative delta when usage is below pace', () => {
+      // 75% elapsed, 25% used → delta = 25 - 75 = -50
+      const elapsedSec = WINDOW_5H * 0.75;
+      const remainingSec = WINDOW_5H - elapsedSec;
+      const result = computeBurnExtrapolation(25, elapsedSec, remainingSec);
+      expect(result.delta).toBeCloseTo(-50, 5);
+    });
+
+    it('delta is near zero when on pace', () => {
+      const elapsedSec = WINDOW_5H * 0.5;
+      const remainingSec = WINDOW_5H - elapsedSec;
+      const result = computeBurnExtrapolation(50, elapsedSec, remainingSec);
+      expect(Math.abs(result.delta)).toBeLessThan(0.01);
+    });
+
+    it('computes timeToExhaustSec = (100 - usedPct) / burnRateSec', () => {
+      // 50% used at 4500s elapsed → burnRate = 50/4500 → TTE = 50 / (50/4500) = 4500s
+      const elapsedSec = WINDOW_5H * 0.25;
+      const remainingSec = WINDOW_5H - elapsedSec;
+      const result = computeBurnExtrapolation(50, elapsedSec, remainingSec);
+      expect(result.timeToExhaustSec).toBeCloseTo(4500, 0);
+    });
+
+    it('TTE in seconds matches pace.ts timeToExhaustion * 60', () => {
+      // 50% used at 4500s elapsed → TTE = 4500s = 75 min
+      const elapsedSec = 4500;
+      const remainingSec = WINDOW_5H - elapsedSec;
+      const result = computeBurnExtrapolation(50, elapsedSec, remainingSec);
+      expect(result.timeToExhaustSec / 60).toBeCloseTo(75, 5);
+    });
+
+    it('willExhaustBefore=true when TTE < remainingSec', () => {
+      // 1d elapsed of 7d, 50% used → TTE = 86400s < 518400s remaining
+      const elapsedSec = 86400;
+      const remainingSec = WINDOW_7D - elapsedSec;
+      const result = computeBurnExtrapolation(50, elapsedSec, remainingSec);
+      expect(result.willExhaustBefore).toBe(true);
+    });
+
+    it('willExhaustBefore=false when TTE > remainingSec', () => {
+      // 6d elapsed, 5% used → TTE >> 1d remaining
+      const elapsedSec = 518400;
+      const remainingSec = WINDOW_7D - elapsedSec;
+      const result = computeBurnExtrapolation(5, elapsedSec, remainingSec);
+      expect(result.willExhaustBefore).toBe(false);
+    });
+
+    it('willExhaustBefore=false when TTE === remainingSec (strict less than)', () => {
+      // 50% elapsed, 50% used → TTE = elapsedSec = remainingSec exactly
+      const elapsedSec = WINDOW_7D / 2;
+      const remainingSec = WINDOW_7D - elapsedSec;
+      const result = computeBurnExtrapolation(50, elapsedSec, remainingSec);
+      expect(result.willExhaustBefore).toBe(false);
+    });
+  });
+
+  describe('delta > 0 ↔ willExhaustBefore equivalence', () => {
+    it('delta > 0 implies willExhaustBefore=true', () => {
+      // 50% used at 25% elapsed → delta = +25
+      const elapsedSec = WINDOW_7D * 0.25;
+      const remainingSec = WINDOW_7D - elapsedSec;
+      const result = computeBurnExtrapolation(50, elapsedSec, remainingSec);
+      expect(result.delta).toBeGreaterThan(0);
+      expect(result.willExhaustBefore).toBe(true);
+    });
+
+    it('delta < 0 implies willExhaustBefore=false', () => {
+      // 25% used at 75% elapsed → delta = -50
+      const elapsedSec = WINDOW_7D * 0.75;
+      const remainingSec = WINDOW_7D - elapsedSec;
+      const result = computeBurnExtrapolation(25, elapsedSec, remainingSec);
+      expect(result.delta).toBeLessThan(0);
+      expect(result.willExhaustBefore).toBe(false);
+    });
+
+    it('delta === 0 (exactly on pace) implies willExhaustBefore=false', () => {
+      // 50% used at 50% elapsed → delta = 0, TTE = remainingSec exactly
+      const elapsedSec = WINDOW_7D / 2;
+      const remainingSec = WINDOW_7D - elapsedSec;
+      const result = computeBurnExtrapolation(50, elapsedSec, remainingSec);
+      expect(result.delta).toBeCloseTo(0, 10);
+      expect(result.willExhaustBefore).toBe(false);
+    });
+
+    it('delta > 0 and willExhaustBefore always agree across multiple scenarios', () => {
+      const scenarios = [
+        { usedPct: 10, elapsedFrac: 0.5 },   // delta < 0
+        { usedPct: 60, elapsedFrac: 0.5 },   // delta > 0
+        { usedPct: 99, elapsedFrac: 0.1 },   // delta >> 0
+        { usedPct: 1,  elapsedFrac: 0.9 },   // delta << 0
+      ];
+      for (const { usedPct, elapsedFrac } of scenarios) {
+        const elapsedSec = WINDOW_7D * elapsedFrac;
+        const remainingSec = WINDOW_7D - elapsedSec;
+        const r = computeBurnExtrapolation(usedPct, elapsedSec, remainingSec);
+        expect(r.delta > 0).toBe(r.willExhaustBefore);
+      }
+    });
+  });
+
+  describe('edge cases', () => {
+    it('usedPct = 100 → TTE = 0, willExhaustBefore=true (TTE 0 < any positive remainingSec)', () => {
+      const elapsedSec = WINDOW_5H * 0.5;
+      const remainingSec = WINDOW_5H - elapsedSec;
+      const result = computeBurnExtrapolation(100, elapsedSec, remainingSec);
+      expect(result.timeToExhaustSec).toBeCloseTo(0, 5);
+      expect(result.willExhaustBefore).toBe(true);
+    });
+
+    it('usedPct = 0 → burnRateSec = 0, timeToExhaustSec = Infinity, willExhaustBefore=false', () => {
+      const elapsedSec = WINDOW_5H * 0.5;
+      const remainingSec = WINDOW_5H - elapsedSec;
+      const result = computeBurnExtrapolation(0, elapsedSec, remainingSec);
+      expect(result.burnRateSec).toBe(0);
+      expect(result.timeToExhaustSec).toBe(Infinity);
+      expect(result.willExhaustBefore).toBe(false);
+    });
+
+    it('windowSec passed indirectly via elapsedSec+remainingSec: different windows produce same math given same fractions', () => {
+      // The function only needs elapsedSec, remainingSec — not windowSec directly
+      const elapsedFrac = 0.25;
+      const usedPct = 50;
+
+      const elapsed5h = WINDOW_5H * elapsedFrac;
+      const result5h = computeBurnExtrapolation(usedPct, elapsed5h, WINDOW_5H - elapsed5h);
+
+      const elapsed7d = WINDOW_7D * elapsedFrac;
+      const result7d = computeBurnExtrapolation(usedPct, elapsed7d, WINDOW_7D - elapsed7d);
+
+      // delta is the same (purely from fraction)
+      expect(result5h.delta).toBeCloseTo(result7d.delta, 5);
+      // Both are ahead → willExhaustBefore=true
+      expect(result5h.willExhaustBefore).toBe(true);
+      expect(result7d.willExhaustBefore).toBe(true);
+    });
+
+    it('deterministic — same inputs same output', () => {
+      const elapsedSec = 3600;
+      const remainingSec = WINDOW_5H - elapsedSec;
+      const a = computeBurnExtrapolation(40, elapsedSec, remainingSec);
+      const b = computeBurnExtrapolation(40, elapsedSec, remainingSec);
+      expect(a).toEqual(b);
+    });
+
+    it('very small elapsedSec (1s) does not throw or produce NaN for normal usedPct', () => {
+      const result = computeBurnExtrapolation(1, 1, WINDOW_5H - 1);
+      expect(Number.isFinite(result.burnRateSec)).toBe(true);
+      expect(Number.isFinite(result.timeToExhaustSec)).toBe(true);
+      expect(Number.isFinite(result.delta)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #131. Internal refactor — no behavior change, no user-facing change.

`computePaceDelta` (5h) and `computeQuotaProjection` (7d) implemented the same burn-rate extrapolation with different output shapes. Extracted a shared `computeBurnExtrapolation(usedPct, elapsedSec, remainingSec)` in the new `src/render/burn-math.ts`; both are now thin adapters. A future formula fix lives in one place.

## Changes

- **NEW** `src/render/burn-math.ts` — `computeBurnExtrapolation` + `BurnExtrapolation` interface.
- `src/render/pace.ts` — `computePaceDelta` delegates; `PaceDelta` unchanged. The `delta > 0 && usedPct > 0` guard (null TTE at 0%) preserved in the adapter.
- `src/render/quota-projection.ts` — `computeQuotaProjection` delegates; `QuotaProjection` unchanged.
- **NEW** `tests/render/burn-math.test.ts` — 19 tests: boundaries, NaN, div-by-zero, `delta > 0 ↔ willExhaustBefore` equivalence.

## What's NOT in this PR

- No change to output shapes, no renderer call-site changes, no new features/deps. The `severity` typing refactor this unblocks is out of scope.

## Test plan

- [x] pace.test.ts + quota-projection.test.ts pass **unmodified** (behavior guard).
- [x] lint clean.
- [x] npm test — 1152 passed (1133 + 19 new).
- [ ] CI green.