### PR TITLE
feat(render): added-dirs badge + worktree breadcrumb on line1

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -325,6 +325,8 @@ const PRESET_DEFS: Record<NonNullable<HudConfig['preset']>, PresetDef> = {
       // surface (see burnRate/rateLimits/paceDelta etc. above). Default
       // remains true; users on full/balanced see the widget out of the box.
       apiLatency: false,
+      addedDirs: false,
+      worktreeBreadcrumb: false,
     },
   },
 };

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -85,6 +85,12 @@ export interface NormalizedInput {
   /** Worktree name */
   worktreeName?: string;
 
+  /** Count of directories added via /add-dir or --add-dir (≥ 2.1.x) */
+  addedDirsCount?: number;
+
+  /** Original branch before entering the worktree session (≥ 2.1.x) */
+  worktreeOriginalBranch?: string;
+
   /** Reasoning effort level (≥ 2.1.x stdin, falls back to transcript regex) */
   effortLevel?: string;
 
@@ -293,6 +299,16 @@ export function normalize(input: RawInput): NormalizedInput {
       ? sanitizeTermString(claude.effort.level)
       : undefined,
     worktreeName: input.worktree?.name ? sanitizeTermString(input.worktree.name) : undefined,
+    addedDirsCount: (() => {
+      const dirs = (input as ClaudeCodeInput).workspace?.added_dirs;
+      if (!Array.isArray(dirs) || dirs.length === 0) return undefined;
+      return dirs.length;
+    })(),
+    worktreeOriginalBranch: (() => {
+      const orig = (input as ClaudeCodeInput).worktree?.original_branch;
+      if (!orig || typeof orig !== 'string') return undefined;
+      return sanitizeTermString(orig);
+    })(),
     rateLimits,
     cacheHitRate,
     raw: input,

--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -52,9 +52,10 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
     left.push(input.addedDirsCount >= 5 ? c.orange(badge) : c.dim(badge));
   }
 
-  // Worktree origin-branch breadcrumb — only when original_branch is present and differs from current
+  // Worktree origin-branch breadcrumb — only when original_branch is present,
+  // there IS a current branch to contrast against (anchor), and they differ.
   const branchForBreadcrumb = input.gitBranch || git.branch;
-  if (display.worktreeBreadcrumb && input.worktreeOriginalBranch && input.worktreeOriginalBranch !== branchForBreadcrumb) {
+  if (display.worktreeBreadcrumb && input.worktreeOriginalBranch && branchForBreadcrumb && input.worktreeOriginalBranch !== branchForBreadcrumb) {
     const truncated = truncField(input.worktreeOriginalBranch, 15);
     left.push(c.gray(`↳ ${truncated}`));
   }

--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -46,6 +46,19 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
     }
   }
 
