### PR TITLE
feat(gsd): detect update cache from gsd-core (open-gsd ≥ 1.4.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Planned
+
+- **GSD Core: plan-level progress within phase.** Parse `Plan: A of B in current phase` from STATE.md (gsd-core ≥ 1.4.x) and render it alongside the phase indicator — e.g. `Phase 3 p2/5 (auth)`. More granular than phase-only progress.
+- **GSD Core: continue-here indicator.** Parse `Resume file:` from STATE.md and show a `↩` icon on line 4 when an active `.continue-here.md` exists. Instant visual cue that a resume point is waiting.
+- **GSD Core: plan-based progress bar.** Use `completed_plans / total_plans` from the STATE.md frontmatter `progress` block for the milestone bar instead of phase-based `percent`. Finer granularity, especially in phases with many plans.
+
 ## [1.9.0] - 2026-06-14
 
 ### Added

--- a/dist/parsers/gsd.js
+++ b/dist/parsers/gsd.js
@@ -185,14 +185,16 @@ function semverCompare(a, b) {
     return 0;
 }
 /**
- * Read GSD update-check cache. Checks the shared tool-agnostic cache first
- * (`~/.cache/gsd/`, introduced by GSD #1421), then falls back to the legacy
- * per-runtime location (`~/.claude/cache/`) for older GSD installs.
+ * Read GSD update-check cache. Checks candidates in order — first match wins:
+ * 1. open-gsd per-package cache (`gsd-update-check-opengsd-gsd-core.json`, gsd-core ≥ 1.4.x)
+ * 2. Legacy shared tool-agnostic cache (`gsd-update-check.json`, get-shit-done-cc ≥ 1.x)
+ * 3. Legacy per-runtime location (`~/.claude/cache/`) for older installs
  * Returns update status, stale hooks flag, and dev install flag.
  */
-function readUpdateCache(sharedCacheFile, legacyCacheFile) {
+function readUpdateCache(openGsdCacheFile, sharedCacheFile, legacyCacheFile) {
     const result = { updateAvailable: false, staleHooks: false, devInstall: false };
     const candidates = [
+        ['open-gsd', openGsdCacheFile],
         ['shared', sharedCacheFile],
         ['legacy', legacyCacheFile],
     ];
@@ -226,9 +228,11 @@ function readUpdateCache(sharedCacheFile, legacyCacheFile) {
 }
 export function getGsdInfo(cwd, opts = {}) {
     const claudeDir = opts.claudeDir ?? process.env['CLAUDE_CONFIG_DIR'] ?? join(homedir(), '.claude');
-    const sharedCacheFile = opts.sharedCacheFile ?? join(homedir(), '.cache', 'gsd', 'gsd-update-check.json');
+    const gsdCacheDir = join(homedir(), '.cache', 'gsd');
+    const openGsdCacheFile = opts.openGsdCacheFile ?? join(gsdCacheDir, 'gsd-update-check-opengsd-gsd-core.json');
+    const sharedCacheFile = opts.sharedCacheFile ?? join(gsdCacheDir, 'gsd-update-check.json');
     const legacyCacheFile = join(claudeDir, 'cache', 'gsd-update-check.json');
-    const cacheData = readUpdateCache(sharedCacheFile, legacyCacheFile);
+    const cacheData = readUpdateCache(openGsdCacheFile, sharedCacheFile, legacyCacheFile);
     let currentTask;
     const stateFile = findStateMd(cwd || process.cwd());
     if (stateFile) {

--- a/src/parsers/gsd.ts
+++ b/src/parsers/gsd.ts
@@ -198,14 +198,16 @@ interface CacheData {
 }
 
 /**
- * Read GSD update-check cache. Checks the shared tool-agnostic cache first
- * (`~/.cache/gsd/`, introduced by GSD #1421), then falls back to the legacy
- * per-runtime location (`~/.claude/cache/`) for older GSD installs.
+ * Read GSD update-check cache. Checks candidates in order — first match wins:
+ * 1. open-gsd per-package cache (`gsd-update-check-opengsd-gsd-core.json`, gsd-core ≥ 1.4.x)
+ * 2. Legacy shared tool-agnostic cache (`gsd-update-check.json`, get-shit-done-cc ≥ 1.x)
+ * 3. Legacy per-runtime location (`~/.claude/cache/`) for older installs
  * Returns update status, stale hooks flag, and dev install flag.
  */
-function readUpdateCache(sharedCacheFile: string, legacyCacheFile: string): CacheData {
+function readUpdateCache(openGsdCacheFile: string, sharedCacheFile: string, legacyCacheFile: string): CacheData {
   const result: CacheData = { updateAvailable: false, staleHooks: false, devInstall: false };
   const candidates: Array<[string, string]> = [
+    ['open-gsd', openGsdCacheFile],
     ['shared', sharedCacheFile],
     ['legacy', legacyCacheFile],
   ];
@@ -246,15 +248,19 @@ function readUpdateCache(sharedCacheFile: string, legacyCacheFile: string): Cach
 export interface GsdInfoOptions {
   /** Per-runtime claude config dir (holds `cache/gsd-update-check.json` in old GSD). */
   claudeDir?: string;
-  /** Tool-agnostic shared cache file path. Overridable for tests. */
+  /** Tool-agnostic shared cache file path (get-shit-done-cc ≥ 1.x). Overridable for tests. */
   sharedCacheFile?: string;
+  /** Per-package cache written by gsd-core ≥ 1.4.x. Overridable for tests. */
+  openGsdCacheFile?: string;
 }
 
 export function getGsdInfo(cwd: string, opts: GsdInfoOptions = {}): GsdInfo | null {
   const claudeDir = opts.claudeDir ?? process.env['CLAUDE_CONFIG_DIR'] ?? join(homedir(), '.claude');
-  const sharedCacheFile = opts.sharedCacheFile ?? join(homedir(), '.cache', 'gsd', 'gsd-update-check.json');
+  const gsdCacheDir = join(homedir(), '.cache', 'gsd');
+  const openGsdCacheFile = opts.openGsdCacheFile ?? join(gsdCacheDir, 'gsd-update-check-opengsd-gsd-core.json');
+  const sharedCacheFile = opts.sharedCacheFile ?? join(gsdCacheDir, 'gsd-update-check.json');
   const legacyCacheFile = join(claudeDir, 'cache', 'gsd-update-check.json');
-  const cacheData = readUpdateCache(sharedCacheFile, legacyCacheFile);
+  const cacheData = readUpdateCache(openGsdCacheFile, sharedCacheFile, legacyCacheFile);
 
   let currentTask: string | undefined;
   const stateFile = findStateMd(cwd || process.cwd());

--- a/tests/parsers/gsd.test.ts
+++ b/tests/parsers/gsd.test.ts
@@ -107,15 +107,19 @@ status: executing
 describe('getGsdInfo', () => {
   let dir: string;
   let claudeDir: string;
-  let opts: { claudeDir: string; sharedCacheFile: string };
+  let opts: { claudeDir: string; sharedCacheFile: string; openGsdCacheFile: string };
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'gsd-cwd-'));
     claudeDir = mkdtempSync(join(tmpdir(), 'gsd-claude-'));
     mkdirSync(join(claudeDir, 'cache'), { recursive: true });
-    // Point the shared cache at a path inside claudeDir so tests never read the
-    // real ~/.cache/gsd on the dev machine.
-    opts = { claudeDir, sharedCacheFile: join(claudeDir, 'shared-cache.json') };
+    // Point all cache paths inside claudeDir so tests never read the real
+    // ~/.cache/gsd on the dev machine.
+    opts = {
+      claudeDir,
+      sharedCacheFile: join(claudeDir, 'shared-cache.json'),
+      openGsdCacheFile: join(claudeDir, 'open-gsd-cache.json'),
+    };
   });
   afterEach(() => {
     rmSync(dir, { recursive: true, force: true });
@@ -132,6 +136,10 @@ describe('getGsdInfo', () => {
   function writeCache(json: string): void {
     writeFileSync(join(claudeDir, 'cache', 'gsd-update-check.json'), json);
   }
+  /** Write the open-gsd per-package update-check cache (gsd-core ≥ 1.4.x). */
+  function writeOpenGsdCache(json: string): void {
+    writeFileSync(opts.openGsdCacheFile, json);
+  }
 
   // ── signal gating ─────────────────────────────────────────────────────────
   it('returns null when there is no STATE.md ancestor and no update cache', () => {
@@ -140,6 +148,17 @@ describe('getGsdInfo', () => {
 
   it('reads update_available from the legacy per-runtime cache', () => {
     writeCache('{"update_available":true}');
+    expect(getGsdInfo(dir, opts)?.updateAvailable).toBe(true);
+  });
+
+  it('reads update_available from the open-gsd per-package cache (gsd-core ≥ 1.4.x)', () => {
+    writeOpenGsdCache('{"update_available":true,"installed":"1.4.5","latest":"1.5.0"}');
+    expect(getGsdInfo(dir, opts)?.updateAvailable).toBe(true);
+  });
+
+  it('open-gsd cache takes priority over legacy shared cache', () => {
+    writeOpenGsdCache('{"update_available":true}');
+    writeCache('{"update_available":false}');
     expect(getGsdInfo(dir, opts)?.updateAvailable).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

`get-shit-done-cc` moved to `@opengsd/gsd-core`, which writes its update-check cache to a new path:

```
~/.cache/gsd/gsd-update-check-opengsd-gsd-core.json
```

The old lumira parser only checked `gsd-update-check.json`, so users who migrated to gsd-core would never see the ⬆ update indicator.

### Changes

- `readUpdateCache` now checks `gsd-update-check-opengsd-gsd-core.json` first, then falls back to the legacy shared cache and per-runtime cache
- `openGsdCacheFile` option added to `GsdInfoOptions` for test isolation
- Two new tests: reading from the new path, and priority over the legacy cache

## Test plan

- [x] `tests/parsers/gsd.test.ts` — 35 tests pass, including 2 new ones for open-gsd cache path
- [x] Full suite: 1242/1242 green