### PR TITLE
fix(normalize): exclude output tokens from context bar, honor CLAUDE_CODE_AUTO_COMPACT_WINDOW

### DIFF
--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -126,15 +126,18 @@ const VALID_EFFORT_LEVELS = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
 type CurrentUsageObject = { input_tokens?: number; output_tokens?: number; cache_read_input_tokens?: number; cache_creation_input_tokens?: number };
 
 /**
- * Sum all four token categories from `context_window.current_usage` to compute
- * a real context usage total (input + output + cache_read + cache_creation).
+ * Sum input token categories from `context_window.current_usage` to compute
+ * a real context usage total (input + cache_read + cache_creation).
+ * Excludes output_tokens: they are per-turn and reset each call, which would
+ * cause the context bar to jitter (jump down at the start of every new turn).
+ * Context window fill is determined by what was READ from the context, not
+ * by how many tokens were output.
  * Returns undefined when `cu` is absent or not an object shape.
  */
 function getRealUsageTotal(cu: unknown): number | undefined {
   if (typeof cu !== 'object' || !cu) return undefined;
   const obj = cu as CurrentUsageObject;
   const total = (obj.input_tokens ?? 0)
-    + (obj.output_tokens ?? 0)
     + (obj.cache_read_input_tokens ?? 0)
     + (obj.cache_creation_input_tokens ?? 0);
   return total;
@@ -217,10 +220,21 @@ export function normalize(input: RawInput): NormalizedInput {
 
   // Auto-compact proximity warning: fires when context fill is in the
   // [threshold-gap, threshold) window. Uses realUsedPercentage when available
-  // (more accurate; includes output+cache), falls back to usedPercentage for
+  // (more accurate; excludes output tokens), falls back to usedPercentage for
   // legacy payloads. Gated by platform (different thresholds Claude vs Qwen).
+  // For claude-code, honors CLAUDE_CODE_AUTO_COMPACT_WINDOW env var when set to
+  // a valid integer in [1, 100]; falls back to the hardcoded default otherwise.
   const effectivePct = realUsedPercentage ?? contextWindow.used_percentage ?? 0;
-  const platformAutoCompactThreshold = AUTO_COMPACT_THRESHOLD[platform];
+  let platformAutoCompactThreshold = AUTO_COMPACT_THRESHOLD[platform];
+  if (platform === 'claude-code') {
+    const envVal = process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
+    if (envVal !== undefined) {
+      const parsed = parseInt(envVal, 10);
+      if (Number.isInteger(parsed) && parsed >= 1 && parsed <= 100) {
+        platformAutoCompactThreshold = parsed;
+      }
+    }
+  }
   const nearAutoCompact = effectivePct >= (platformAutoCompactThreshold - AUTO_COMPACT_WARNING_GAP)
     && effectivePct < platformAutoCompactThreshold;
 

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -206,9 +206,9 @@ export function normalize(input: RawInput): NormalizedInput {
     ({ denominator: cacheTurnDenominator } = getCacheFields(claude.context_window?.current_usage));
   }
 
-  // Real context usage percentage (Claude only): includes output tokens in the numerator,
-  // unlike the hook-provided `used_percentage` which excludes them. This gives an accurate
-  // picture of actual context consumption, especially near auto-compact thresholds.
+  // Real context usage percentage (Claude only): sums input + cache_read + cache_creation
+  // (output_tokens excluded — per-turn, resets each call, causes bar jitter). More stable
+  // than the hook-provided `used_percentage` near auto-compact thresholds.
   let realUsedPercentage: number | undefined;
   if (claude) {
     const total = getRealUsageTotal(claude.context_window?.current_usage);

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -222,14 +222,18 @@ export function normalize(input: RawInput): NormalizedInput {
   // [threshold-gap, threshold) window. Uses realUsedPercentage when available
   // (more accurate; excludes output tokens), falls back to usedPercentage for
   // legacy payloads. Gated by platform (different thresholds Claude vs Qwen).
-  // For claude-code, honors CLAUDE_CODE_AUTO_COMPACT_WINDOW env var when set to
-  // a valid integer in [1, 100]; falls back to the hardcoded default otherwise.
+  // For claude-code, honors CLAUDE_CODE_AUTO_COMPACT_WINDOW env var — a fill-%
+  // threshold (1-100) that mirrors Claude Code's own auto-compact trigger point.
+  // Users who changed this setting in Claude Code should set the same value here.
+  // Falls back to the hardcoded 80% default when absent or invalid.
   const effectivePct = realUsedPercentage ?? contextWindow.used_percentage ?? 0;
   let platformAutoCompactThreshold = AUTO_COMPACT_THRESHOLD[platform];
   if (platform === 'claude-code') {
     const envVal = process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
     if (envVal !== undefined) {
-      const parsed = parseInt(envVal, 10);
+      // Use Number() + Number.isInteger() so floats ("75.5") and trailing-junk
+      // strings ("80abc") are rejected rather than silently truncated by parseInt.
+      const parsed = Number(envVal);
       if (Number.isInteger(parsed) && parsed >= 1 && parsed <= 100) {
         platformAutoCompactThreshold = parsed;
       }

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { normalize, sanitizeTermString, isQwenInput } from '../src/normalize.js';
@@ -130,9 +130,29 @@ describe('normalize', () => {
   });
 
   describe('realUsedPercentage', () => {
+    it('excludes output_tokens from realUsedPercentage to prevent bar jitter', () => {
+      // output_tokens should NOT contribute to realUsedPercentage
+      // input_tokens: 40000, output_tokens: 10000, cache_read: 5000, cache_creation: 2000
+      // Expected: (40000 + 5000 + 2000) / 100000 * 100 = 47 (not 57)
+      const input = {
+        ...modernInput,
+        context_window: {
+          ...modernInput.context_window,
+          context_window_size: 100000,
+          current_usage: {
+            input_tokens: 40000,
+            output_tokens: 10000,
+            cache_read_input_tokens: 5000,
+            cache_creation_input_tokens: 2000,
+          },
+        },
+      };
+      expect(normalize(input).context.realUsedPercentage).toBeCloseTo(47, 1);
+    });
+
     it('modern payload calculates real percentage from all token categories', () => {
-      // (70000 + 12000 + 10000 + 5000) / 200000 * 100 = 48.5
-      expect(normalize(modernInput).context.realUsedPercentage).toBeCloseTo(48.5, 1);
+      // output_tokens excluded: (70000 + 10000 + 5000) / 200000 * 100 = 42.5
+      expect(normalize(modernInput).context.realUsedPercentage).toBeCloseTo(42.5, 1);
     });
 
     it('legacy payload without full current_usage shape returns undefined', () => {
@@ -170,7 +190,7 @@ describe('normalize', () => {
           },
         },
       };
-      // 140000 / 100000 * 100 = 140 → clamped to 100
+      // output_tokens excluded: (80000 + 20000 + 10000) / 100000 * 100 = 110 → clamped to 100
       expect(normalize(input).context.realUsedPercentage).toBe(100);
     });
 
@@ -242,7 +262,9 @@ describe('normalize', () => {
 
     it('modern Claude payload uses realUsedPercentage to gate the flag', () => {
       // Construct current_usage so the real usage sum is 152000 / 200000 = 76%
-      // while used_percentage (hook-provided, input-only) stays at 42%.
+      // (output_tokens excluded — only input + cache_read + cache_creation count).
+      // used_percentage (hook-provided, input-only) stays at 42% to confirm that
+      // the nearAutoCompact flag is driven by realUsedPercentage, not usedPercentage.
       const input: ClaudeCodeInput = {
         ...modernInput,
         context_window: {
@@ -250,7 +272,7 @@ describe('normalize', () => {
           context_window_size: 200000,
           used_percentage: 42,
           current_usage: {
-            input_tokens: 120000,
+            input_tokens: 132000,
             output_tokens: 12000,
             cache_read_input_tokens: 15000,
             cache_creation_input_tokens: 5000,
@@ -258,7 +280,7 @@ describe('normalize', () => {
         },
       };
       const result = normalize(input);
-      // Sanity: realUsedPercentage should land at 76 (in [75, 80))
+      // Sanity: realUsedPercentage = (132000 + 15000 + 5000) / 200000 = 76 (in [75, 80))
       expect(result.context.realUsedPercentage).toBeCloseTo(76, 1);
       expect(result.context.nearAutoCompact).toBe(true);
     });
@@ -270,6 +292,23 @@ describe('normalize', () => {
       };
       expect(normalize(input).context.nearAutoCompact).toBe(false);
     });
+
+    it('nearAutoCompact honors CLAUDE_CODE_AUTO_COMPACT_WINDOW env var', () => {
+      // With env var = 60, the warning window is [55, 60).
+      // 57% context fill should trigger nearAutoCompact = true.
+      vi.stubEnv('CLAUDE_CODE_AUTO_COMPACT_WINDOW', '60');
+      const input = claudeAt(57);
+      expect(normalize(input).context.nearAutoCompact).toBe(true);
+
+      // Without env var (default threshold = 80), [75, 80).
+      // 57% should NOT trigger nearAutoCompact.
+      vi.unstubAllEnvs();
+      expect(normalize(claudeAt(57)).context.nearAutoCompact).toBe(false);
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   describe('cost and duration (Claude only)', () => {

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -41,8 +41,8 @@ describe('renderLine2', () => {
   });
 
   it('context bar uses realUsedPercentage when available (not usedPercentage)', () => {
-    // usedPercentage=42 but realUsedPercentage=48.5 (red test — passes after Task 3 updates renderer)
-    // (input 70k + output 12k + cache_read 10k + cache_creation 5k) / 200k * 100 = 48.5
+    // usedPercentage=42 but realUsedPercentage=42.5 (output_tokens excluded — per-turn jitter)
+    // (input 70k + cache_read 10k + cache_creation 5k) / 200k * 100 = 42.5
     const inputOverride = {
       context_window: {
         used_percentage: 42,
@@ -59,9 +59,9 @@ describe('renderLine2', () => {
       },
     };
     const out = stripAnsi(renderLine2(makeCtx({}, inputOverride), c));
-    // Must show 49% (realUsedPercentage 48.5 rounds to 49) not 42% (input-only %)
-    // buildContextBar uses Math.round, so 48.5 → 49%
-    expect(out).toContain('49%');
+    // Must show 43% (realUsedPercentage 42.5 rounds to 43) not 42% (hook used_percentage)
+    // buildContextBar uses Math.round, so 42.5 → 43%
+    expect(out).toContain('43%');
     expect(out).not.toContain('42%');
   });
 


### PR DESCRIPTION
## Summary

Two fixes in `src/normalize.ts`:

**1. Context bar jitter (output_tokens excluded from realUsedPercentage)**

`getRealUsageTotal` was summing `current_usage.output_tokens` alongside input tokens. But `current_usage` is per-turn — `output_tokens` resets to a small value at the start of each new API call, causing the context bar to visually jump down then climb back up every turn. Context window fill is determined by what was READ from the context, not what was generated.

**2. `CLAUDE_CODE_AUTO_COMPACT_WINDOW` env var honored**

Users who set `CLAUDE_CODE_AUTO_COMPACT_WINDOW` in Claude Code can now mirror that threshold in lumira. The `nearAutoCompact` warning fires at the right time when using a custom compact window. Falls back to the hardcoded 80% default when absent or invalid.

## Test plan

- [ ] `npm test tests/normalize.test.ts` — 94 tests pass
- [ ] New test: `excludes output_tokens from realUsedPercentage to prevent bar jitter`
- [ ] New test: `nearAutoCompact honors CLAUDE_CODE_AUTO_COMPACT_WINDOW env var`
- [ ] Full suite: `npm test` — no regressions