### PR TITLE
chore(plugin): remove unsupported homepage field from manifest metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,7 @@
   },
   "metadata": {
     "description": "Real-time statusline HUD for Claude Code and Qwen Code — analytics, quota projection, themes, powerline",
-    "version": "1.9.0",
-    "homepage": "https://github.com/cativo23/lumira"
+    "version": "1.9.0"
   },
   "plugins": [
     {


### PR DESCRIPTION
## Summary
- Removes the `homepage` field from `metadata` in `.claude-plugin/marketplace.json`
- Claude Code ignores unknown fields at load time; the field was surfacing a validator warning on `/plugin validate`

## Test plan
- [ ] `/plugin validate .` returns `✔ Validation passed` with no warnings