### PR TITLE
chore(release): v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-05-28
+
+### Added
+
+- **Added-dirs badge** — line 1 now renders `+N dirs` when `workspace.added_dirs` is non-empty. Color escalates to orange at ≥5 new directories. Self-gating: renders nothing when the field is absent or zero. Toggled via `display.addedDirs` (default `true` in `full`/`balanced`; `false` in `minimal`). Closes [#129](https://github.com/cativo23/lumira/issues/129).
+- **Worktree origin-branch breadcrumb** — during native `--worktree` sessions, line 1 renders `↳ <branch>` when `worktree.original_branch` differs from the current branch. Gives at-a-glance context of which base branch the worktree tracks. Toggled via `display.worktreeBreadcrumb` (default `true` in `full`/`balanced`; `false` in `minimal`). Renders nothing when not in a worktree session or when origin matches current. Closes [#130](https://github.com/cativo23/lumira/issues/130).
+
+### Fixed
+
+- **`lumira` skill now accepts `apiLatency`, `addedDirs`, and `worktreeBreadcrumb` as valid `display.*` keys** — previously the skill's valid-key guard rejected all three and would have told users their config was invalid. `apiLatency` has been live since v1.4.0 (latent bug); `addedDirs` and `worktreeBreadcrumb` are new in this release.
+
+### Changed
+
+- **Burn-rate math consolidated internally** — pace/quota burn-rate calculations are now computed once in a shared helper rather than duplicated across pace-delta and quota-projection modules. No behavior change for users. (#131)
+
 ## [1.6.1] - 2026-05-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Interactive wizard — preset, theme, icons — previewed live before write.
 
 > 3,400+ monthly downloads, zero marketing. Try it for one session — `npx lumira install`.
 
-> **What's new in v1.5:** the [`lumira stats` CLI](#stats-cli) prints post-session analytics (cost, tokens, cache hit, tool frequency, burn rate). Combined with the `API N%` latency widget (v1.4.0), 7-day quota projection warning (v1.3.0), and auto-compact proximity glyph ⚠ (v1.4.1), recent releases add several diagnostic signals to the session.
+> **What's new in v1.7.0:** added-dirs badge (`+N dirs`, orange at ≥5) and worktree origin-branch breadcrumb (`↳ <branch>`) — both togglable via `display.addedDirs` / `display.worktreeBreadcrumb`, on by default in `full`/`balanced`. Combined with the [`lumira stats` CLI](#stats-cli) (v1.5), `API N%` latency widget (v1.4.0), 7-day quota projection warning (v1.3.0), and auto-compact proximity glyph ⚠ (v1.4.1), recent releases add several diagnostic signals to the session.
 
 ## Table of contents
 
@@ -87,7 +87,7 @@ Inspired by [claude-hud](https://github.com/jarrodwatts/claude-hud); takes a dif
 - **Config health widget** — surfaces silent fallbacks (theme/powerline degrading in named-ANSI, missing GSD STATE.md). Opt-in.
 - **Memory usage** — process RSS percentage.
 - **MCP server detection** — count of attached MCP servers per session.
-- **Vim-mode hint, thinking effort, worktree, output style, session name** — all togglable per-field via `display.*`.
+- **Vim-mode hint, thinking effort, worktree, output style, session name, added-dirs badge, worktree origin-branch breadcrumb** — all togglable per-field via `display.*`.
 - **3-tier color system** — named ANSI / 256-color / truecolor, auto-detected.
 - **Config-driven** — every feature toggleable via JSON config + CLI flags.
 
@@ -269,6 +269,7 @@ Create `~/.config/lumira/config.json`:
     "burnRate": true,
     "duration": true,
     "tokenSpeed": true,
+    "apiLatency": true,
     "rateLimits": true,
     "paceDelta": true,
     "quotaProjection": true,
@@ -278,6 +279,8 @@ Create `~/.config/lumira/config.json`:
     "vim": true,
     "effort": true,
     "worktree": true,
+    "addedDirs": true,
+    "worktreeBreadcrumb": true,
     "agent": true,
     "sessionName": true,
     "style": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lumira",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lumira",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "license": "MIT",
       "bin": {
         "lumira": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Real-time statusline HUD for Claude Code and Qwen Code. Includes session analytics CLI, API latency overhead widget, 7d quota projection, auto-compact proximity warnings, themes, and powerline. Zero deps.",
   "type": "module",
   "main": "dist/index.js",

--- a/skills/lumira/SKILL.md
+++ b/skills/lumira/SKILL.md
@@ -44,7 +44,7 @@ Your job: read the user's current config, translate their natural-language reque
 
 Valid keys (anything else must be rejected):
 
-`model`, `branch`, `gitChanges`, `directory`, `contextBar`, `contextTokens`, `tokens`, `cost`, `burnRate`, `duration`, `tokenSpeed`, `rateLimits`, `paceDelta`, `quotaProjection`, `tools`, `todos`, `vim`, `effort`, `worktree`, `agent`, `agents`, `sessionName`, `style`, `version`, `linesChanged`, `memory`, `cacheMetrics`, `mcp`, `health`
+`model`, `branch`, `gitChanges`, `directory`, `contextBar`, `contextTokens`, `tokens`, `cost`, `burnRate`, `duration`, `tokenSpeed`, `rateLimits`, `paceDelta`, `quotaProjection`, `tools`, `todos`, `vim`, `effort`, `worktree`, `agent`, `agents`, `sessionName`, `style`, `version`, `linesChanged`, `memory`, `cacheMetrics`, `mcp`, `health`, `apiLatency`, `addedDirs`, `worktreeBreadcrumb`
 
 ### Display thresholds (`display.*`, numeric)
 


### PR DESCRIPTION
## Summary

v1.7.0 — two new line1 segments + a skill fix.

- **#129** added-dirs badge (`+N dirs`, orange at >=5) — `display.addedDirs`.
- **#130** worktree origin-branch breadcrumb (`↳ <branch>`) — `display.worktreeBreadcrumb`.
- Both default ON in full/balanced, OFF in minimal; self-gating (render nothing when data absent).
- **Fixed**: the `lumira` skill rejected `apiLatency`/`addedDirs`/`worktreeBreadcrumb` as invalid `display.*` keys (`apiLatency` since v1.4.0) — now accepted.
- **#131** internal burn-rate math consolidation (no behavior change).

## Release checklist

- [x] Version bumped to 1.7.0
- [x] CHANGELOG `[1.7.0]` section
- [x] README updated (banner, feature bullet, config example) + SKILL.md valid keys
- [ ] CI green -> merge -> tag v1.7.0 -> release.yml auto-publishes to npm