+  // Added dirs badge — only when count > 0; warning color at >= 5
+  if (display.addedDirs && input.addedDirsCount != null && input.addedDirsCount > 0) {
+    const badge = `+${input.addedDirsCount} dirs`;
+    left.push(input.addedDirsCount >= 5 ? c.orange(badge) : c.dim(badge));
+  }
+
+  // Worktree origin-branch breadcrumb — only when original_branch is present and differs from current
+  const branchForBreadcrumb = input.gitBranch || git.branch;
+  if (display.worktreeBreadcrumb && input.worktreeOriginalBranch && input.worktreeOriginalBranch !== branchForBreadcrumb) {
+    const truncated = truncField(input.worktreeOriginalBranch, 15);
+    left.push(c.gray(`↳ ${truncated}`));
+  }
+
   // Duration (Claude only)
   if (display.duration && input.durationMs != null) {
     right.push(c.dim(`${icons.clock} ${formatDuration(input.durationMs)}`));

--- a/src/render/powerline-line1.ts
+++ b/src/render/powerline-line1.ts
@@ -23,19 +23,21 @@ import {
 /**
  * Build the line1 segment list for the powerline renderer. Segment priorities
  * control which get dropped first when the terminal is narrow (lower = drops first):
- *   model:        100  (always kept)
- *   branch:        80
- *   dir:           60
- *   task:          40
- *   duration:      35
- *   memory:        30
- *   tokenSpeed:    25
- *   linesChanged:  24
- *   worktree:      23
- *   agent:         22
- *   sessionName:   21
- *   version:       20
- *   style:         18  (dropped first)
+ *   model:             100  (always kept)
+ *   branch:             80
+ *   dir:                60
+ *   addedDirs:          61  (just after dir; data-gated, renders nothing when 0)
+ *   task:               40
+ *   duration:           35
+ *   memory:             30
+ *   tokenSpeed:         25
+ *   linesChanged:       24
+ *   worktree:           23
+ *   worktreeBreadcrumb: 22.5 (between worktree@23 and agent@22; data-gated)
+ *   agent:              22
+ *   sessionName:        21
+ *   version:            20
+ *   style:              18  (dropped first)
  */
 function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: import('./colors.js').Colors): PowerlineSegment[] {
   const { input, git, transcript, config: { display }, icons, memory, tokenSpeed } = ctx;
@@ -87,6 +89,12 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: import(
       fg: palette.fg,
       priority: 60,
     });
+  }
+
+  if (display.addedDirs && input.addedDirsCount != null && input.addedDirsCount > 0) {
+    const badge = `+${input.addedDirsCount} dirs`;
+    const bg = input.addedDirsCount >= 5 ? palette.taskBg : palette.versionBg;
+    segments.push({ text: badge, bg, fg: palette.fg, priority: 61 });
   }
 
   const activeTask = getActiveTodo(transcript);
@@ -152,6 +160,18 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: import(
       fg: palette.fg,
       priority: 23,
     });
+  }
+
+  if (display.worktreeBreadcrumb && input.worktreeOriginalBranch) {
+    const currentBranch = input.gitBranch || git.branch;
+    if (input.worktreeOriginalBranch !== currentBranch) {
+      segments.push({
+        text: `↳ ${truncField(input.worktreeOriginalBranch, 15)}`,
+        bg: palette.versionBg,
+        fg: palette.fg,
+        priority: 22.5,
+      });
+    }
   }
 
   // Mirrors classic line1: prefer the explicit input.agentName (subagent

