### PR TITLE
fix(gsd): mirror GSD 1.42.3 statusline for parity

### DIFF
--- a/src/parsers/gsd.ts
+++ b/src/parsers/gsd.ts
@@ -17,6 +17,12 @@ interface GsdState {
   phaseNum?: string;
   phaseTotal?: string;
   phaseName?: string;
+  activePhase?: string;
+  nextAction?: string;
+  nextPhases?: string[];
+  completedPhases?: string;
+  totalPhases?: string;
+  percent?: string;
 }
 
 /**
@@ -28,15 +34,58 @@ export function parseStateMd(content: string): GsdState {
 
   const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
   if (fmMatch) {
-    for (const line of fmMatch[1].split('\n')) {
+    const fmText = fmMatch[1];
+
+    // Parse simple scalar fields
+    for (const line of fmText.split('\n')) {
       const m = line.match(/^(\w+):\s*(.+)/);
       if (!m) continue;
       const [, key, val] = m;
       const v = val.trim().replace(/^(["'])(.*)\1$/, '$2');
-      if (v === 'null') continue;
+      if (v === 'null' || v === '') continue;
       if (key === 'status') state.status = v;
       else if (key === 'milestone') state.milestone = v;
       else if (key === 'milestone_name') state.milestoneName = v;
+      else if (key === 'active_phase') state.activePhase = v;
+      else if (key === 'next_action') state.nextAction = v;
+    }
+
+    // Parse next_phases: flow form [a, b]
+    const flowMatch = fmText.match(/^next_phases:\s*\[([^\]]*)\]/m);
+    if (flowMatch && flowMatch[1]) {
+      const items = flowMatch[1].split(',').map(s => {
+        const trimmed = s.trim().replace(/^(["'])(.*)\1$/, '$2');
+        return trimmed;
+      }).filter(s => s.length > 0);
+      if (items.length > 0) state.nextPhases = items;
+    }
+
+    // Parse next_phases: block-list form
+    if (!state.nextPhases) {
+      const blockMatch = fmText.match(/^next_phases:\s*\n((?:[ \t]*-[ \t]*[^\n]+\n?)*)/m);
+      if (blockMatch && blockMatch[1]) {
+        const items: string[] = [];
+        for (const itemLine of blockMatch[1].split('\n')) {
+          const itemM = itemLine.match(/^[ \t]*-[ \t]*(.+)/);
+          if (itemM) {
+            const itemVal = itemM[1].trim().replace(/^(["'])(.*)\1$/, '$2');
+            if (itemVal) items.push(itemVal);
+          }
+        }
+        if (items.length > 0) state.nextPhases = items;
+      }
+    }
+
+    // Parse progress block
+    const progressMatch = fmText.match(/^progress:\s*\n((?:[ \t]+\w+:.+\n?)+)/m);
+    if (progressMatch && progressMatch[1]) {
+      const progressText = progressMatch[1];
+      const completedM = progressText.match(/completed_phases:\s*(\d+)/);
+      if (completedM) state.completedPhases = completedM[1];
+      const totalM = progressText.match(/total_phases:\s*(\d+)/);
+      if (totalM) state.totalPhases = totalM[1];
+      const percentM = progressText.match(/percent:\s*(\d+)/);
+      if (percentM) state.percent = percentM[1];
     }
   }
 
@@ -60,6 +109,16 @@ export function parseStateMd(content: string): GsdState {
   return state;
 }
 
+/** Render a 10-segment progress bar: █████░░░░░ 50%. */
+function renderProgressBar(percent: string | number | undefined): string {
+  if (percent === undefined || percent === null) return '';
+  const pct = Math.max(0, Math.min(100, parseInt(String(percent), 10)));
+  if (isNaN(pct)) return '';
+  const filled = Math.floor(pct / 10);
+  const bar = '█'.repeat(filled) + '░'.repeat(10 - filled);
+  return `${bar} ${pct}%`;
+}
+
 /** Walk up from `cwd` looking for `.planning/STATE.md`; stop at home or filesystem root. */
 export function findStateMd(cwd: string): string | null {
   const home = homedir();
@@ -77,26 +136,68 @@ export function findStateMd(cwd: string): string | null {
 /** Format a GSD state into a compact status string: `milestone · status · phase`. */
 function formatState(s: GsdState): string {
   const parts: string[] = [];
+
+  // Milestone segment with optional progress bar
   if (s.milestone || s.milestoneName) {
     const ver = s.milestone ?? '';
     const name = s.milestoneName && s.milestoneName !== 'milestone' ? s.milestoneName : '';
-    const ms = [ver, name].filter(Boolean).join(' ');
-    if (ms) parts.push(ms);
+    const bar = renderProgressBar(s.percent);
+    const msParts = [ver, name, bar].filter(Boolean);
+    if (msParts.length > 0) parts.push(msParts.join(' '));
   }
-  if (s.status) parts.push(s.status);
-  if (s.phaseNum && s.phaseTotal) {
-    const phase = s.phaseName ? `${s.phaseName} (${s.phaseNum}/${s.phaseTotal})` : `ph ${s.phaseNum}/${s.phaseTotal}`;
-    parts.push(phase);
+
+  // Scene selection: activePhase → nextAction → milestone-complete → default
+  const phasesStr = s.nextPhases?.length ? s.nextPhases.join('/') : null;
+
+  if (s.activePhase) {
+    // Scene 1: activePhase (with optional status)
+    parts.push(s.status ? `Phase ${s.activePhase} ${s.status}` : `Phase ${s.activePhase}`);
+  } else if (s.nextAction && phasesStr) {
+    // Scene 2: nextAction + phases when idle
+    parts.push(`next ${s.nextAction} ${phasesStr}`);
+  } else if (Number(s.percent) === 100 || (s.completedPhases && s.totalPhases && s.completedPhases === s.totalPhases)) {
+    // Scene 3: milestone complete
+    parts.push('milestone complete');
+  } else {
+    // Scene 4 (default): preserve existing behavior
+    if (s.status) parts.push(s.status);
+    if (s.phaseNum && s.phaseTotal) {
+      const phase = s.phaseName ? `${s.phaseName} (${s.phaseNum}/${s.phaseTotal})` : `ph ${s.phaseNum}/${s.phaseTotal}`;
+      parts.push(phase);
+    }
   }
+
   return parts.join(' · ');
+}
+
+/** Compare two semver versions. Returns 1 if a > b, -1 if a < b, 0 if equal. */
+function semverCompare(a: string, b: string): number {
+  const parseVer = (v: string) => {
+    const parts = v.replace(/^v/, '').split('.').map(p => parseInt(p, 10));
+    return { major: parts[0] ?? 0, minor: parts[1] ?? 0, patch: parts[2] ?? 0 };
+  };
+  const av = parseVer(a);
+  const bv = parseVer(b);
+  if (av.major !== bv.major) return av.major > bv.major ? 1 : -1;
+  if (av.minor !== bv.minor) return av.minor > bv.minor ? 1 : -1;
+  if (av.patch !== bv.patch) return av.patch > bv.patch ? 1 : -1;
+  return 0;
+}
+
+interface CacheData {
+  updateAvailable: boolean;
+  staleHooks: boolean;
+  devInstall: boolean;
 }
 
 /**
  * Read GSD update-check cache. Checks the shared tool-agnostic cache first
  * (`~/.cache/gsd/`, introduced by GSD #1421), then falls back to the legacy
  * per-runtime location (`~/.claude/cache/`) for older GSD installs.
+ * Returns update status, stale hooks flag, and dev install flag.
  */
-function readUpdateCache(sharedCacheFile: string, legacyCacheFile: string): boolean {
+function readUpdateCache(sharedCacheFile: string, legacyCacheFile: string): CacheData {
+  const result: CacheData = { updateAvailable: false, staleHooks: false, devInstall: false };
   const candidates: Array<[string, string]> = [
     ['shared', sharedCacheFile],
     ['legacy', legacyCacheFile],
@@ -104,14 +205,29 @@ function readUpdateCache(sharedCacheFile: string, legacyCacheFile: string): bool
   for (const [source, file] of candidates) {
     if (!existsSync(file)) continue;
     try {
-      const parsed = JSON.parse(readFileSync(file, 'utf8')) as { update_available?: boolean };
+      const parsed = JSON.parse(readFileSync(file, 'utf8')) as {
+        update_available?: boolean;
+        stale_hooks?: string[];
+        installed?: string;
+        latest?: string;
+      };
       if (parsed.update_available) {
+        result.updateAvailable = true;
         log('update cache:', source, file);
-        return true;
       }
+      if (Array.isArray(parsed.stale_hooks) && parsed.stale_hooks.length > 0) {
+        result.staleHooks = true;
+      }
+      // DevInstall: stale_hooks present AND installed > latest
+      if (result.staleHooks && parsed.installed && parsed.latest) {
+        if (semverCompare(parsed.installed, parsed.latest) > 0) {
+          result.devInstall = true;
+        }
+      }
+      return result;
     } catch { /* ignore malformed */ }
   }
-  return false;
+  return result;
 }
 
 export interface GsdInfoOptions {
@@ -125,7 +241,7 @@ export function getGsdInfo(cwd: string, opts: GsdInfoOptions = {}): GsdInfo | nu
   const claudeDir = opts.claudeDir ?? process.env['CLAUDE_CONFIG_DIR'] ?? join(homedir(), '.claude');
   const sharedCacheFile = opts.sharedCacheFile ?? join(homedir(), '.cache', 'gsd', 'gsd-update-check.json');
   const legacyCacheFile = join(claudeDir, 'cache', 'gsd-update-check.json');
-  const updateAvailable = readUpdateCache(sharedCacheFile, legacyCacheFile);
+  const cacheData = readUpdateCache(sharedCacheFile, legacyCacheFile);
 
   let currentTask: string | undefined;
   const stateFile = findStateMd(cwd || process.cwd());
@@ -145,9 +261,14 @@ export function getGsdInfo(cwd: string, opts: GsdInfoOptions = {}): GsdInfo | nu
     log('no STATE.md found walking up from:', cwd || process.cwd());
   }
 
-  if (!updateAvailable && !currentTask) {
-    log('no gsd signal — update=false, task=none (line4 will be empty)');
+  if (!cacheData.updateAvailable && !cacheData.staleHooks && !currentTask) {
+    log('no gsd signal — update=false, staleHooks=false, task=none (line4 will be empty)');
     return null;
   }
-  return { updateAvailable, currentTask };
+  return {
+    updateAvailable: cacheData.updateAvailable || undefined,
+    staleHooks: cacheData.staleHooks || undefined,
+    devInstall: cacheData.devInstall || undefined,
+    currentTask,
+  };
 }

--- a/src/parsers/gsd.ts
+++ b/src/parsers/gsd.ts
@@ -109,7 +109,14 @@ export function parseStateMd(content: string): GsdState {
   return state;
 }
 
-/** Render a 10-segment progress bar: █████░░░░░ 50%. */
+/**
+ * Render a 10-segment progress bar: `█████░░░░░ 50%`.
+ *
+ * INTENTIONAL deviation from GSD's own statusline (gsd-statusline.js wraps the
+ * bar in brackets — `[█████░░░░░] 50%`). lumira drops the brackets so the
+ * milestone bar reads as distinct from the line-2 context bar. Do NOT re-add
+ * brackets when re-syncing GSD's format — this is a deliberate design choice.
+ */
 function renderProgressBar(percent: string | number | undefined): string {
   if (percent === undefined || percent === null) return '';
   const pct = Math.max(0, Math.min(100, parseInt(String(percent), 10)));
@@ -218,11 +225,17 @@ function readUpdateCache(sharedCacheFile: string, legacyCacheFile: string): Cach
       if (Array.isArray(parsed.stale_hooks) && parsed.stale_hooks.length > 0) {
         result.staleHooks = true;
       }
-      // DevInstall: stale_hooks present AND installed > latest
-      if (result.staleHooks && parsed.installed && parsed.latest) {
-        if (semverCompare(parsed.installed, parsed.latest) > 0) {
-          result.devInstall = true;
-        }
+      // DevInstall: stale_hooks present AND installed is ahead of latest.
+      // Guard against an unknown/missing latest explicitly (mirrors GSD's own
+      // check) rather than relying on NaN comparison semantics in semverCompare.
+      if (
+        result.staleHooks &&
+        parsed.installed &&
+        parsed.latest &&
+        parsed.latest !== 'unknown' &&
+        semverCompare(parsed.installed, parsed.latest) > 0
+      ) {
+        result.devInstall = true;
       }
       return result;
     } catch { /* ignore malformed */ }

--- a/src/render/line4.ts
+++ b/src/render/line4.ts
@@ -7,14 +7,23 @@ export function renderLine4(ctx: RenderContext, c: Colors): string {
   const { gsd, icons } = ctx;
   const parts: string[] = [];
 
-  // GSD widget — only emit when GSD has something to display.
-  if (gsd && (gsd.currentTask || gsd.updateAvailable)) {
+  // GSD widget — only emit when GSD has something to display. Text and glyphs
+  // mirror GSD's own statusline (gsd-statusline.js) so the integration reads
+  // identically. The update/stale-hooks indicators render even without a
+  // current task, so a GSD update is visible in any project (gated only on the
+  // update-check cache, not on being inside a GSD project).
+  if (gsd && (gsd.currentTask || gsd.updateAvailable || gsd.staleHooks)) {
     parts.push(c.dim('GSD'));
     if (gsd.currentTask) {
-      parts.push(c.bold(`${icons.hammer} ${truncField(gsd.currentTask, 40)}`));
+      parts.push(c.bold(`${icons.hammer} ${truncField(gsd.currentTask, 60)}`));
     }
     if (gsd.updateAvailable) {
-      parts.push(c.yellow(`${icons.warning} GSD update available`));
+      parts.push(c.yellow('⬆ /gsd:update'));
+    }
+    if (gsd.staleHooks) {
+      parts.push(gsd.devInstall
+        ? c.yellow('⚠ dev install — re-run installer to sync hooks')
+        : c.red('⚠ stale hooks — run /gsd:update'));
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,8 @@ export interface TodoEntry {
 export interface GsdInfo {
   currentTask?: string;
   updateAvailable?: boolean;
+  staleHooks?: boolean;
+  devInstall?: boolean;
 }
 
 export interface MemoryInfo {
@@ -408,7 +410,11 @@ export const DEFAULT_DISPLAY: DisplayToggles = {
 
 export const DEFAULT_CONFIG: HudConfig = {
   layout: 'auto',
-  gsd: false,
+  // GSD on by default, mirroring GSD's own always-on statusline. Self-gates to
+  // nothing when there's no .planning/STATE.md and no update-check cache, so
+  // non-GSD users see no extra line and pay only a few cheap existsSync checks.
+  // Minimal/singleline returns early (renderMinimal) and never reaches line 4.
+  gsd: true,
   display: { ...DEFAULT_DISPLAY },
   colors: { mode: 'auto' },
   customCommands: { enabled: false, commands: [] },

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -474,7 +474,9 @@ describe('mergeCliFlags', () => {
   it('gsd is on by default (self-gates to nothing when no GSD is present, mirroring GSD itself)', () => {
     expect(DEFAULT_CONFIG.gsd).toBe(true);
   });
-  it('enables gsd', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--gsd']).gsd).toBe(true); });
+  it('--gsd enables gsd from a disabled config', () => {
+    expect(mergeCliFlags({ ...DEFAULT_CONFIG, gsd: false }, ['node', 'i', '--gsd']).gsd).toBe(true);
+  });
   it('no flags = unchanged', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i'])).toEqual(DEFAULT_CONFIG); });
   it('--preset=balanced drives layout', () => {
     const r = mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--preset=balanced']);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -471,6 +471,9 @@ describe('mergeCliFlags', () => {
     expect(r.preset).toBe('full');
     expect(r.layout).toBe('multiline');
   });
+  it('gsd is on by default (self-gates to nothing when no GSD is present, mirroring GSD itself)', () => {
+    expect(DEFAULT_CONFIG.gsd).toBe(true);
+  });
   it('enables gsd', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i', '--gsd']).gsd).toBe(true); });
   it('no flags = unchanged', () => { expect(mergeCliFlags(DEFAULT_CONFIG, ['node', 'i'])).toEqual(DEFAULT_CONFIG); });
   it('--preset=balanced drives layout', () => {

--- a/tests/parsers/gsd.test.ts
+++ b/tests/parsers/gsd.test.ts
@@ -211,8 +211,20 @@ describe('getGsdInfo', () => {
     expect(info?.devInstall).toBe(true);
   });
 
-  it('does not flag a dev install when installed is equal to or behind latest', () => {
+  it('does not flag a dev install when installed is behind latest', () => {
     writeCache('{"stale_hooks":["a.js"],"installed":"1.42.0","latest":"1.42.3"}');
     expect(getGsdInfo(dir, opts)?.devInstall).toBeFalsy();
+  });
+
+  it('does not flag a dev install when installed equals latest', () => {
+    writeCache('{"stale_hooks":["a.js"],"installed":"1.42.3","latest":"1.42.3"}');
+    expect(getGsdInfo(dir, opts)?.devInstall).toBeFalsy();
+  });
+
+  it('does not flag a dev install when latest is unknown', () => {
+    writeCache('{"stale_hooks":["a.js"],"installed":"1.42.3","latest":"unknown"}');
+    const info = getGsdInfo(dir, opts);
+    expect(info?.staleHooks).toBe(true);
+    expect(info?.devInstall).toBeFalsy();
   });
 });

--- a/tests/parsers/gsd.test.ts
+++ b/tests/parsers/gsd.test.ts
@@ -4,7 +4,12 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { getGsdInfo, parseStateMd } from '../../src/parsers/gsd.js';
 
+// lumira mirrors GSD's own statusline (gsd-statusline.js v1.42.3) for all GSD
+// content — same STATE.md field set, same update-cache semantics, same scenes.
+// GSD is the source of truth; re-sync these tests when GSD's format changes.
+
 describe('parseStateMd', () => {
+  // ── frontmatter + phase + status ──────────────────────────────────────────
   it('parses YAML frontmatter (milestone, status, name)', () => {
     const content = `---
 milestone: v2.0
@@ -20,63 +25,82 @@ status: executing
   });
 
   it('parses Phase: N of M (name) line', () => {
-    const content = `---\nstatus: planning\n---\n\nPhase: 9 of 12 (multi-role-permissions)`;
-    const s = parseStateMd(content);
+    const s = parseStateMd(`---\nstatus: planning\n---\n\nPhase: 9 of 12 (multi-role-permissions)`);
     expect(s.phaseNum).toBe('9');
     expect(s.phaseTotal).toBe('12');
     expect(s.phaseName).toBe('multi-role-permissions');
   });
 
   it('falls back to body Status when frontmatter is absent', () => {
-    const content = `# State\n\nStatus: Ready to plan phase 3`;
-    expect(parseStateMd(content).status).toBe('planning');
+    expect(parseStateMd(`# State\n\nStatus: Ready to plan phase 3`).status).toBe('planning');
   });
 
-  it('picks up body Status even when Phase line is present but frontmatter has no status', () => {
-    const content = `# State\n\nPhase: 2 of 5 (auth)\n\nStatus: Executing`;
-    const s = parseStateMd(content);
+  it('picks up body Status even when a Phase line is present but frontmatter has no status', () => {
+    const s = parseStateMd(`# State\n\nPhase: 2 of 5 (auth)\n\nStatus: Executing`);
     expect(s.phaseNum).toBe('2');
-    expect(s.status).toBe('executing'); // was undefined before fix — body Status ignored when phaseMatch fired
+    expect(s.status).toBe('executing'); // body Status must not be ignored when phaseMatch fires
   });
 
   it('frontmatter status wins over body Status when both are present', () => {
-    const content = `---\nstatus: planning\n---\n\nPhase: 2 of 5 (auth)\n\nStatus: Executing`;
-    const s = parseStateMd(content);
+    const s = parseStateMd(`---\nstatus: planning\n---\n\nPhase: 2 of 5 (auth)\n\nStatus: Executing`);
     expect(s.status).toBe('planning'); // frontmatter always wins; body Status is fallback only
     expect(s.phaseNum).toBe('2');
   });
 
   it('treats `null` frontmatter values as absent', () => {
-    const content = `---\nstatus: null\nmilestone: v1.0\n---`;
-    const s = parseStateMd(content);
+    const s = parseStateMd(`---\nstatus: null\nmilestone: v1.0\n---`);
     expect(s.status).toBeUndefined();
     expect(s.milestone).toBe('v1.0');
   });
 
+  // ── quote stripping ───────────────────────────────────────────────────────
   it('strips balanced double-quote pairs', () => {
-    const content = `---\nmilestone: "v1.0"\n---`;
-    expect(parseStateMd(content).milestone).toBe('v1.0');
+    expect(parseStateMd(`---\nmilestone: "v1.0"\n---`).milestone).toBe('v1.0');
   });
 
   it('strips balanced single-quote pairs', () => {
-    const content = `---\nmilestone: 'v1.0'\n---`;
-    expect(parseStateMd(content).milestone).toBe('v1.0');
+    expect(parseStateMd(`---\nmilestone: 'v1.0'\n---`).milestone).toBe('v1.0');
   });
 
-  it('preserves leading quote when trailing quote is absent (unmatched)', () => {
-    const content = `---\nmilestone: "foo\n---`;
-    // Unmatched quote — no stripping should occur
-    expect(parseStateMd(content).milestone).toBe('"foo');
+  it('preserves an unmatched leading quote', () => {
+    expect(parseStateMd(`---\nmilestone: "foo\n---`).milestone).toBe('"foo');
   });
 
-  it('preserves trailing quote when leading quote is absent (unmatched)', () => {
-    const content = `---\nmilestone: foo"\n---`;
-    expect(parseStateMd(content).milestone).toBe('foo"');
+  it('preserves an unmatched trailing quote', () => {
+    expect(parseStateMd(`---\nmilestone: foo"\n---`).milestone).toBe('foo"');
   });
 
-  it('does not strip mismatched quote pair', () => {
-    const content = `---\nmilestone: "foo'\n---`;
-    expect(parseStateMd(content).milestone).toBe('"foo\'');
+  it('does not strip a mismatched quote pair', () => {
+    expect(parseStateMd(`---\nmilestone: "foo'\n---`).milestone).toBe('"foo\'');
+  });
+
+  // ── GSD 1.42.3 lifecycle fields ───────────────────────────────────────────
+  it('parses active_phase', () => {
+    expect(parseStateMd(`---\nactive_phase: "4.5"\nstatus: executing\n---`).activePhase).toBe('4.5');
+  });
+
+  it('treats active_phase null/empty as absent', () => {
+    expect(parseStateMd(`---\nactive_phase: null\n---`).activePhase).toBeUndefined();
+    expect(parseStateMd(`---\nactive_phase:\n---`).activePhase).toBeUndefined();
+  });
+
+  it('parses next_action', () => {
+    expect(parseStateMd(`---\nnext_action: execute-phase\n---`).nextAction).toBe('execute-phase');
+  });
+
+  it('parses next_phases in flow form [a, b]', () => {
+    expect(parseStateMd(`---\nnext_phases: [4.5, 6]\n---`).nextPhases).toEqual(['4.5', '6']);
+  });
+
+  it('parses next_phases in block-list form', () => {
+    expect(parseStateMd(`---\nnext_phases:\n  - "4.5"\n  - 6\n---`).nextPhases).toEqual(['4.5', '6']);
+  });
+
+  it('parses the nested progress block (completed/total/percent)', () => {
+    const s = parseStateMd(`---\nprogress:\n  completed_phases: 3\n  total_phases: 6\n  percent: 50\n---`);
+    expect(s.completedPhases).toBe('3');
+    expect(s.totalPhases).toBe('6');
+    expect(s.percent).toBe('50');
   });
 });
 
@@ -84,11 +108,12 @@ describe('getGsdInfo', () => {
   let dir: string;
   let claudeDir: string;
   let opts: { claudeDir: string; sharedCacheFile: string };
+
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'gsd-cwd-'));
     claudeDir = mkdtempSync(join(tmpdir(), 'gsd-claude-'));
     mkdirSync(join(claudeDir, 'cache'), { recursive: true });
-    // Point shared cache at a path inside claudeDir so tests don't read the
+    // Point the shared cache at a path inside claudeDir so tests never read the
     // real ~/.cache/gsd on the dev machine.
     opts = { claudeDir, sharedCacheFile: join(claudeDir, 'shared-cache.json') };
   });
@@ -97,55 +122,97 @@ describe('getGsdInfo', () => {
     rmSync(claudeDir, { recursive: true, force: true });
   });
 
-  it('returns null when no STATE.md and no update cache', () => {
+  /** Write .planning/STATE.md at `dir` (or a nested subdir under it). */
+  function writeState(content: string, subdir = ''): void {
+    const root = subdir ? join(dir, subdir) : dir;
+    mkdirSync(join(root, '.planning'), { recursive: true });
+    writeFileSync(join(root, '.planning', 'STATE.md'), content);
+  }
+  /** Write the legacy per-runtime update-check cache. */
+  function writeCache(json: string): void {
+    writeFileSync(join(claudeDir, 'cache', 'gsd-update-check.json'), json);
+  }
+
+  // ── signal gating ─────────────────────────────────────────────────────────
+  it('returns null when there is no STATE.md ancestor and no update cache', () => {
     expect(getGsdInfo(dir, opts)).toBeNull();
   });
 
-  it('reads update_available from legacy per-runtime cache', () => {
-    writeFileSync(join(claudeDir, 'cache', 'gsd-update-check.json'), '{"update_available":true}');
+  it('reads update_available from the legacy per-runtime cache', () => {
+    writeCache('{"update_available":true}');
     expect(getGsdInfo(dir, opts)?.updateAvailable).toBe(true);
   });
 
-  it('reads GSD state from nearest .planning/STATE.md walking up from cwd', () => {
-    const projectRoot = join(dir, 'project');
-    const nested = join(projectRoot, 'src', 'deeply', 'nested');
-    mkdirSync(join(projectRoot, '.planning'), { recursive: true });
-    mkdirSync(nested, { recursive: true });
-    writeFileSync(
-      join(projectRoot, '.planning', 'STATE.md'),
-      `---\nmilestone: v1.2\nstatus: executing\n---\n\nPhase: 3 of 5 (auth)`,
-    );
-    const info = getGsdInfo(nested, opts);
+  it('walks up from cwd to the nearest .planning/STATE.md', () => {
+    writeState(`---\nmilestone: v1.2\nstatus: executing\n---\n\nPhase: 3 of 5 (auth)`, 'project');
+    const info = getGsdInfo(join(dir, 'project', 'src', 'deeply', 'nested'), opts);
     expect(info?.currentTask).toContain('v1.2');
     expect(info?.currentTask).toContain('executing');
     expect(info?.currentTask).toContain('auth (3/5)');
   });
 
-  it('stops walking at home directory', () => {
-    // cwd is a tmpdir outside any .planning ancestor
+  // ── resilience ────────────────────────────────────────────────────────────
+  it('treats malformed cache JSON as no update', () => {
+    writeCache('not json');
     expect(getGsdInfo(dir, opts)).toBeNull();
   });
 
-  it('handles malformed JSON in cache gracefully', () => {
-    writeFileSync(join(claudeDir, 'cache', 'gsd-update-check.json'), 'not json');
+  it('treats an empty STATE.md as no state', () => {
+    writeState('');
     expect(getGsdInfo(dir, opts)).toBeNull();
   });
 
-  it('handles malformed STATE.md gracefully', () => {
-    mkdirSync(join(dir, '.planning'), { recursive: true });
-    writeFileSync(join(dir, '.planning', 'STATE.md'), '');
-    expect(getGsdInfo(dir, opts)).toBeNull();
-  });
-
-  it('sanitizes control characters from formatted state', () => {
-    mkdirSync(join(dir, '.planning'), { recursive: true });
-    writeFileSync(
-      join(dir, '.planning', 'STATE.md'),
-      `---\nmilestone: v1.0\nmilestone_name: "Safe\x1b[31mPart\x00end"\nstatus: executing\n---`,
-    );
+  it('sanitizes control characters out of the formatted state', () => {
+    writeState(`---\nmilestone: v1.0\nmilestone_name: "Safe\x1b[31mPart\x00end"\nstatus: executing\n---`);
     const task = getGsdInfo(dir, opts)?.currentTask ?? '';
     expect(task).not.toMatch(/[\x00-\x1f\x7f-\x9f]/);
     expect(task).toContain('Safe');
     expect(task).toContain('end');
+  });
+
+  // ── GSD 1.42.3 scenes (mirror gsd-statusline.js formatGsdState) ────────────
+  it('renders a 10-segment progress bar in the milestone segment', () => {
+    writeState(`---\nmilestone: v2.0\nmilestone_name: "Automation"\nprogress:\n  completed_phases: 3\n  total_phases: 6\n  percent: 50\n---`);
+    expect(getGsdInfo(dir, opts)?.currentTask).toContain('v2.0 Automation █████░░░░░ 50%');
+  });
+
+  it('renders the active_phase scene: "Phase X <status>"', () => {
+    writeState(`---\nmilestone: v2.0\nactive_phase: "4.5"\nstatus: executing\n---`);
+    expect(getGsdInfo(dir, opts)?.currentTask).toContain('Phase 4.5 executing');
+  });
+
+  it('renders the idle next_action scene: "next <action> <phases>"', () => {
+    writeState(`---\nmilestone: v2.0\nnext_action: execute-phase\nnext_phases: [4.5]\n---`);
+    expect(getGsdInfo(dir, opts)?.currentTask).toContain('next execute-phase 4.5');
+  });
+
+  it('renders "milestone complete" at percent 100', () => {
+    writeState(`---\nmilestone: v2.0\nprogress:\n  completed_phases: 6\n  total_phases: 6\n  percent: 100\n---`);
+    expect(getGsdInfo(dir, opts)?.currentTask).toContain('milestone complete');
+  });
+
+  it('preserves the default "<status> · <phase>" scene when no lifecycle fields are present', () => {
+    writeState(`---\nmilestone: v1.2\nstatus: executing\n---\n\nPhase: 3 of 5 (auth)`);
+    const task = getGsdInfo(dir, opts)?.currentTask ?? '';
+    expect(task).toContain('executing');
+    expect(task).toContain('auth (3/5)');
+  });
+
+  // ── stale hooks + dev-install detection ───────────────────────────────────
+  it('reports staleHooks when the cache lists stale hooks', () => {
+    writeCache('{"stale_hooks":["a.js"]}');
+    expect(getGsdInfo(dir, opts)?.staleHooks).toBe(true);
+  });
+
+  it('flags a dev install when the installed version is ahead of latest', () => {
+    writeCache('{"stale_hooks":["a.js"],"installed":"1.43.0","latest":"1.42.3"}');
+    const info = getGsdInfo(dir, opts);
+    expect(info?.staleHooks).toBe(true);
+    expect(info?.devInstall).toBe(true);
+  });
+
+  it('does not flag a dev install when installed is equal to or behind latest', () => {
+    writeCache('{"stale_hooks":["a.js"],"installed":"1.42.0","latest":"1.42.3"}');
+    expect(getGsdInfo(dir, opts)?.devInstall).toBeFalsy();
   });
 });

--- a/tests/render/line4.test.ts
+++ b/tests/render/line4.test.ts
@@ -41,15 +41,35 @@ describe('renderLine4', () => {
     expect(out).toContain('Fix critical bug');
   });
 
-  it('shows update available warning', () => {
+  // Update indicator mirrors GSD's own statusline text (`⬆ /gsd:update`) and
+  // renders even without a current task — so a GSD update is visible in ANY
+  // project, whether or not it has a .planning/STATE.md.
+  it('shows the GSD update indicator with no task (global)', () => {
     const out = stripAnsi(renderLine4(makeCtx({ updateAvailable: true }), c));
-    expect(out).toContain('GSD update available');
+    expect(out).toContain('/gsd:update');
   });
 
-  it('shows both task and update', () => {
+  it('shows both task and update indicator', () => {
     const out = stripAnsi(renderLine4(makeCtx({ currentTask: 'My task', updateAvailable: true }), c));
     expect(out).toContain('My task');
-    expect(out).toContain('GSD update available');
+    expect(out).toContain('/gsd:update');
+  });
+
+  it('shows the stale-hooks warning', () => {
+    const out = stripAnsi(renderLine4(makeCtx({ staleHooks: true }), c));
+    expect(out).toContain('stale hooks');
+    expect(out).toContain('/gsd:update');
+  });
+
+  it('shows the dev-install warning instead of stale-hooks when devInstall is set', () => {
+    const out = stripAnsi(renderLine4(makeCtx({ staleHooks: true, devInstall: true }), c));
+    expect(out).toContain('dev install');
+    expect(out).not.toContain('stale hooks');
+  });
+
+  it('renders progress-bar scene content carried in currentTask', () => {
+    const out = stripAnsi(renderLine4(makeCtx({ currentTask: 'v2.0 Automation █████░░░░░ 50%' }), c));
+    expect(out).toContain('█████░░░░░ 50%');
   });
 
   // ── Custom commands (issue #143 phase 3) ─────────────────────────


### PR DESCRIPTION
## Summary
GSD ships its own statusline; lumira (born as "a better statusline with GSD support") had drifted behind GSD 1.42.3. This brings the GSD widget to parity.

- Parse GSD's lifecycle/progress frontmatter (`active_phase`, `next_action`, `next_phases`, `progress`) and render its scenes (active phase / next action / milestone complete / default).
- Render the milestone progress bar (no brackets) + stale-hooks / dev-install warnings.
- Use GSD's own text/glyphs (`⬆ /gsd:update`, `⚠ stale hooks — run /gsd:update`).
- Show the update indicator in **any** project (gated on the update-check cache, not on a `.planning/STATE.md`).
- **GSD on by default** — self-gating, so non-GSD users see no extra line; minimal/singleline returns early and never reaches line 4.

## Tests
- Parser parity + scenes + stale/dev-install (consolidated, deduplicated GSD test file).
- Line-4 render: global update, stale/dev-install, bracket-less progress bar.
- `gsd` default-on assertion.
- Full suite green (1219), build + lint clean.

## Out of scope (separate)
- `CLAUDE_CODE_AUTO_COMPACT_WINDOW` (general context bar, not GSD).