### PR TITLE
chore(plugin): remove unsupported homepage field from manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,7 @@
   },
   "metadata": {
     "description": "Real-time statusline HUD for Claude Code and Qwen Code — analytics, quota projection, themes, powerline",
-    "version": "1.9.0",
-    "homepage": "https://github.com/cativo23/lumira"
+    "version": "1.9.0"
   },
   "plugins": [
     {


### PR DESCRIPTION
## Summary

- Removes the `homepage` field from `.claude-plugin/marketplace.json` metadata block
- Claude Code ignores unknown fields at load time, but the validator surfaces a warning — cleaning it up removes the noise

## Test plan

- [ ] Plugin still installs correctly via `/plugin marketplace add cativo23/lumira`
- [ ] No marketplace validator warnings on `homepage` field