### PR TITLE
chore(release): v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-05-28
+
+### Added
+
+- **Compaction counter widget** — line 2 renders `⊙ N` next to the context bar, counting how many times the session transcript has been compacted (auto + manual). Pairs with the auto-compact proximity glyph ⚠ to show both "how close to the next compaction" and "how many already happened". Computed inside the existing mtime-cached transcript parser (no extra I/O). Self-gating: renders nothing at zero. Toggled via `display.compactionCount` (default `true` in `full`/`balanced`; `false` in `minimal`). (#154)
+
+### Fixed
+
+- **Flaky git cache test** — `tests/parsers/git.test.ts` no longer fails intermittently when a prior run's on-disk TTL cache survives; the test now forces a cache miss so the write path is deterministic. Dev-only, no user-facing change. (#155)
+
 ## [1.7.0] - 2026-05-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Interactive wizard — preset, theme, icons — previewed live before write.
 
 > 3,400+ monthly downloads, zero marketing. Try it for one session — `npx lumira install`.
 
-> **What's new in v1.7.0:** added-dirs badge (`+N dirs`, orange at ≥5) and worktree origin-branch breadcrumb (`↳ <branch>`) — both togglable via `display.addedDirs` / `display.worktreeBreadcrumb`, on by default in `full`/`balanced`. Combined with the [`lumira stats` CLI](#stats-cli) (v1.5), `API N%` latency widget (v1.4.0), 7-day quota projection warning (v1.3.0), and auto-compact proximity glyph ⚠ (v1.4.1), recent releases add several diagnostic signals to the session.
+> **What's new in v1.8.0:** compaction counter (`⊙ N` on line 2) — tracks how many times the session has been compacted, pairing with the auto-compact proximity glyph ⚠. Togglable via `display.compactionCount`, on by default in `full`/`balanced`. Combined with the added-dirs badge and worktree breadcrumb (v1.7.0), [`lumira stats` CLI](#stats-cli) (v1.5), `API N%` latency widget (v1.4.0), 7-day quota projection warning (v1.3.0), and auto-compact proximity glyph ⚠ (v1.4.1), recent releases add several diagnostic signals to the session.
 
 ## Table of contents
 
@@ -288,6 +288,7 @@ Create `~/.config/lumira/config.json`:
     "linesChanged": true,
     "memory": true,
     "agents": true,
+    "compactionCount": true,
     "health": false,
     "contextWarningThreshold": 70,
     "contextCriticalThreshold": 85

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lumira",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lumira",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "bin": {
         "lumira": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Real-time statusline HUD for Claude Code and Qwen Code. Includes session analytics CLI, API latency overhead widget, 7d quota projection, auto-compact proximity warnings, themes, and powerline. Zero deps.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
Release v1.8.0 — bumps `package.json`, CHANGELOG, and README banner.

Ships two already-merged PRs:
- **#154** — compaction counter widget (`⊙ N` on line 2), `display.compactionCount` toggle (on in full/balanced, off in minimal).
- **#155** — fix for the flaky git cache test (dev-only).

## Test plan
- [x] `npm run build` ok
- [x] Full suite: 1202/1202 passing, 52 files
- [ ] CI green on this PR → merge → tag `v1.8.0` → `release.yml` auto-publishes to npm