### PR TITLE
ci: bump checkout/setup-node to v6 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
       - run: npm ci
@@ -56,7 +56,7 @@ jobs:
       tag: ${{ steps.version.outputs.tag }}
       exists: ${{ steps.check_tag.outputs.exists }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Extract and validate version
         id: version
@@ -140,9 +140,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout@v4` → `@v6` and `actions/setup-node@v4` → `@v6` across `ci.yml` and `release.yml` (7 occurrences).
- v4 runs on **Node 20**, which GitHub forces to Node 24 on **2026-06-02** and removes on **2026-09-16**. v6 already runs on Node 24, so this clears the deprecation warnings and future-proofs the auto-release pipeline.
- No logic changes — same `node-version` (22 for CI/gate, 24 for npm-publish), same steps.

## Test plan
- [ ] CI green on this PR (the bumped actions exercise themselves on the `pull_request` run)
- [ ] No more "Node.js 20 actions are deprecated" annotations in the run