### PR TITLE
fix(stats): dedup message IDs to prevent 2-4x token inflation

### DIFF
--- a/src/parsers/transcript-stats.ts
+++ b/src/parsers/transcript-stats.ts
@@ -82,6 +82,15 @@ export async function aggregateStats(transcriptPath: string): Promise<SessionSta
 
   const stats = emptyStats();
 
+  // Dedup guard: Claude Code streams one JSONL entry per content block for
+  // the same logical message (thinking → text → tool_use all share one
+  // message.id). Each entry carries the full usage block for that turn, so
+  // naively accumulating every entry inflates tokens/cost by the number of
+  // content blocks. Track seen message IDs and skip usage+cost on repeats.
+  // Content extraction (tool_use, tool_result) is NOT gated — each block
+  // appears exactly once in its own entry and must still be counted.
+  const seenMessageIds = new Set<string>();
+
   let fileStream: ReturnType<typeof createReadStream> | null = null;
   try {
     fileStream = createReadStream(resolved);
@@ -111,10 +120,20 @@ export async function aggregateStats(transcriptPath: string): Promise<SessionSta
 
       const message = (entry.message ?? null) as Record<string, unknown> | null;
 
+      // Determine whether this is the first time we're seeing this message.id.
+      // Entries without a message.id (e.g. user turns, summary lines) are
+      // always treated as first-occurrence so they're never suppressed.
+      const messageId = message !== null && typeof message.id === 'string' ? message.id : null;
+      const isFirstOccurrence = messageId === null || !seenMessageIds.has(messageId);
+      if (messageId !== null) seenMessageIds.add(messageId);
+
       // Usage block (assistant turns only). The mere presence of a usage
       // payload flips hasCostData=true even if all counts are zero — see
       // the "zero-cost-with-usage" test for why this matters.
-      if (entry.type === 'assistant' && message && typeof message === 'object') {
+      //
+      // Gated on isFirstOccurrence: duplicate entries for the same message.id
+      // carry identical usage blocks; accumulating them inflates counts 2-3×.
+      if (isFirstOccurrence && entry.type === 'assistant' && message && typeof message === 'object') {
         const usage = message.usage as Record<string, unknown> | undefined;
         if (usage && typeof usage === 'object') {
           stats.hasCostData = true;
@@ -135,10 +154,14 @@ export async function aggregateStats(transcriptPath: string): Promise<SessionSta
       // undefined`), not truthiness — Anthropic emits `total_cost_usd: 0` for
       // fully-cached turns, and a `topCost || msgCost` short-circuit would
       // incorrectly fall through to the message field in that case.
-      const topCost = safeNumber(entry.total_cost_usd);
-      const msgCost = message ? safeNumber(message.total_cost_usd) : 0;
-      const costContribution = entry.total_cost_usd !== undefined ? topCost : msgCost;
-      stats.costUsd += costContribution;
+      //
+      // Also gated on isFirstOccurrence for the same dedup reason as usage above.
+      if (isFirstOccurrence) {
+        const topCost = safeNumber(entry.total_cost_usd);
+        const msgCost = message ? safeNumber(message.total_cost_usd) : 0;
+        const costContribution = entry.total_cost_usd !== undefined ? topCost : msgCost;
+        stats.costUsd += costContribution;
+      }
 
       // Tool / agent / error extraction from the message.content array.
       const content = message?.content;

--- a/tests/parsers/transcript-stats.test.ts
+++ b/tests/parsers/transcript-stats.test.ts
@@ -229,6 +229,54 @@ describe('aggregateStats — edge cases', () => {
     expect(stats.hasCostData).toBe(true);
   });
 
+  it('counts tokens only once when Claude Code emits multiple entries for the same message.id', async () => {
+    // Real transcripts: Claude Code streams one JSONL entry *per content block*
+    // for the same logical message (thinking → text → tool_use all share one
+    // message.id). Every entry carries the full usage block for that message.
+    // aggregateStats must dedup by message.id so tokens are counted once,
+    // not once-per-content-block.
+    //
+    // This fixture mirrors the real pattern: one logical message (msg_dup)
+    // split across three lines — thinking, text, tool_use — each with
+    // identical usage counts. A second message (msg_unique) appears once.
+    // Expected: inputTokens = 100 (msg_dup) + 50 (msg_unique) = 150, not
+    //           100*3 + 50 = 350.
+    const p = join(workDir, 'duplicate-message-id.jsonl');
+    const makeEntry = (id: string, contentType: string, inputTokens: number) => JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-05-23T05:00:00.000Z',
+      total_cost_usd: 0.01,
+      message: {
+        id,
+        content: [{ type: contentType, text: 'x' }],
+        usage: {
+          input_tokens: inputTokens,
+          output_tokens: 10,
+          cache_read_input_tokens: 200,
+          cache_creation_input_tokens: 0,
+        },
+      },
+    });
+    writeFileSync(p, [
+      makeEntry('msg_dup', 'thinking', 100),  // first content block for msg_dup
+      makeEntry('msg_dup', 'text', 100),       // second content block — same id, same usage
+      makeEntry('msg_dup', 'tool_use', 100),   // third content block — same id, same usage
+      makeEntry('msg_unique', 'text', 50),     // different message, counted once
+    ].join('\n') + '\n');
+
+    const stats = await aggregateStats(p);
+    // msg_dup contributes 100 input tokens (not 300), msg_unique contributes 50.
+    expect(stats.inputTokens).toBe(150);
+    // output_tokens: 10 each × 2 unique messages = 20
+    expect(stats.outputTokens).toBe(20);
+    // cacheReadTokens: 200 each × 2 unique messages = 400
+    expect(stats.cacheReadTokens).toBe(400);
+    // costUsd: 0.01 per entry — but cost lives on the entry, not the message.
+    // With dedup on message.id, cost is also counted once per unique message.
+    expect(stats.costUsd).toBeCloseTo(0.02, 5);
+    expect(stats.hasCostData).toBe(true);
+  });
+
   it('prefers top-level total_cost_usd:0 over a non-zero message.total_cost_usd', async () => {
     // Regression: Anthropic emits `total_cost_usd: 0` for fully-cached turns.
     // The aggregator must treat that explicit 0 as authoritative and NOT


### PR DESCRIPTION
## Summary

Fixes a token/cost inflation bug in `lumira stats`. Claude Code writes one JSONL entry per content block for the same logical message (thinking, text, tool_use all share `message.id`). Each entry carries the identical full `usage` block, so accumulating without dedup inflates tokens and cost by the number of content blocks — observed 2-4× in normal sessions, up to 7× in heavy sessions.

**Root cause verified** against real transcripts:
- `3439295b`: 203 entries, 62 duplicate message IDs
- `e1483367`: 1317 entries, 427 duplicate message IDs

Fix: track seen `message.id` in a `Set`; skip usage+cost accumulation on duplicates. Tool/error extraction is not gated (each content block appears exactly once in its own entry).

## Test plan

- [ ] `npm test tests/parsers/transcript-stats.test.ts` — all tests pass
- [ ] New test: `counts tokens only once when Claude Code emits multiple entries for the same message.id`
- [ ] Full suite: `npm test` — 1238 tests, no regressions