### PR TITLE
fix(installer): write fast per-render command instead of npx@latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Installer writes a fast per-render command instead of `npx lumira@latest`.** The `statusLine.command` runs on every statusline refresh, and `npx lumira@latest` re-resolved "latest" from the npm registry each time (~600ms, cold ~1.3s) — ~10× slower than running the compiled binary directly (~60ms). `npx lumira install` now resolves the fastest available form: it writes the direct `lumira` binary when a global install exists, offers to `npm i -g lumira` in an interactive terminal (falling back to cached `npx lumira` if declined or non-interactive), and **migrates** existing `npx lumira@latest` setups to the faster form on re-install. Never downgrades a command that's already direct.
+
 ## [1.8.1] - 2026-06-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ npx lumira install
 
 The installer walks you through three choices — **preset** (`full` / `balanced` / `minimal`), **theme**, and **icons** — showing a live preview at each step. Press `Esc` to abort without writing anything. In non-interactive shells (piped stdin, CI), the installer skips the wizard and writes sensible defaults (`preset: balanced`, `icons: nerd`). If Qwen Code is detected (`~/.qwen/` exists), the `/lumira` skill is installed for both CLIs.
 
+For the fastest statusline (the command runs on **every** render), the installer offers to install lumira globally so it can invoke the compiled binary directly (`lumira`, ~60ms) instead of `npx` (which is ~10× slower). It also migrates older `npx lumira@latest` setups to the faster form automatically.
+
 Or install globally:
 
 ```bash
@@ -120,19 +122,19 @@ Your preferences are saved to `~/.config/lumira/config.json` — hand-edited key
 
 ### Manual setup
 
-Add to `~/.claude/settings.json`:
+The `statusLine.command` runs on every render, so prefer the **direct binary**. Install globally (`npm install -g lumira`), then add to `~/.claude/settings.json`:
 
 ```json
 {
   "statusLine": {
     "type": "command",
-    "command": "npx lumira@latest",
+    "command": "lumira",
     "padding": 0
   }
 }
 ```
 
-If installed from source:
+If installed from source, point at the compiled entry:
 
 ```json
 {
@@ -143,6 +145,8 @@ If installed from source:
   }
 }
 ```
+
+> Without a global install you can use `"command": "npx lumira"` — it works, but resolves through npx on every render (~10× slower). Avoid `npx lumira@latest`: the `@latest` hits the npm registry on every render.
 
 ## Display
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync, existsSync, copyFileSync, unlinkSync, mkdirSync, rmdirSync, renameSync, openSync, writeSync, fsyncSync, closeSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
+import { execFileSync } from 'node:child_process';
 import { sanitizeTermString } from './normalize.js';
 import { fileURLToPath } from 'node:url';
 import { createInterface } from 'node:readline';
@@ -20,11 +21,26 @@ const warn = (msg: string) => `${YELLOW}⚠${RST} ${msg}`;
 const header = () => `\n${CYAN} lumira installer${RST}\n`;
 
 // ── StatusLine value ────────────────────────────────────────────────
-const LUMIRA_STATUSLINE = {
-  type: 'command' as const,
-  command: 'npx lumira@latest',
-  padding: 0,
-};
+// The per-render command. `lumira` (a real global bin) runs the compiled
+// binary directly (~60ms). `npx lumira` resolves from cache (~150-300ms).
+// `npx lumira@latest` hits the npm registry EVERY render (~600ms) — never
+// write that form; it's the perf bug this installer migrates away from.
+function makeStatusLine(command: string) {
+  return { type: 'command' as const, command, padding: 0 };
+}
+
+// Rank a statusLine command by per-render speed (higher = faster).
+//   2 = direct binary  (`lumira`, `node …/dist/index.js`, ${CLAUDE_PLUGIN_ROOT})
+//   1 = npx, cached    (`npx lumira`)
+//   0 = npx, registry  (`npx lumira@latest` / any pinned `@version`)
+// Used to decide migration: only ever rewrite TOWARD a faster form.
+export function commandSpeed(command: string): 0 | 1 | 2 {
+  const c = command.trim();
+  if (/(^|\s)npx(\s|$)/.test(c)) {
+    return /@(latest|\d)/.test(c) ? 0 : 1;
+  }
+  return 2;
+}
 
 // ── Install options (DI for testing) ────────────────────────────────
 export interface InstallerOptions {
@@ -38,6 +54,58 @@ export interface InstallerOptions {
   });
   stdout?: NodeJS.WriteStream | (import('node:stream').Writable & { columns?: number });
   homeOverride?: string;
+  // Returns true if a global `lumira` bin is resolvable on PATH.
+  hasGlobalBin?: () => boolean;
+  // Runs `npm i -g lumira`; returns true on success. Injected in tests.
+  installGlobal?: () => boolean;
+}
+
+// Is `lumira` resolvable as a global bin on PATH?
+function defaultHasGlobalBin(): boolean {
+  const probe = process.platform === 'win32' ? 'where' : 'which';
+  try {
+    execFileSync(probe, ['lumira'], { stdio: 'ignore', timeout: 3000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Install lumira globally so the per-render command can invoke it directly.
+function defaultInstallGlobal(): boolean {
+  try {
+    execFileSync('npm', ['install', '-g', 'lumira'], { stdio: 'inherit', timeout: 120000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Resolve the fastest statusLine command available in this environment.
+// In a TTY with no global bin, offer to `npm i -g lumira` (confirmed) so the
+// command can be the direct `lumira`; otherwise fall back to cached `npx lumira`.
+async function resolveStatusLineCommand(ctx: {
+  isTTY: boolean;
+  confirm: (prompt: string) => Promise<boolean>;
+  hasGlobalBin: () => boolean;
+  installGlobal: () => boolean;
+  lines: string[];
+}): Promise<string> {
+  if (ctx.hasGlobalBin()) return 'lumira';
+
+  if (ctx.isTTY) {
+    const accepted = await ctx.confirm('Install lumira globally for ~10× faster rendering (npm i -g lumira)?');
+    if (accepted) {
+      if (ctx.installGlobal()) {
+        ctx.lines.push(ok('Installed lumira globally — statusline runs the compiled binary directly'));
+        return 'lumira';
+      }
+      ctx.lines.push(warn('Global install failed — using npx for now (run npm i -g lumira later for full speed)'));
+      return 'npx lumira';
+    }
+    ctx.lines.push(`  ${DIM}Tip: npm i -g lumira for ~10× faster rendering${RST}`);
+  }
+  return 'npx lumira';
 }
 
 function defaultSettingsPath(): string {
@@ -121,6 +189,8 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
   const confirm = opts.confirm ?? promptYN;
   const stdin = opts.stdin ?? process.stdin;
   const stdout = opts.stdout ?? process.stdout;
+  const hasGlobalBin = opts.hasGlobalBin ?? defaultHasGlobalBin;
+  const installGlobal = opts.installGlobal ?? defaultInstallGlobal;
   const lines: string[] = [];
 
   // Build banner prelude (shown on each wizard frame so it survives screen clears)
@@ -189,22 +259,45 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
     lines.push(ok('Non-interactive mode — using defaults (preset: balanced, icons: nerd)'));
   }
 
-  // ── settings.json replace/backup ───────────────────────────────
-  if (settings.statusLine) {
-    if (isLumira(settings.statusLine)) {
-      lines.push(ok('lumira is already configured as your statusline'));
-      saveConfig(wizard, configPath);
-      lines.push(ok(`Saved config → ${DIM}${configPath}${RST}`));
-      emitFooter(lines, opts.homeOverride);
-      return lines.join('\n') + '\n';
-    }
+  // Save config + emit footer + render output. Shared by every exit below.
+  const finalize = (): string => {
+    saveConfig(wizard, configPath);
+    lines.push(ok(`Saved config → ${DIM}${configPath}${RST}`));
+    emitFooter(lines, opts.homeOverride);
+    return lines.join('\n') + '\n';
+  };
 
+  // ── settings.json replace / backup / migrate ───────────────────
+  const existingIsLumira = !!settings.statusLine && isLumira(settings.statusLine);
+  const existingCmd = existingIsLumira
+    ? String((settings.statusLine as Record<string, unknown>).command ?? '')
+    : '';
+
+  // Already on the fastest form (direct binary) — nothing to rewrite.
+  if (existingIsLumira && commandSpeed(existingCmd) >= 2) {
+    lines.push(ok('lumira is already configured (optimal command)'));
+    return finalize();
+  }
+
+  // Resolve the fastest per-render command this environment can offer.
+  const resolvedCmd = await resolveStatusLineCommand({
+    isTTY: !!stdin?.isTTY, confirm, hasGlobalBin, installGlobal, lines,
+  });
+
+  if (existingIsLumira) {
+    // Existing lumira command (npx form) — only rewrite if strictly faster,
+    // so we never downgrade a user's direct binary to npx.
+    if (commandSpeed(resolvedCmd) <= commandSpeed(existingCmd)) {
+      lines.push(ok('lumira is already configured'));
+      return finalize();
+    }
+  } else if (settings.statusLine) {
     // Foreign statusLine already confirmed above — back it up and replace.
     copyFileSync(settingsPath, backupPath);
     lines.push(ok(`Backed up existing settings → ${DIM}settings.json.lumira.bak${RST}`));
   }
 
-  settings.statusLine = { ...LUMIRA_STATUSLINE };
+  settings.statusLine = makeStatusLine(resolvedCmd);
   mkdirSync(dirname(settingsPath), { recursive: true });
   const tmp = `${settingsPath}.${process.pid}.${Date.now()}.lumira.tmp`;
   try {
@@ -217,13 +310,11 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
     try { unlinkSync(tmp); } catch {}
     throw e;
   }
-  lines.push(ok('Configured lumira as statusline'));
+  lines.push(ok(existingIsLumira
+    ? `Upgraded statusline command → ${DIM}${resolvedCmd}${RST} (faster)`
+    : 'Configured lumira as statusline'));
 
-  saveConfig(wizard, configPath);
-  lines.push(ok(`Saved config → ${DIM}${configPath}${RST}`));
-
-  emitFooter(lines, opts.homeOverride);
-  return lines.join('\n') + '\n';
+  return finalize();
 }
 
 // ── Uninstall ───────────────────────────────────────────────────────

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -36,7 +36,8 @@ function makeStatusLine(command: string) {
 // Used to decide migration: only ever rewrite TOWARD a faster form.
 export function commandSpeed(command: string): 0 | 1 | 2 {
   const c = command.trim();
-  if (/(^|\s)npx(\s|$)/.test(c)) {
+  // `npx` as a bare word or a path basename (e.g. /usr/local/bin/npx, …\npx).
+  if (/(^|[\s/\\])npx(\s|$)/.test(c)) {
     return /@(latest|\d)/.test(c) ? 0 : 1;
   }
   return 2;

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -321,6 +321,8 @@ describe('install — wizard integration', () => {
       settingsPath, configPath,
       confirm: async () => true,
       stdin,
+      hasGlobalBin: () => false,
+      installGlobal: () => true,
     });
 
     const cfg = JSON.parse(readFileSync(configPath, 'utf8'));
@@ -349,7 +351,7 @@ describe('install — wizard integration', () => {
     const settingsPath = join(dir, 'settings.json');
     const stdin = createMockStdin(false);
 
-    await install({ settingsPath, configPath, confirm: async () => true, stdin });
+    await install({ settingsPath, configPath, confirm: async () => true, stdin, hasGlobalBin: () => false, installGlobal: () => true });
     const cfg = JSON.parse(readFileSync(configPath, 'utf8'));
     expect(cfg.display).toEqual({ tokens: false });
     expect(cfg.preset).toBe('balanced');
@@ -379,6 +381,8 @@ describe('install — skill dual install for Qwen', () => {
       confirm: async () => true,
       stdin,
       homeOverride: tmpHome,
+      hasGlobalBin: () => false,
+      installGlobal: () => true,
     });
 
     expect(existsSync(join(claudeHome, 'skills', 'lumira', 'SKILL.md'))).toBe(true);
@@ -396,6 +400,8 @@ describe('install — skill dual install for Qwen', () => {
       confirm: async () => true,
       stdin,
       homeOverride: tmpHome,
+      hasGlobalBin: () => false,
+      installGlobal: () => true,
     });
 
     expect(existsSync(join(claudeHome, 'skills', 'lumira', 'SKILL.md'))).toBe(true);

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -10,7 +10,10 @@ describe('commandSpeed', () => {
   it.each([
     ['npx lumira@latest', 0],
     ['npx -y lumira@latest', 0],
+    ['npx lumira@1.2.3', 0],
     ['npx lumira', 1],
+    ['npx -y lumira', 1],
+    ['/usr/local/bin/npx lumira', 1], // path-prefixed npx still counts as npx
     ['lumira', 2],
     ['node /home/u/lumira/dist/index.js', 2],
     ['node "${CLAUDE_PLUGIN_ROOT}/dist/index.js"', 2],
@@ -103,9 +106,10 @@ describe('install', () => {
         hasGlobalBin: () => false, installGlobal, confirm: async () => false,
       });
       await completeWizard(stdin);
-      await promise;
+      const output = await promise;
       expect(installGlobal).not.toHaveBeenCalled();
       expect(readCmd()).toBe('npx lumira');
+      expect(output).toContain('npm i -g lumira'); // tip toward the faster form
     });
 
     it('migrates a legacy `npx lumira@latest` command to `npx lumira`', async () => {
@@ -293,6 +297,9 @@ describe('install — wizard integration', () => {
       settingsPath, configPath,
       confirm: async () => true,
       stdin, stdout,
+      // Stub bin detection so a TTY install never shells out to `npm i -g`.
+      hasGlobalBin: () => false,
+      installGlobal: () => true,
     });
 
     // defaults: preset=balanced, theme=(none), icons=nerd

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -1,9 +1,23 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { install, uninstall } from '../src/installer.js';
+import { install, uninstall, commandSpeed } from '../src/installer.js';
 import { createMockStdin, createMockStdout } from './tui/_mock-stdin.js';
+
+describe('commandSpeed', () => {
+  // 0 = npx@registry (slow), 1 = npx cached, 2 = direct binary (fast)
+  it.each([
+    ['npx lumira@latest', 0],
+    ['npx -y lumira@latest', 0],
+    ['npx lumira', 1],
+    ['lumira', 2],
+    ['node /home/u/lumira/dist/index.js', 2],
+    ['node "${CLAUDE_PLUGIN_ROOT}/dist/index.js"', 2],
+  ])('ranks %j as speed %i', (cmd, rank) => {
+    expect(commandSpeed(cmd as string)).toBe(rank);
+  });
+});
 
 describe('install', () => {
   let dir: string;
@@ -11,14 +25,26 @@ describe('install', () => {
   let backupPath: string;
   let configPath: string;
 
-  // Helper: non-TTY stdin + isolated home + temp config path. Installs run
-  // through the single interactive path with wizard defaults.
+  // Read back the statusLine command that was written.
+  const readCmd = () => JSON.parse(readFileSync(settingsPath, 'utf8')).statusLine.command;
+  const flush = () => new Promise((r) => setImmediate(r));
+  // Drive the 3-step wizard (preset → theme → icons) to its defaults.
+  const completeWizard = async (stdin: ReturnType<typeof createMockStdin>) => {
+    await flush(); stdin.pressKey('return');
+    await flush(); stdin.pressKey('return');
+    await flush(); stdin.pressKey('return');
+  };
+
+  // baseOpts: non-TTY, no global bin → resolves to the `npx lumira` fallback
+  // (no prompt). installGlobal is stubbed so the real `npm i -g` never runs.
   const baseOpts = () => ({
     settingsPath,
     configPath,
     homeOverride: dir,
     stdin: createMockStdin(false),
     confirm: async () => true,
+    hasGlobalBin: () => false,
+    installGlobal: () => true,
   });
 
   beforeEach(() => {
@@ -29,109 +55,157 @@ describe('install', () => {
   });
   afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
 
-  it('creates settings file when none exists', async () => {
-    const output = await install(baseOpts());
-    expect(existsSync(settingsPath)).toBe(true);
-    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
-    expect(data.statusLine.command).toBe('npx lumira@latest');
-    expect(output).toContain('Configured');
+  // ── The fix: what per-render command gets written ────────────────
+  describe('statusLine command resolution', () => {
+    it('falls back to `npx lumira` when no global bin and non-TTY', async () => {
+      const output = await install(baseOpts());
+      expect(readCmd()).toBe('npx lumira');
+      expect(output).toContain('Configured');
+    });
+
+    it('writes the direct `lumira` binary when a global bin is present', async () => {
+      const installGlobal = vi.fn(() => true);
+      await install({ ...baseOpts(), hasGlobalBin: () => true, installGlobal });
+      expect(readCmd()).toBe('lumira');
+      expect(installGlobal).not.toHaveBeenCalled(); // already global, no install
+    });
+
+    it('offers a global install in a TTY and writes `lumira` on success', async () => {
+      const installGlobal = vi.fn(() => true);
+      const stdin = createMockStdin(true);
+      const promise = install({
+        ...baseOpts(), stdin, stdout: createMockStdout(),
+        hasGlobalBin: () => false, installGlobal, confirm: async () => true,
+      });
+      await completeWizard(stdin);
+      await promise;
+      expect(installGlobal).toHaveBeenCalledOnce();
+      expect(readCmd()).toBe('lumira');
+    });
+
+    it('falls back to `npx lumira` and warns when the global install fails', async () => {
+      const stdin = createMockStdin(true);
+      const promise = install({
+        ...baseOpts(), stdin, stdout: createMockStdout(),
+        hasGlobalBin: () => false, installGlobal: () => false, confirm: async () => true,
+      });
+      await completeWizard(stdin);
+      const output = await promise;
+      expect(readCmd()).toBe('npx lumira');
+      expect(output).toContain('Global install failed');
+    });
+
+    it('falls back to `npx lumira` when the user declines the global install', async () => {
+      const installGlobal = vi.fn(() => true);
+      const stdin = createMockStdin(true);
+      const promise = install({
+        ...baseOpts(), stdin, stdout: createMockStdout(),
+        hasGlobalBin: () => false, installGlobal, confirm: async () => false,
+      });
+      await completeWizard(stdin);
+      await promise;
+      expect(installGlobal).not.toHaveBeenCalled();
+      expect(readCmd()).toBe('npx lumira');
+    });
+
+    it('migrates a legacy `npx lumira@latest` command to `npx lumira`', async () => {
+      writeFileSync(settingsPath, JSON.stringify({ statusLine: { type: 'command', command: 'npx lumira@latest', padding: 0 } }));
+      const output = await install(baseOpts());
+      expect(readCmd()).toBe('npx lumira');
+      expect(output).toContain('Upgraded');
+      expect(existsSync(backupPath)).toBe(false); // our own command — no backup
+    });
+
+    it('upgrades `npx lumira@latest` to the direct `lumira` when a global bin exists', async () => {
+      writeFileSync(settingsPath, JSON.stringify({ statusLine: { type: 'command', command: 'npx lumira@latest', padding: 0 } }));
+      await install({ ...baseOpts(), hasGlobalBin: () => true });
+      expect(readCmd()).toBe('lumira');
+    });
+
+    it('leaves an already-direct `lumira` command untouched without prompting to install', async () => {
+      writeFileSync(settingsPath, JSON.stringify({ statusLine: { type: 'command', command: 'lumira', padding: 0 } }));
+      const installGlobal = vi.fn(() => true);
+      const output = await install({ ...baseOpts(), installGlobal });
+      expect(readCmd()).toBe('lumira');
+      expect(installGlobal).not.toHaveBeenCalled();
+      expect(output).toContain('already configured');
+    });
+
+    it('does not downgrade or churn an equal `npx lumira` command', async () => {
+      writeFileSync(settingsPath, JSON.stringify({ statusLine: { type: 'command', command: 'npx lumira', padding: 0 } }));
+      const output = await install(baseOpts());
+      expect(readCmd()).toBe('npx lumira');
+      expect(output).toContain('already configured');
+      expect(existsSync(backupPath)).toBe(false);
+    });
   });
 
-  it('adds statusLine when settings exists without one', async () => {
-    writeFileSync(settingsPath, JSON.stringify({ hooks: {} }, null, 2));
-    await install(baseOpts());
-    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
-    expect(data.statusLine.command).toBe('npx lumira@latest');
-    expect(data.hooks).toEqual({});
-    expect(existsSync(backupPath)).toBe(false);
-  });
+  // ── settings.json read/merge/backup/atomicity ────────────────────
+  describe('settings file handling', () => {
+    it('creates settings.json with no backup when none exists', async () => {
+      const output = await install(baseOpts());
+      expect(existsSync(settingsPath)).toBe(true);
+      expect(existsSync(backupPath)).toBe(false);
+      expect(output).toContain('Configured');
+    });
 
-  it('backs up and replaces existing statusLine after confirmation', async () => {
-    const original = { statusLine: { type: 'command', command: 'other-tool', padding: 0 } };
-    writeFileSync(settingsPath, JSON.stringify(original, null, 2));
-    const output = await install(baseOpts());
-    expect(existsSync(backupPath)).toBe(true);
-    const backup = JSON.parse(readFileSync(backupPath, 'utf8'));
-    expect(backup.statusLine.command).toBe('other-tool');
-    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
-    expect(data.statusLine.command).toBe('npx lumira@latest');
-    expect(output).toContain('Backed up');
-  });
+    it('preserves unrelated keys when settings exists without a statusLine', async () => {
+      writeFileSync(settingsPath, JSON.stringify({ hooks: {} }, null, 2));
+      await install(baseOpts());
+      const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
+      expect(data.hooks).toEqual({});
+      expect(data.statusLine.command).toBe('npx lumira');
+      expect(existsSync(backupPath)).toBe(false);
+    });
 
-  it('skips when already configured with lumira', async () => {
-    const existing = { statusLine: { type: 'command', command: 'npx lumira@latest', padding: 0 } };
-    writeFileSync(settingsPath, JSON.stringify(existing, null, 2));
-    const output = await install(baseOpts());
-    expect(output).toContain('already configured');
-    expect(existsSync(backupPath)).toBe(false);
-  });
+    it('backs up and replaces a foreign statusLine after confirmation', async () => {
+      writeFileSync(settingsPath, JSON.stringify({ statusLine: { type: 'command', command: 'other-tool', padding: 0 } }));
+      const output = await install(baseOpts());
+      expect(existsSync(backupPath)).toBe(true);
+      expect(JSON.parse(readFileSync(backupPath, 'utf8')).statusLine.command).toBe('other-tool');
+      expect(readCmd()).toBe('npx lumira');
+      expect(output).toContain('Backed up');
+    });
 
-  it('aborts when user declines replacement', async () => {
-    const original = { statusLine: { type: 'command', command: 'other-tool', padding: 0 } };
-    writeFileSync(settingsPath, JSON.stringify(original, null, 2));
-    const output = await install({ ...baseOpts(), confirm: async () => false });
-    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
-    expect(data.statusLine.command).toBe('other-tool');
-    expect(output).toContain('Aborted');
-  });
+    it('aborts and keeps the foreign statusLine when replacement is declined', async () => {
+      writeFileSync(settingsPath, JSON.stringify({ statusLine: { type: 'command', command: 'other-tool', padding: 0 } }));
+      const output = await install({ ...baseOpts(), confirm: async () => false });
+      expect(readCmd()).toBe('other-tool');
+      expect(output).toContain('Aborted');
+    });
 
-  it('recovers from malformed settings.json and creates fresh settings', async () => {
-    writeFileSync(settingsPath, 'this is { not valid JSON!!');
-    const output = await install(baseOpts());
-    expect(output).toContain('Could not parse');
-    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
-    expect(data.statusLine.command).toBe('npx lumira@latest');
-    expect(output).toContain('Configured');
-  });
+    it.each([
+      ['malformed JSON', 'this is { not valid JSON!!'],
+      ['JSON null', 'null'],
+      ['a JSON array', '[1,2,3]'],
+    ])('recovers from %s and writes a fresh statusLine', async (_label, contents) => {
+      writeFileSync(settingsPath, contents);
+      const output = await install(baseOpts());
+      expect(output).toContain('Could not parse');
+      expect(readCmd()).toBe('npx lumira');
+    });
 
-  it('creates parent directory when it does not exist', async () => {
-    const nestedSettingsPath = join(dir, 'nested', 'deep', 'settings.json');
-    const output = await install({ ...baseOpts(), settingsPath: nestedSettingsPath });
-    expect(existsSync(nestedSettingsPath)).toBe(true);
-    const data = JSON.parse(readFileSync(nestedSettingsPath, 'utf8'));
-    expect(data.statusLine.command).toBe('npx lumira@latest');
-    expect(output).toContain('Configured');
-  });
+    it('creates parent directories that do not exist', async () => {
+      const nested = join(dir, 'nested', 'deep', 'settings.json');
+      await install({ ...baseOpts(), settingsPath: nested });
+      expect(existsSync(nested)).toBe(true);
+      expect(JSON.parse(readFileSync(nested, 'utf8')).statusLine.command).toBe('npx lumira');
+    });
 
-  it('handles settings.json containing JSON null (treats as fresh)', async () => {
-    writeFileSync(settingsPath, 'null');
-    const output = await install(baseOpts());
-    expect(output).toContain('Could not parse');
-    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
-    expect(data.statusLine.command).toBe('npx lumira@latest');
-  });
+    it('writes valid JSON atomically and leaves no .lumira.tmp file behind', async () => {
+      await install(baseOpts());
+      expect(() => JSON.parse(readFileSync(settingsPath, 'utf8'))).not.toThrow();
+      expect(readdirSync(dir).filter(f => f.includes('lumira.tmp'))).toHaveLength(0);
+    });
 
-  it('handles settings.json containing a JSON array (treats as fresh)', async () => {
-    writeFileSync(settingsPath, '[1,2,3]');
-    const output = await install(baseOpts());
-    expect(output).toContain('Could not parse');
-    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
-    expect(data.statusLine.command).toBe('npx lumira@latest');
-  });
-
-  it('writes settings.json atomically — result is valid JSON', async () => {
-    await install(baseOpts());
-    expect(() => JSON.parse(readFileSync(settingsPath, 'utf8'))).not.toThrow();
-  });
-
-  it('writes temp file in same dir as settingsPath (no cross-fs rename)', async () => {
-    // Temp file lives beside settings.json (same-fs rename). Includes process.pid
-    // so concurrent installs don't collide. Neither the PID-based name nor the
-    // legacy static name should remain after a successful install.
-    await install(baseOpts());
-    const leftover = readdirSync(dir).filter(f => f.includes('lumira.tmp'));
-    expect(leftover).toHaveLength(0);
-    expect(existsSync(settingsPath)).toBe(true);
-  });
-
-  it('strips ANSI escapes from foreign statusLine.command in the warning banner', async () => {
-    const malicious = '\x1b[31mevil\x1b[0m';
-    writeFileSync(settingsPath, JSON.stringify({
-      statusLine: { type: 'command', command: malicious, padding: 0 },
-    }, null, 2));
-    const output = await install({ ...baseOpts(), confirm: async () => false });
-    expect(output).not.toContain('\x1b[31m');
-    expect(output).toContain('evil');
+    it('strips ANSI escapes from a foreign command in the warning banner', async () => {
+      writeFileSync(settingsPath, JSON.stringify({
+        statusLine: { type: 'command', command: '\x1b[31mevil\x1b[0m', padding: 0 },
+      }));
+      const output = await install({ ...baseOpts(), confirm: async () => false });
+      expect(output).not.toContain('\x1b[31m');
+      expect(output).toContain('evil');
+    });
   });
 });
 


### PR DESCRIPTION
## What

The installer's `statusLine.command` runs on **every** statusline render. It was hardcoded to `npx lumira@latest`, which re-resolves "latest" from the npm registry each render (~600ms, cold ~1.3s) — ~10× slower than invoking the compiled binary directly (~60ms).

`npx lumira install` now resolves the fastest command the environment can offer.

## Behavior

| Situation | Command written | Speed |
|---|---|---|
| Global bin present | `lumira` (direct) | ~60ms |
| TTY, no global, accepts | runs `npm i -g lumira` → `lumira` | ~60ms |
| TTY, declines / install fails | `npx lumira` + tip/warning | ~150-300ms |
| Non-TTY (CI/pipe) | `npx lumira` | ~150-300ms |
| Legacy `npx lumira@latest` | **migrated** → `lumira` or `npx lumira` | (was ~600ms) |

- New `commandSpeed()` ranks a command (direct=2 / cached npx=1 / `@latest`=0). Idempotency keys on speed, so re-install **migrates up** but never downgrades an already-direct command.
- Global install is offered only in a TTY (confirmed); non-interactive shells fall back silently to `npx lumira`. The real `npm i -g` is dependency-injected (`installGlobal`) and stubbed in tests.

## Tests

Consolidated the `install` suite (not just appended):
- 3 "treats as fresh" cases (malformed/null/array) → one `it.each`; 2 atomicity tests → 1.
- New `commandSpeed` table + `statusLine command resolution` describe covering all 9 branches.
- Split into `command resolution` / `settings file handling`.

1234 tests pass · `tsc` clean · `lint` clean.

## Notes
- README manual-setup section updated to recommend the direct binary; `@latest` removed.
- Docs comparison file intentionally left out of this PR (separate concern).
