### PR TITLE
chore(release): v1.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Real-time statusline HUD for Claude Code and Qwen Code — analytics, quota projection, themes, powerline",
-    "version": "1.8.2",
+    "version": "1.9.0",
     "homepage": "https://github.com/cativo23/lumira"
   },
   "plugins": [
@@ -13,7 +13,7 @@
       "name": "lumira",
       "source": "./",
       "description": "Real-time statusline HUD for Claude Code and Qwen Code. Session analytics, API latency widget, 7-day quota projection, auto-compact warnings, 7 themes, powerline support. Zero runtime dependencies. Run /lumira:setup after install to activate.",
-      "version": "1.8.2",
+      "version": "1.9.0",
       "author": {
         "name": "Carlos Cativo"
       },
@@ -33,5 +33,5 @@
       ]
     }
   ],
-  "version": "1.8.2"
+  "version": "1.9.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "description": "Real-time statusline HUD for Claude Code and Qwen Code — session analytics, API latency, 7-day quota projection, auto-compact warnings, 7 themes, powerline. Zero runtime deps.",
   "author": {
     "name": "Carlos Cativo"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-06-14
+
+### Added
+
+- **Claude Code plugin marketplace support.** lumira can now be installed without npm via the Claude Code plugin system: `/plugin marketplace add cativo23/lumira`. After install, run `/lumira:setup` — the new activation skill reads the plugin cache path from `~/.claude/plugins/installed_plugins.json` and writes `statusLine.command` to `~/.claude/settings.json` pointing to the bundled binary. No `npm install` required. The `dist/` directory is now committed to git so the plugin system can use the binary directly from the cloned repo. A `scripts/bump-plugin-version.mjs` npm `version` lifecycle hook keeps `.claude-plugin/*.json` versions in sync with `package.json` on every release. (#162)
+
 ## [1.8.2] - 2026-06-02
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lumira",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lumira",
-      "version": "1.8.2",
+      "version": "1.9.0",
       "license": "MIT",
       "bin": {
         "lumira": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "description": "Real-time statusline HUD for Claude Code and Qwen Code. Includes session analytics CLI, API latency overhead widget, 7d quota projection, auto-compact proximity warnings, themes, and powerline. Zero deps.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Bumps version to **v1.9.0**.

### What's in this release

**Plugin marketplace support** — lumira can now be installed without npm:

```
/plugin marketplace add cativo23/lumira
/lumira:setup
```

Full changelog: see `CHANGELOG.md [1.9.0]`.