--- a/src/render/powerline-line1.ts
+++ b/src/render/powerline-line1.ts
@@ -26,7 +26,7 @@ import {
  *   model:             100  (always kept)
  *   branch:             80
  *   dir:                60
- *   addedDirs:          61  (just after dir; data-gated, renders nothing when 0)
+ *   addedDirs:          59  (renders after dir; data-gated; evicts before dir under pressure)
  *   task:               40
  *   duration:           35
  *   memory:             30
@@ -94,7 +94,11 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: import(
   if (display.addedDirs && input.addedDirsCount != null && input.addedDirsCount > 0) {
     const badge = `+${input.addedDirsCount} dirs`;
     const bg = input.addedDirsCount >= 5 ? palette.taskBg : palette.versionBg;
-    segments.push({ text: badge, bg, fg: palette.fg, priority: 61 });
+    // Priority 59 — one BELOW directory@60. The badge annotates the directory,
+    // so it must evict before the directory under narrow-terminal pressure
+    // (applyPriorityEviction drops lowest-priority first). Insertion order is
+    // unchanged, so it still renders right after the directory.
+    segments.push({ text: badge, bg, fg: palette.fg, priority: 59 });
   }
 
   const activeTask = getActiveTodo(transcript);
@@ -164,7 +168,9 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: import(
 
   if (display.worktreeBreadcrumb && input.worktreeOriginalBranch) {
     const currentBranch = input.gitBranch || git.branch;
-    if (input.worktreeOriginalBranch !== currentBranch) {
+    // Only render when there is a current branch to contrast against — the
+    // breadcrumb is meaningless without an anchor (no branch shown / branch off).
+    if (currentBranch && input.worktreeOriginalBranch !== currentBranch) {
       segments.push({
         text: `↳ ${truncField(input.worktreeOriginalBranch, 15)}`,
         bg: palette.versionBg,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export interface ClaudeCodeInput {
   session_id: string;
   session_name?: string;
   cwd?: string;
-  workspace?: { current_dir: string };
+  workspace?: { current_dir: string; added_dirs?: string[] };
   context_window: {
     context_window_size?: number;
     used_percentage: number;
@@ -33,7 +33,7 @@ export interface ClaudeCodeInput {
   output_style?: { name: string };
   version?: string;
   agent?: { name: string };
-  worktree?: { name: string };
+  worktree?: { name: string; original_branch?: string };
   vim?: { mode: string };
   rate_limits?: {
     five_hour?: RateLimitWindow;
@@ -306,6 +306,8 @@ export interface DisplayToggles {
   agents: boolean;
   health: boolean;
   apiLatency: boolean;
+  addedDirs: boolean;
+  worktreeBreadcrumb: boolean;
   /**
    * Percentage at which the context bar turns orange and shows the fire icon. Default 65. Clamped [0,100].
    * Setting this ≤ 50 collapses the yellow zone; the bar jumps green→orange directly at this value.
@@ -394,6 +396,8 @@ export const DEFAULT_DISPLAY: DisplayToggles = {
   agents: true,
   health: false,
   apiLatency: true,
+  addedDirs: true,
+  worktreeBreadcrumb: true,
   contextWarningThreshold: DEFAULT_CONTEXT_WARNING_THRESHOLD,
   contextCriticalThreshold: DEFAULT_CONTEXT_CRITICAL_THRESHOLD,
 };

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -53,6 +53,9 @@ describe('loadConfig', () => {
     expect(c.display.contextBar).toBe(true);
     // apiLatency stays on so balanced users see the v1.4.0 widget out of the box
     expect(c.display.apiLatency).toBe(true);
+    // addedDirs and worktreeBreadcrumb default ON in balanced (data-gated, no clutter)
+    expect(c.display.addedDirs).toBe(true);
+    expect(c.display.worktreeBreadcrumb).toBe(true);
   });
 
   it('preset minimal disables most toggles', () => {
@@ -72,6 +75,9 @@ describe('loadConfig', () => {
     // widgets, so the toggle matches the dead-toggle convention used by
     // burnRate/rateLimits/paceDelta/etc. above.
     expect(c.display.apiLatency).toBe(false);
+    // addedDirs and worktreeBreadcrumb are OFF in minimal (too noisy for single-line)
+    expect(c.display.addedDirs).toBe(false);
+    expect(c.display.worktreeBreadcrumb).toBe(false);
   });
 
   it('user display overrides win over preset', () => {
@@ -93,6 +99,9 @@ describe('loadConfig', () => {
     expect(c.display.version).toBe(true);
     // apiLatency is the v1.4.0 headline widget — on by default in full.
     expect(c.display.apiLatency).toBe(true);
+    // addedDirs and worktreeBreadcrumb are ON in full (data-gated, no clutter when data absent)
+    expect(c.display.addedDirs).toBe(true);
+    expect(c.display.worktreeBreadcrumb).toBe(true);
   });
   it('ignores invalid preset', () => {
     mkdirSync(dir, { recursive: true });

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -581,6 +581,70 @@ describe('apiDurationMs normalization', () => {
   });
 });
 
+describe('addedDirsCount normalization (issue #129)', () => {
+  const base: ClaudeCodeInput = {
+    model: 'Claude',
+    session_id: 's',
+    context_window: { used_percentage: 10, remaining_percentage: 90 },
+    cost: { total_cost_usd: 0, total_duration_ms: 0 },
+  };
+
+  it('normalizes count when added_dirs is a non-empty array', () => {
+    const input: ClaudeCodeInput = { ...base, workspace: { current_dir: '/tmp', added_dirs: ['/a', '/b', '/c'] } };
+    expect(normalize(input).addedDirsCount).toBe(3);
+  });
+
+  it('returns undefined when added_dirs is an empty array', () => {
+    const input: ClaudeCodeInput = { ...base, workspace: { current_dir: '/tmp', added_dirs: [] } };
+    expect(normalize(input).addedDirsCount).toBeUndefined();
+  });
+
+  it('returns undefined when added_dirs is missing from workspace', () => {
+    const input: ClaudeCodeInput = { ...base, workspace: { current_dir: '/tmp' } };
+    expect(normalize(input).addedDirsCount).toBeUndefined();
+  });
+
+  it('returns undefined when workspace is absent entirely', () => {
+    expect(normalize(base).addedDirsCount).toBeUndefined();
+  });
+});
+
+describe('worktreeOriginalBranch normalization (issue #130)', () => {
+  const base: ClaudeCodeInput = {
+    model: 'Claude',
+    session_id: 's',
+    context_window: { used_percentage: 10, remaining_percentage: 90 },
+    cost: { total_cost_usd: 0, total_duration_ms: 0 },
+  };
+
+  it('extracts worktreeOriginalBranch when present', () => {
+    const input: ClaudeCodeInput = { ...base, worktree: { name: 'feat-wt', original_branch: 'main' } };
+    expect(normalize(input).worktreeOriginalBranch).toBe('main');
+  });
+
+  it('returns undefined when original_branch is absent', () => {
+    const input: ClaudeCodeInput = { ...base, worktree: { name: 'feat-wt' } };
+    expect(normalize(input).worktreeOriginalBranch).toBeUndefined();
+  });
+
+  it('returns undefined when worktree is absent', () => {
+    expect(normalize(base).worktreeOriginalBranch).toBeUndefined();
+  });
+
+  it('should_sanitize_original_branch_string_no_control_chars_no_zero_width_unicode', () => {
+    // sanitizeTermString strips C0 controls (\x00-\x1f) and zero-width Unicode.
+    // ESC (0x1b) is stripped; the remaining ANSI suffix chars are printable ASCII.
+    // Zero-width space (U+200B) is stripped.
+    const input: ClaudeCodeInput = { ...base, worktree: { name: 'wt', original_branch: 'main​suffix' } };
+    const result = normalize(input).worktreeOriginalBranch;
+    expect(result).toBe('mainsuffix');
+    // ESC itself is stripped
+    const input2: ClaudeCodeInput = { ...base, worktree: { name: 'wt', original_branch: 'pre\x1bpost' } };
+    const result2 = normalize(input2).worktreeOriginalBranch;
+    expect(result2).not.toContain('\x1b');
+  });
+});
+
 describe('isQwenInput discriminant', () => {
   it('returns true for valid Qwen input', () => {
     expect(isQwenInput(qwenInput)).toBe(true);

--- a/tests/render/line1.test.ts
+++ b/tests/render/line1.test.ts
@@ -6,6 +6,7 @@ import type { ClaudeCodeInput, GitStatus, RenderContext } from '../../src/types.
 import { NERD_ICONS } from '../../src/render/icons.js';
 import { normalize } from '../../src/normalize.js';
 import { displayWidth } from '../../src/render/text.js';
+import { applyPreset } from '../../src/config.js';
 
 const c = createColors('named');
 
@@ -412,7 +413,11 @@ describe('renderLine1', () => {
     });
 
     it('should_not_render_breadcrumb_in_minimal_preset_toggle_defaults_to_false', () => {
-      const config = { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, worktreeBreadcrumb: false } };
+      // Exercise the real minimal-preset path: applyPreset must turn the
+      // breadcrumb off (DEFAULT_DISPLAY has it ON) so minimal stays clean.
+      const config = { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } };
+      applyPreset(config, 'minimal');
+      expect(config.display.worktreeBreadcrumb).toBe(false);
       const ctx = makeCtx(
         { git: { branch: 'feat/my-feature', staged: 0, modified: 0, untracked: 0 }, config },
         { worktree: { name: 'wt', original_branch: 'main' } },

--- a/tests/render/line1.test.ts
+++ b/tests/render/line1.test.ts
@@ -285,4 +285,140 @@ describe('renderLine1', () => {
       expect(withEmpty).toBe(without);
     });
   });
+
+  // ── Added dirs badge (issue #129) ────────────────────────────────────
+  describe('added dirs badge', () => {
+    it('should_not_show_added_dirs_badge_when_display_addedDirs_is_false', () => {
+      const ctx = makeCtx(
+        { config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, addedDirs: false } } },
+        { workspace: { current_dir: '/home/user/project', added_dirs: ['/a', '/b'] } },
+      );
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out).not.toContain('dirs');
+    });
+
+    it('should_show_added_dirs_badge_when_count_gt_0_and_display_addedDirs_is_true', () => {
+      const ctx = makeCtx(
+        { config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, addedDirs: true } } },
+        { workspace: { current_dir: '/home/user/project', added_dirs: ['/a', '/b', '/c'] } },
+      );
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out).toContain('+3 dirs');
+    });
+
+    it('should_not_show_badge_when_added_dirs_is_empty_array', () => {
+      const ctx = makeCtx(
+        { config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, addedDirs: true } } },
+        { workspace: { current_dir: '/home/user/project', added_dirs: [] } },
+      );
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out).not.toContain('dirs');
+    });
+
+    it('should_not_show_badge_when_added_dirs_is_missing_graceful_degrade', () => {
+      const ctx = makeCtx(
+        { config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, addedDirs: true } } },
+        { workspace: { current_dir: '/home/user/project' } },
+      );
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out).not.toContain('dirs');
+    });
+
+    it('should_apply_warning_color_to_badge_when_count_gte_5', () => {
+      const ctx = makeCtx(
+        { config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, addedDirs: true } } },
+        { workspace: { current_dir: '/home/user/project', added_dirs: ['/1', '/2', '/3', '/4', '/5'] } },
+      );
+      const raw = renderLine1(ctx, c);
+      // orange = 256-color 208 escape
+      expect(raw).toContain('\x1b[38;5;208m');
+      expect(stripAnsi(raw)).toContain('+5 dirs');
+    });
+
+    it('should_format_count_correctly_plus_3_dirs_for_count_3', () => {
+      const ctx = makeCtx(
+        { config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, addedDirs: true } } },
+        { workspace: { current_dir: '/home/user/project', added_dirs: ['/x', '/y', '/z'] } },
+      );
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out).toContain('+3 dirs');
+      expect(out).not.toContain('+4 dirs');
+    });
+  });
+
+  // ── Worktree origin-branch breadcrumb (issue #130) ───────────────────
+  describe('worktree breadcrumb', () => {
+    it('should_render_breadcrumb_when_original_branch_present_and_differs_from_current', () => {
+      const ctx = makeCtx(
+        { git: { branch: 'feat/my-feature', staged: 0, modified: 0, untracked: 0 } },
+        { worktree: { name: 'feat-wt', original_branch: 'main' } },
+      );
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out).toContain('↳ main');
+    });
+
+    it('should_not_render_breadcrumb_when_original_branch_is_missing', () => {
+      const ctx = makeCtx(
+        { git: { branch: 'feat/x', staged: 0, modified: 0, untracked: 0 } },
+        { worktree: { name: 'feat-wt' } },
+      );
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out).not.toContain('↳');
+    });
+
+    it('should_not_render_breadcrumb_when_original_branch_equals_current_branch', () => {
+      const ctx = makeCtx(
+        { git: { branch: 'main', staged: 0, modified: 0, untracked: 0 } },
+        { worktree: { name: 'wt', original_branch: 'main' } },
+      );
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out).not.toContain('↳');
+    });
+
+    it('should_sanitize_original_branch_string_no_control_chars_no_zero_width_unicode', () => {
+      // U+200B (zero-width space) is stripped by sanitizeTermString
+      const ctx = makeCtx(
+        { git: { branch: 'feat/x', staged: 0, modified: 0, untracked: 0 } },
+        { worktree: { name: 'wt', original_branch: 'main​suffix' } },
+      );
+      const out = stripAnsi(renderLine1(ctx, c));
+      // zero-width space stripped → appears as 'mainsuffix'
+      expect(out).toContain('↳ mainsuffix');
+      expect(out).not.toContain('​');
+    });
+
+    it('should_truncate_long_original_branch_names_to_15_chars', () => {
+      const longBranch = 'feat/' + 'x'.repeat(50);
+      const ctx = makeCtx(
+        { git: { branch: 'develop', staged: 0, modified: 0, untracked: 0 } },
+        { worktree: { name: 'wt', original_branch: longBranch } },
+      );
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out).toContain('↳ ');
+      expect(out).not.toContain(longBranch);
+      expect(out).toContain('…');
+    });
+
+    it('should_respect_display_worktreeBreadcrumb_toggle', () => {
+      const ctx = makeCtx(
+        {
+          git: { branch: 'feat/my-feature', staged: 0, modified: 0, untracked: 0 },
+          config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, worktreeBreadcrumb: false } },
+        },
+        { worktree: { name: 'wt', original_branch: 'main' } },
+      );
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out).not.toContain('↳');
+    });
+
+    it('should_not_render_breadcrumb_in_minimal_preset_toggle_defaults_to_false', () => {
+      const config = { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, worktreeBreadcrumb: false } };
+      const ctx = makeCtx(
+        { git: { branch: 'feat/my-feature', staged: 0, modified: 0, untracked: 0 }, config },
+        { worktree: { name: 'wt', original_branch: 'main' } },
+      );
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out).not.toContain('↳');
+    });
+  });
 });

--- a/tests/render/powerline-line1.test.ts
+++ b/tests/render/powerline-line1.test.ts
@@ -868,7 +868,13 @@ describe('renderPowerlineLine1', () => {
       const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
       expect(out).toContain('+5 dirs');
 
-      const withDirs4 = makeCtx({
+      // Pin the actual warning bg: DEFAULT_POWERLINE_PALETTE.taskBg is {128,96,24},
+      // rendered as a truecolor bg escape. count>=5 must use taskBg.
+      const warnRaw = renderPowerlineLine1(ctx, 'truecolor', null);
+      expect(warnRaw).toContain('\x1b[48;2;128;96;24m');
+
+      // count<5 uses versionBg {64,64,72} (not the taskBg warning slot).
+      const normCtx = makeCtx({
         input: {
           ...normalize({
             model: 'Claude',
@@ -880,9 +886,8 @@ describe('renderPowerlineLine1', () => {
         },
         config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, addedDirs: true } },
       });
-      const outWarn = renderPowerlineLine1(ctx, 'truecolor', null);
-      const outNorm = renderPowerlineLine1(withDirs4, 'truecolor', null);
-      expect(outWarn).not.toBe(outNorm);
+      const normRaw = renderPowerlineLine1(normCtx, 'truecolor', null);
+      expect(normRaw).toContain('\x1b[48;2;64;64;72m');
     });
   });
 

--- a/tests/render/powerline-line1.test.ts
+++ b/tests/render/powerline-line1.test.ts
@@ -793,4 +793,213 @@ describe('renderPowerlineLine1', () => {
       expect(raw).toContain('\x1b[2m');
     });
   });
+
+  // ── Added dirs segment (issue #129) ─────────────────────────────────
+  describe('added dirs segment', () => {
+    it('should_add_segment_for_added_dirs_when_display_addedDirs_is_true_and_count_gt_0', () => {
+      const ctx = makeCtx({
+        input: {
+          ...normalize({
+            model: 'Claude',
+            session_id: 't',
+            context_window: { used_percentage: 10, remaining_percentage: 90 },
+            cost: { total_cost_usd: 0, total_duration_ms: 0 },
+            workspace: { current_dir: '/tmp', added_dirs: ['/a', '/b'] },
+          }),
+        },
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, addedDirs: true } },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).toContain('+2 dirs');
+    });
+
+    it('should_not_add_segment_when_count_is_0', () => {
+      const ctx = makeCtx({
+        input: {
+          ...normalize({
+            model: 'Claude',
+            session_id: 't',
+            context_window: { used_percentage: 10, remaining_percentage: 90 },
+            cost: { total_cost_usd: 0, total_duration_ms: 0 },
+            workspace: { current_dir: '/tmp', added_dirs: [] },
+          }),
+        },
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, addedDirs: true } },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).not.toContain('dirs');
+    });
+
+    it('should_place_added_dirs_segment_after_directory_with_priority_61', () => {
+      const ctx = makeCtx({
+        input: {
+          ...normalize({
+            model: 'Claude',
+            session_id: 't',
+            context_window: { used_percentage: 10, remaining_percentage: 90 },
+            cost: { total_cost_usd: 0, total_duration_ms: 0 },
+            workspace: { current_dir: '/home/user/myproject', added_dirs: ['/x'] },
+          }),
+        },
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, addedDirs: true } },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      const dirIdx = out.indexOf('myproject');
+      const badgeIdx = out.indexOf('+1 dirs');
+      expect(dirIdx).toBeGreaterThanOrEqual(0);
+      expect(badgeIdx).toBeGreaterThanOrEqual(0);
+      expect(dirIdx).toBeLessThan(badgeIdx);
+    });
+
+    it('should_apply_warning_color_to_segment_when_count_gte_5', () => {
+      const dirs = ['/1', '/2', '/3', '/4', '/5'];
+      const ctx = makeCtx({
+        input: {
+          ...normalize({
+            model: 'Claude',
+            session_id: 't',
+            context_window: { used_percentage: 10, remaining_percentage: 90 },
+            cost: { total_cost_usd: 0, total_duration_ms: 0 },
+            workspace: { current_dir: '/tmp', added_dirs: dirs },
+          }),
+        },
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, addedDirs: true } },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).toContain('+5 dirs');
+
+      const withDirs4 = makeCtx({
+        input: {
+          ...normalize({
+            model: 'Claude',
+            session_id: 't',
+            context_window: { used_percentage: 10, remaining_percentage: 90 },
+            cost: { total_cost_usd: 0, total_duration_ms: 0 },
+            workspace: { current_dir: '/tmp', added_dirs: ['/1', '/2', '/3', '/4'] },
+          }),
+        },
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, addedDirs: true } },
+      });
+      const outWarn = renderPowerlineLine1(ctx, 'truecolor', null);
+      const outNorm = renderPowerlineLine1(withDirs4, 'truecolor', null);
+      expect(outWarn).not.toBe(outNorm);
+    });
+  });
+
+  // ── Worktree breadcrumb segment (issue #130) ─────────────────────────
+  describe('worktree breadcrumb segment', () => {
+    it('should_render_breadcrumb_when_original_branch_present_and_differs_from_current', () => {
+      const ctx = makeCtx({
+        input: {
+          ...normalize({
+            model: 'Claude',
+            session_id: 't',
+            context_window: { used_percentage: 10, remaining_percentage: 90 },
+            cost: { total_cost_usd: 0, total_duration_ms: 0 },
+            worktree: { name: 'feat-wt', original_branch: 'main' },
+          }),
+        },
+        git: { ...EMPTY_GIT, branch: 'feat/my-feature' },
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, worktreeBreadcrumb: true } },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).toContain('↳ main');
+    });
+
+    it('should_not_render_breadcrumb_when_original_branch_is_missing', () => {
+      const ctx = makeCtx({
+        input: {
+          ...normalize({
+            model: 'Claude',
+            session_id: 't',
+            context_window: { used_percentage: 10, remaining_percentage: 90 },
+            cost: { total_cost_usd: 0, total_duration_ms: 0 },
+            worktree: { name: 'feat-wt' },
+          }),
+        },
+        git: { ...EMPTY_GIT, branch: 'feat/x' },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).not.toContain('↳');
+    });
+
+    it('should_not_render_breadcrumb_when_original_branch_equals_current_branch', () => {
+      const ctx = makeCtx({
+        input: {
+          ...normalize({
+            model: 'Claude',
+            session_id: 't',
+            context_window: { used_percentage: 10, remaining_percentage: 90 },
+            cost: { total_cost_usd: 0, total_duration_ms: 0 },
+            worktree: { name: 'wt', original_branch: 'main' },
+          }),
+        },
+        git: { ...EMPTY_GIT, branch: 'main' },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).not.toContain('↳');
+    });
+
+    it('should_truncate_long_original_branch_to_15_chars', () => {
+      const longBranch = 'feature/' + 'a'.repeat(50);
+      const ctx = makeCtx({
+        input: {
+          ...normalize({
+            model: 'Claude',
+            session_id: 't',
+            context_window: { used_percentage: 10, remaining_percentage: 90 },
+            cost: { total_cost_usd: 0, total_duration_ms: 0 },
+            worktree: { name: 'wt', original_branch: longBranch },
+          }),
+        },
+        git: { ...EMPTY_GIT, branch: 'develop' },
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, worktreeBreadcrumb: true } },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).toContain('↳ ');
+      expect(out).not.toContain(longBranch);
+      expect(out).toContain('…');
+    });
+
+    it('should_respect_display_worktreeBreadcrumb_toggle', () => {
+      const ctx = makeCtx({
+        input: {
+          ...normalize({
+            model: 'Claude',
+            session_id: 't',
+            context_window: { used_percentage: 10, remaining_percentage: 90 },
+            cost: { total_cost_usd: 0, total_duration_ms: 0 },
+            worktree: { name: 'wt', original_branch: 'main' },
+          }),
+        },
+        git: { ...EMPTY_GIT, branch: 'feat/x' },
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, worktreeBreadcrumb: false } },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).not.toContain('↳');
+    });
+
+    it('powerline_renderer_should_emit_breadcrumb_as_single_segment_with_correct_priority', () => {
+      const ctx = makeCtx({
+        input: {
+          ...normalize({
+            model: 'Claude',
+            session_id: 't',
+            context_window: { used_percentage: 10, remaining_percentage: 90 },
+            cost: { total_cost_usd: 0, total_duration_ms: 0 },
+            worktree: { name: 'feat-wt', original_branch: 'develop' },
+          }),
+        },
+        git: { ...EMPTY_GIT, branch: 'feat/x' },
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, worktree: true, worktreeBreadcrumb: true } },
+        cols: 250,
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      const worktreeIdx = out.indexOf('feat-wt');
+      const breadcrumbIdx = out.indexOf('↳ develop');
+      expect(worktreeIdx).toBeGreaterThanOrEqual(0);
+      expect(breadcrumbIdx).toBeGreaterThanOrEqual(0);
+      expect(worktreeIdx).toBeLessThan(breadcrumbIdx);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Two small, self-gating line1 segments surfacing newly-confirmed Claude Code payload fields. Closes #129 and #130. Bundled because they touch the same 5 source files and share the same theme (new payload field → line1 segment).

### #129 — added-dirs badge
`workspace.added_dirs` → `+N dirs` badge after the directory segment, only when count > 0. Orange at count >= 5 (many added dirs slow git scanning).

### #130 — worktree origin-branch breadcrumb
`worktree.original_branch` → `↳ <branch>` breadcrumb near the branch, only when present (native `--worktree` sessions) and differs from the current branch. Truncated to 15 chars, sanitized.

## Preset defaults — note (differs from issue text)
Both issues said "OFF in all presets". Implemented instead as **ON in `full`+`balanced`, OFF in `minimal`** — consistent with the `apiLatency` widget. Both segments self-gate on data presence, so default-on adds no clutter in the common case and gives the features visibility.

## Verification
- Self-gating confirmed: no badge/breadcrumb when `added_dirs` empty or `original_branch` absent.
- `npm run lint` clean; `npm test` 1183 passed (1152 baseline + 31 new).
- New tests cover presence/absence/equality/truncation/toggle/preset-override, count formatting, warning color, and powerline segments (priorities 61 for added-dirs, 22.5 for breadcrumb).

## Not in this PR
No renderer changes beyond line1/powerline-line1, no new deps, no version bump (release separate).