### PR TITLE
chore(release): v1.9.1

### DIFF
--- a/dist/normalize.js
+++ b/dist/normalize.js
@@ -29,8 +29,12 @@ export function sanitizeTermString(s) {
 /** Allowed values for the reasoning effort level field (CC ≥ 2.1.x). */
 const VALID_EFFORT_LEVELS = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
 /**
- * Sum all four token categories from `context_window.current_usage` to compute
- * a real context usage total (input + output + cache_read + cache_creation).
+ * Sum input token categories from `context_window.current_usage` to compute
+ * a real context usage total (input + cache_read + cache_creation).
+ * Excludes output_tokens: they are per-turn and reset each call, which would
+ * cause the context bar to jitter (jump down at the start of every new turn).
+ * Context window fill is determined by what was READ from the context, not
+ * by how many tokens were output.
  * Returns undefined when `cu` is absent or not an object shape.
  */
 function getRealUsageTotal(cu) {
@@ -38,7 +42,6 @@ function getRealUsageTotal(cu) {
         return undefined;
     const obj = cu;
     const total = (obj.input_tokens ?? 0)
-        + (obj.output_tokens ?? 0)
         + (obj.cache_read_input_tokens ?? 0)
         + (obj.cache_creation_input_tokens ?? 0);
     return total;
@@ -100,9 +103,9 @@ export function normalize(input) {
     if (claude) {
         ({ denominator: cacheTurnDenominator } = getCacheFields(claude.context_window?.current_usage));
     }
-    // Real context usage percentage (Claude only): includes output tokens in the numerator,
-    // unlike the hook-provided `used_percentage` which excludes them. This gives an accurate
-    // picture of actual context consumption, especially near auto-compact thresholds.
+    // Real context usage percentage (Claude only): sums input + cache_read + cache_creation
+    // (output_tokens excluded — per-turn, resets each call, causes bar jitter). More stable
+    // than the hook-provided `used_percentage` near auto-compact thresholds.
     let realUsedPercentage;
     if (claude) {
         const total = getRealUsageTotal(claude.context_window?.current_usage);
@@ -113,10 +116,25 @@ export function normalize(input) {
     }
     // Auto-compact proximity warning: fires when context fill is in the
     // [threshold-gap, threshold) window. Uses realUsedPercentage when available
-    // (more accurate; includes output+cache), falls back to usedPercentage for
+    // (more accurate; excludes output tokens), falls back to usedPercentage for
     // legacy payloads. Gated by platform (different thresholds Claude vs Qwen).
+    // For claude-code, honors CLAUDE_CODE_AUTO_COMPACT_WINDOW env var — a fill-%
+    // threshold (1-100) that mirrors Claude Code's own auto-compact trigger point.
+    // Users who changed this setting in Claude Code should set the same value here.
+    // Falls back to the hardcoded 80% default when absent or invalid.
     const effectivePct = realUsedPercentage ?? contextWindow.used_percentage ?? 0;
-    const platformAutoCompactThreshold = AUTO_COMPACT_THRESHOLD[platform];
+    let platformAutoCompactThreshold = AUTO_COMPACT_THRESHOLD[platform];
+    if (platform === 'claude-code') {
+        const envVal = process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
+        if (envVal !== undefined) {
+            // Use Number() + Number.isInteger() so floats ("75.5") and trailing-junk
+            // strings ("80abc") are rejected rather than silently truncated by parseInt.
+            const parsed = Number(envVal);
+            if (Number.isInteger(parsed) && parsed >= 1 && parsed <= 100) {
+                platformAutoCompactThreshold = parsed;
+            }
+        }
+    }
     const nearAutoCompact = effectivePct >= (platformAutoCompactThreshold - AUTO_COMPACT_WARNING_GAP)
         && effectivePct < platformAutoCompactThreshold;
     // Performance (Qwen only)

--- a/dist/parsers/transcript-stats.js
+++ b/dist/parsers/transcript-stats.js
@@ -53,6 +53,14 @@ export async function aggregateStats(transcriptPath) {
         throw new Error(`Transcript file not found: ${transcriptPath}`);
     }
     const stats = emptyStats();
+    // Dedup guard: Claude Code streams one JSONL entry per content block for
+    // the same logical message (thinking → text → tool_use all share one
+    // message.id). Each entry carries the full usage block for that turn, so
+    // naively accumulating every entry inflates tokens/cost by the number of
+    // content blocks. Track seen message IDs and skip usage+cost on repeats.
+    // Content extraction (tool_use, tool_result) is NOT gated — each block
+    // appears exactly once in its own entry and must still be counted.
+    const seenMessageIds = new Set();
     let fileStream = null;
     try {
         fileStream = createReadStream(resolved);
@@ -81,10 +89,20 @@ export async function aggregateStats(transcriptPath) {
                 }
             }
             const message = (entry.message ?? null);
+            // Determine whether this is the first time we're seeing this message.id.
+            // Entries without a message.id (e.g. user turns, summary lines) are
+            // always treated as first-occurrence so they're never suppressed.
+            const messageId = message !== null && typeof message.id === 'string' ? message.id : null;
+            const isFirstOccurrence = messageId === null || !seenMessageIds.has(messageId);
+            if (messageId !== null)
+                seenMessageIds.add(messageId);
             // Usage block (assistant turns only). The mere presence of a usage
             // payload flips hasCostData=true even if all counts are zero — see
             // the "zero-cost-with-usage" test for why this matters.
-            if (entry.type === 'assistant' && message && typeof message === 'object') {
+            //
+            // Gated on isFirstOccurrence: duplicate entries for the same message.id
+            // carry identical usage blocks; accumulating them inflates counts 2-3×.
+            if (isFirstOccurrence && entry.type === 'assistant' && message && typeof message === 'object') {
                 const usage = message.usage;
                 if (usage && typeof usage === 'object') {
                     stats.hasCostData = true;
@@ -104,10 +122,14 @@ export async function aggregateStats(transcriptPath) {
             // undefined`), not truthiness — Anthropic emits `total_cost_usd: 0` for
             // fully-cached turns, and a `topCost || msgCost` short-circuit would
             // incorrectly fall through to the message field in that case.
-            const topCost = safeNumber(entry.total_cost_usd);
-            const msgCost = message ? safeNumber(message.total_cost_usd) : 0;
-            const costContribution = entry.total_cost_usd !== undefined ? topCost : msgCost;
-            stats.costUsd += costContribution;
+            //
+            // Also gated on isFirstOccurrence for the same dedup reason as usage above.
+            if (isFirstOccurrence) {
+                const topCost = safeNumber(entry.total_cost_usd);
+                const msgCost = message ? safeNumber(message.total_cost_usd) : 0;
+                const costContribution = entry.total_cost_usd !== undefined ? topCost : msgCost;
+                stats.costUsd += costContribution;
+            }
             // Tool / agent / error extraction from the message.content array.
             const content = message?.content;
             if (!Array.isArray(content))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Real-time statusline HUD for Claude Code and Qwen Code. Includes session analytics CLI, API latency overhead widget, 7d quota projection, auto-compact proximity warnings, themes, and powerline. Zero deps.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Patch release bundling fixes merged since v1.9.0.

### Fixed
- Context bar no longer jitters when output tokens reset between turns (excludes `output_tokens` from `realUsedPercentage` numerator)
- `CLAUDE_CODE_AUTO_COMPACT_WINDOW` env var now rejects floats (`Number()` + `Number.isInteger()` instead of `parseInt`)
- Transcript stats no longer inflate token/cost counts 2–4× on sessions with duplicate JSONL message IDs
- `/lumira:setup` skill now guards against overwriting an existing `~/.config/lumira/config.json` with an explicit Bash `test -f` check
- Plugin manifest `homepage` field removed (unsupported, caused marketplace warnings)

### Added
- `--help` / `-h`: prints usage to stdout, exits 0
- `--version` / `-v`: prints version from `package.json`, exits 0
- Unknown commands print an error to stderr and exit 1 instead of crashing into the render path
- GSD update indicator now detects `@opengsd/gsd-core` (≥ 1.4.x) update-check cache at `~/.cache/gsd/gsd-update-check-opengsd-gsd-core.json`