### PR TITLE
chore(release): v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-06-02
+
+### Fixed
+
+- **GSD integration brought to parity with GSD 1.42.3.** lumira's GSD widget had drifted behind GSD's own statusline. It now mirrors GSD's lifecycle/progress format: parses `active_phase`, `next_action`/`next_phases`, and the nested `progress` block, and renders GSD's scenes (active phase, next action, milestone complete) plus a milestone progress bar. Stale-hooks and dev-install warnings are surfaced (`⚠ stale hooks — run /gsd:update`), and the update indicator (`⬆ /gsd:update`) now shows in **any** project — gated on GSD's update-check cache, not on the presence of a `.planning/STATE.md`. (#158)
+
+### Changed
+
+- **GSD support is on by default.** Mirroring GSD's own always-on statusline, the GSD widget no longer requires `--gsd`. It self-gates: with no `.planning/STATE.md` and no update-check cache it renders nothing, so non-GSD users see no change, and the `minimal`/single-line layout never reaches it. The milestone progress bar is rendered without brackets so it reads distinctly from the line-2 context bar. (#158)
+
 ## [1.8.0] - 2026-05-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Interactive wizard — preset, theme, icons — previewed live before write.
 
 > 3,400+ monthly downloads, zero marketing. Try it for one session — `npx lumira install`.
 
-> **What's new in v1.8.0:** compaction counter (`⊙ N` on line 2) — tracks how many times the session has been compacted, pairing with the auto-compact proximity glyph ⚠. Togglable via `display.compactionCount`, on by default in `full`/`balanced`. Combined with the added-dirs badge and worktree breadcrumb (v1.7.0), [`lumira stats` CLI](#stats-cli) (v1.5), `API N%` latency widget (v1.4.0), 7-day quota projection warning (v1.3.0), and auto-compact proximity glyph ⚠ (v1.4.1), recent releases add several diagnostic signals to the session.
+> **What's new in v1.8.1:** the GSD widget now mirrors get-shit-done (GSD)'s own statusline — phase/milestone lifecycle, a milestone progress bar, and `⬆ /gsd:update` / `⚠ stale hooks` indicators that show in any project. GSD support is on by default and self-gates (no GSD project → nothing renders). Earlier releases added the compaction counter `⊙ N` (v1.8.0), added-dirs badge + worktree breadcrumb (v1.7.0), [`lumira stats` CLI](#stats-cli) (v1.5), `API N%` latency widget (v1.4.0), 7-day quota projection (v1.3.0), and the auto-compact proximity glyph ⚠ (v1.4.1).
 
 ## Table of contents
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lumira",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lumira",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "MIT",
       "bin": {
         "lumira": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Real-time statusline HUD for Claude Code and Qwen Code. Includes session analytics CLI, API latency overhead widget, 7d quota projection, auto-compact proximity warnings, themes, and powerline. Zero deps.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
Release v1.8.1 — GSD integration parity hotfix (#158).

- Bumps `package.json`/`package-lock.json` → 1.8.1.
- CHANGELOG `[1.8.1]` (Fixed: GSD 1.42.3 parity + global update indicator; Changed: GSD on by default, self-gating, bracket-less progress bar).
- README "What's new" banner → v1.8.1.

## Test plan
- [x] `npm run build` ok
- [x] Full suite 1221/1221
- [ ] CI green → merge → tag `v1.8.1` → auto-publish to npm