### PR TITLE
chore(release): v1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.2] - 2026-06-02
+
 ### Fixed
 
-- **Installer writes a fast per-render command instead of `npx lumira@latest`.** The `statusLine.command` runs on every statusline refresh, and `npx lumira@latest` re-resolved "latest" from the npm registry each time (~600ms, cold ~1.3s) — ~10× slower than running the compiled binary directly (~60ms). `npx lumira install` now resolves the fastest available form: it writes the direct `lumira` binary when a global install exists, offers to `npm i -g lumira` in an interactive terminal (falling back to cached `npx lumira` if declined or non-interactive), and **migrates** existing `npx lumira@latest` setups to the faster form on re-install. Never downgrades a command that's already direct.
+- **Installer writes a fast per-render command instead of `npx lumira@latest`.** The `statusLine.command` runs on every statusline refresh, and `npx lumira@latest` re-resolved "latest" from the npm registry each time (~600ms, cold ~1.3s) — ~10× slower than running the compiled binary directly (~60ms). `npx lumira install` now resolves the fastest available form: it writes the direct `lumira` binary when a global install exists, offers to `npm i -g lumira` in an interactive terminal (falling back to cached `npx lumira` if declined or non-interactive), and **migrates** existing `npx lumira@latest` setups to the faster form on re-install. Never downgrades a command that's already direct. (#160)
 
 ## [1.8.1] - 2026-06-02
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Interactive wizard — preset, theme, icons — previewed live before write.
 
 > 3,400+ monthly downloads, zero marketing. Try it for one session — `npx lumira install`.
 
-> **What's new in v1.8.1:** the GSD widget now mirrors get-shit-done (GSD)'s own statusline — phase/milestone lifecycle, a milestone progress bar, and `⬆ /gsd:update` / `⚠ stale hooks` indicators that show in any project. GSD support is on by default and self-gates (no GSD project → nothing renders). Earlier releases added the compaction counter `⊙ N` (v1.8.0), added-dirs badge + worktree breadcrumb (v1.7.0), [`lumira stats` CLI](#stats-cli) (v1.5), `API N%` latency widget (v1.4.0), 7-day quota projection (v1.3.0), and the auto-compact proximity glyph ⚠ (v1.4.1).
+> **What's new in v1.8.2:** the installer now writes a fast per-render command — it runs the compiled `lumira` binary directly (~10× faster than `npx lumira@latest`, which hit the npm registry on every render) and migrates existing setups automatically. v1.8.1 brought the GSD widget to parity with get-shit-done (GSD)'s own statusline — phase/milestone lifecycle, a milestone progress bar, and `⬆ /gsd:update` / `⚠ stale hooks` indicators that show in any project (on by default, self-gating). Earlier releases added the compaction counter `⊙ N` (v1.8.0), added-dirs badge + worktree breadcrumb (v1.7.0), [`lumira stats` CLI](#stats-cli) (v1.5), `API N%` latency widget (v1.4.0), 7-day quota projection (v1.3.0), and the auto-compact proximity glyph ⚠ (v1.4.1).
 
 ## Table of contents
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lumira",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lumira",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "MIT",
       "bin": {
         "lumira": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Real-time statusline HUD for Claude Code and Qwen Code. Includes session analytics CLI, API latency overhead widget, 7d quota projection, auto-compact proximity warnings, themes, and powerline. Zero deps.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release v1.8.2 — installer perf fix.

## Included
- #160 — installer writes a fast per-render command (direct `lumira` / cached `npx lumira`) instead of `npx lumira@latest` (~10× faster per render); migrates existing setups; offers global install in a TTY.

## Release mechanics
- `package.json` + `package-lock.json` bumped to 1.8.2.
- CHANGELOG `[Unreleased]` → `[1.8.2]` dated section.
- README "What's new" updated.

On merge: tag `v1.8.2` → `release.yml` runs CI gate → GitHub Release → npm publish.