### PR TITLE
fix(test): stop flaky git MD5 digest cache test

### DIFF
--- a/tests/parsers/git.test.ts
+++ b/tests/parsers/git.test.ts
@@ -55,6 +55,10 @@ describe('parseGitStatus', () => {
   });
 
   it('cache key uses full MD5 digest (32 hex chars) to prevent birthday collisions', async () => {
+    // Force a cache miss so the write path always runs — otherwise a fresh
+    // on-disk TTL entry from a prior `vitest run` (within GIT_CACHE_TTL) makes
+    // parseGitStatus return early and writeTtlCache is never called (flaky).
+    vi.spyOn(cacheUtils, 'readTtlCache').mockReturnValue(null);
     // Spy on writeTtlCache to capture the key the production code actually uses.
     // If someone truncates the digest or changes the algorithm in git.ts, the
     // captured key will no longer match the expected 32-char hex pattern.

--- a/tests/parsers/git.test.ts
+++ b/tests/parsers/git.test.ts
@@ -58,7 +58,7 @@ describe('parseGitStatus', () => {
     // Force a cache miss so the write path always runs — otherwise a fresh
     // on-disk TTL entry from a prior `vitest run` (within GIT_CACHE_TTL) makes
     // parseGitStatus return early and writeTtlCache is never called (flaky).
-    vi.spyOn(cacheUtils, 'readTtlCache').mockReturnValue(null);
+    const readSpy = vi.spyOn(cacheUtils, 'readTtlCache').mockReturnValue(null);
     // Spy on writeTtlCache to capture the key the production code actually uses.
     // If someone truncates the digest or changes the algorithm in git.ts, the
     // captured key will no longer match the expected 32-char hex pattern.
@@ -79,6 +79,7 @@ describe('parseGitStatus', () => {
     expect(usedKey).toMatch(/^git-[0-9a-f]{32}$/);
 
     writeSpy.mockRestore();
+    readSpy.mockRestore();
   });
 
 });


### PR DESCRIPTION
## Summary
- `tests/parsers/git.test.ts` "cache key uses full MD5 digest" failed intermittently (~1 in 4 runs).
- Root cause: the test asserts `writeTtlCache` is called once, but doesn't force a TTL cache-miss. When a fresh on-disk cache entry for `/cache-key-test` survived between `vitest run` invocations (within the 5s `GIT_CACHE_TTL`), `parseGitStatus` returned from cache and skipped the write → spy assertion failed.
- Fix: mock `readTtlCache` to return `null`, forcing the write path deterministically. Tests exactly what it intends (the write-key format), independent of `/tmp` state.

## Test plan
- [x] Ran the previously-flaky test 5× back-to-back (within the TTL window that used to trigger the flake) — 5/5 pass.
- [x] Full suite: 1202/1202 passing, 52 files.