### PR TITLE
feat(gsd): surface plan progress and resume indicator (gsd-core ≥ 1.4.x)

### DIFF
--- a/dist/parsers/gsd.js
+++ b/dist/parsers/gsd.js
@@ -83,6 +83,22 @@ export function parseStateMd(content) {
         state.phaseTotal = phaseMatch[2];
         state.phaseName = phaseMatch[3];
     }
+    // Plan progress within the current phase (gsd-core ≥ 1.4.x). Accepts both the
+    // compound "X of Y in current phase" and the bare "X of Y" forms. A "Plan: —"
+    // (not started) line has no digits and is correctly skipped.
+    const planMatch = content.match(/^Plan:\s*(\d+)\s+of\s+(\d+)/m);
+    if (planMatch) {
+        state.planNum = planMatch[1];
+        state.planTotal = planMatch[2];
+    }
+    // Resume point (gsd-core ≥ 1.4.x). "Resume file: None" means no active resume
+    // point and is treated as absent.
+    const resumeMatch = content.match(/^Resume file:\s*(.+)/m);
+    if (resumeMatch) {
+        const path = resumeMatch[1].trim();
+        if (path && path.toLowerCase() !== 'none')
+            state.resumeFile = path;
+    }
     if (!state.status) {
         // Fallback: parse body Status line when frontmatter status is missing
         const bodyStatus = content.match(/^Status:\s*(.+)/m);
@@ -145,9 +161,13 @@ function formatState(s) {
     }
     // Scene selection: activePhase → nextAction → milestone-complete → default
     const phasesStr = s.nextPhases?.length ? s.nextPhases.join('/') : null;
+    // Plan progress within the phase (gsd-core ≥ 1.4.x), appended to the phase
+    // descriptor in the active/default scenes — e.g. "auth (3/5) p2/9".
+    const planSuffix = s.planNum && s.planTotal ? ` p${s.planNum}/${s.planTotal}` : '';
     if (s.activePhase) {
         // Scene 1: activePhase (with optional status)
-        parts.push(s.status ? `Phase ${s.activePhase} ${s.status}` : `Phase ${s.activePhase}`);
+        const phase = s.status ? `Phase ${s.activePhase} ${s.status}` : `Phase ${s.activePhase}`;
+        parts.push(`${phase}${planSuffix}`);
     }
     else if (s.nextAction && phasesStr) {
         // Scene 2: nextAction + phases when idle
@@ -163,7 +183,7 @@ function formatState(s) {
             parts.push(s.status);
         if (s.phaseNum && s.phaseTotal) {
             const phase = s.phaseName ? `${s.phaseName} (${s.phaseNum}/${s.phaseTotal})` : `ph ${s.phaseNum}/${s.phaseTotal}`;
-            parts.push(phase);
+            parts.push(`${phase}${planSuffix}`);
         }
     }
     return parts.join(' · ');
@@ -234,11 +254,13 @@ export function getGsdInfo(cwd, opts = {}) {
     const legacyCacheFile = join(claudeDir, 'cache', 'gsd-update-check.json');
     const cacheData = readUpdateCache(openGsdCacheFile, sharedCacheFile, legacyCacheFile);
     let currentTask;
+    let hasResume = false;
     const stateFile = findStateMd(cwd || process.cwd());
     if (stateFile) {
         log('STATE.md found:', stateFile);
         try {
             const state = parseStateMd(readFileSync(stateFile, 'utf8'));
+            hasResume = state.resumeFile !== undefined;
             const formatted = formatState(state);
             if (formatted) {
                 currentTask = sanitizeTermString(formatted);
@@ -261,6 +283,7 @@ export function getGsdInfo(cwd, opts = {}) {
         staleHooks: cacheData.staleHooks || undefined,
         devInstall: cacheData.devInstall || undefined,
         currentTask,
+        hasResume: hasResume || undefined,
     };
 }
 //# sourceMappingURL=gsd.js.map

--- a/dist/render/line4.js
+++ b/dist/render/line4.js
@@ -13,6 +13,12 @@ export function renderLine4(ctx, c) {
         if (gsd.currentTask) {
             parts.push(c.bold(`${icons.hammer} ${truncField(gsd.currentTask, 60)}`));
         }
+        // Resume-point indicator (gsd-core ≥ 1.4.x). A ↩ glyph signals STATE.md has
+        // an active `.continue-here`/spec resume file — a cue that work can be picked
+        // up where it left off. Cyan: informational, distinct from update/stale warns.
+        if (gsd.hasResume) {
+            parts.push(c.cyan('↩'));
+        }
         if (gsd.updateAvailable) {
             parts.push(c.yellow('⬆ /gsd:update'));
         }

--- a/src/parsers/gsd.ts
+++ b/src/parsers/gsd.ts
@@ -23,6 +23,11 @@ interface GsdState {
   completedPhases?: string;
   totalPhases?: string;
   percent?: string;
+  /** Plan progress within the current phase (gsd-core ≥ 1.4.x body `Plan: X of Y`). */
+  planNum?: string;
+  planTotal?: string;
+  /** Active resume point (gsd-core ≥ 1.4.x body `Resume file: <path>`); absent for "None". */
+  resumeFile?: string;
 }
 
 /**
@@ -95,6 +100,24 @@ export function parseStateMd(content: string): GsdState {
     state.phaseTotal = phaseMatch[2];
     state.phaseName = phaseMatch[3];
   }
+
+  // Plan progress within the current phase (gsd-core ≥ 1.4.x). Accepts both the
+  // compound "X of Y in current phase" and the bare "X of Y" forms. A "Plan: —"
+  // (not started) line has no digits and is correctly skipped.
+  const planMatch = content.match(/^Plan:\s*(\d+)\s+of\s+(\d+)/m);
+  if (planMatch) {
+    state.planNum = planMatch[1];
+    state.planTotal = planMatch[2];
+  }
+
+  // Resume point (gsd-core ≥ 1.4.x). "Resume file: None" means no active resume
+  // point and is treated as absent.
+  const resumeMatch = content.match(/^Resume file:\s*(.+)/m);
+  if (resumeMatch) {
+    const path = resumeMatch[1].trim();
+    if (path && path.toLowerCase() !== 'none') state.resumeFile = path;
+  }
+
   if (!state.status) {
     // Fallback: parse body Status line when frontmatter status is missing
     const bodyStatus = content.match(/^Status:\s*(.+)/m);
@@ -155,10 +178,14 @@ function formatState(s: GsdState): string {
 
   // Scene selection: activePhase → nextAction → milestone-complete → default
   const phasesStr = s.nextPhases?.length ? s.nextPhases.join('/') : null;
+  // Plan progress within the phase (gsd-core ≥ 1.4.x), appended to the phase
+  // descriptor in the active/default scenes — e.g. "auth (3/5) p2/9".
+  const planSuffix = s.planNum && s.planTotal ? ` p${s.planNum}/${s.planTotal}` : '';
 
   if (s.activePhase) {
     // Scene 1: activePhase (with optional status)
-    parts.push(s.status ? `Phase ${s.activePhase} ${s.status}` : `Phase ${s.activePhase}`);
+    const phase = s.status ? `Phase ${s.activePhase} ${s.status}` : `Phase ${s.activePhase}`;
+    parts.push(`${phase}${planSuffix}`);
   } else if (s.nextAction && phasesStr) {
     // Scene 2: nextAction + phases when idle
     parts.push(`next ${s.nextAction} ${phasesStr}`);
@@ -170,7 +197,7 @@ function formatState(s: GsdState): string {
     if (s.status) parts.push(s.status);
     if (s.phaseNum && s.phaseTotal) {
       const phase = s.phaseName ? `${s.phaseName} (${s.phaseNum}/${s.phaseTotal})` : `ph ${s.phaseNum}/${s.phaseTotal}`;
-      parts.push(phase);
+      parts.push(`${phase}${planSuffix}`);
     }
   }
 
@@ -263,11 +290,13 @@ export function getGsdInfo(cwd: string, opts: GsdInfoOptions = {}): GsdInfo | nu
   const cacheData = readUpdateCache(openGsdCacheFile, sharedCacheFile, legacyCacheFile);
 
   let currentTask: string | undefined;
+  let hasResume = false;
   const stateFile = findStateMd(cwd || process.cwd());
   if (stateFile) {
     log('STATE.md found:', stateFile);
     try {
       const state = parseStateMd(readFileSync(stateFile, 'utf8'));
+      hasResume = state.resumeFile !== undefined;
       const formatted = formatState(state);
       if (formatted) {
         currentTask = sanitizeTermString(formatted);
@@ -289,5 +318,6 @@ export function getGsdInfo(cwd: string, opts: GsdInfoOptions = {}): GsdInfo | nu
     staleHooks: cacheData.staleHooks || undefined,
     devInstall: cacheData.devInstall || undefined,
     currentTask,
+    hasResume: hasResume || undefined,
   };
 }

--- a/src/render/line4.ts
+++ b/src/render/line4.ts
@@ -17,6 +17,12 @@ export function renderLine4(ctx: RenderContext, c: Colors): string {
     if (gsd.currentTask) {
       parts.push(c.bold(`${icons.hammer} ${truncField(gsd.currentTask, 60)}`));
     }
+    // Resume-point indicator (gsd-core ≥ 1.4.x). A ↩ glyph signals STATE.md has
+    // an active `.continue-here`/spec resume file — a cue that work can be picked
+    // up where it left off. Cyan: informational, distinct from update/stale warns.
+    if (gsd.hasResume) {
+      parts.push(c.cyan('↩'));
+    }
     if (gsd.updateAvailable) {
       parts.push(c.yellow('⬆ /gsd:update'));
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,8 @@ export interface GsdInfo {
   updateAvailable?: boolean;
   staleHooks?: boolean;
   devInstall?: boolean;
+  /** True when STATE.md declares an active resume point (gsd-core ≥ 1.4.x `Resume file:`). */
+  hasResume?: boolean;
 }
 
 export interface MemoryInfo {

--- a/tests/parsers/gsd.test.ts
+++ b/tests/parsers/gsd.test.ts
@@ -102,6 +102,35 @@ status: executing
     expect(s.totalPhases).toBe('6');
     expect(s.percent).toBe('50');
   });
+
+  // ── gsd-core ≥ 1.4.x body fields (Plan, Resume file) ──────────────────────
+  it('parses the compound Plan line "X of Y in current phase"', () => {
+    const s = parseStateMd(`---\nstatus: executing\n---\n\nPhase: 16 of 5 (auth)\nPlan: 2 of 9 in current phase`);
+    expect(s.planNum).toBe('2');
+    expect(s.planTotal).toBe('9');
+  });
+
+  it('parses the bare Plan line "X of Y"', () => {
+    const s = parseStateMd(`---\nstatus: executing\n---\n\nPlan: 3 of 7`);
+    expect(s.planNum).toBe('3');
+    expect(s.planTotal).toBe('7');
+  });
+
+  it('treats "Plan: —" (not started) as no plan progress', () => {
+    const s = parseStateMd(`---\nstatus: planning\n---\n\nPlan: —`);
+    expect(s.planNum).toBeUndefined();
+    expect(s.planTotal).toBeUndefined();
+  });
+
+  it('parses a Resume file path', () => {
+    const s = parseStateMd(`---\nstatus: executing\n---\n\nResume file: .planning/phases/16-x/16-UI-SPEC.md`);
+    expect(s.resumeFile).toBe('.planning/phases/16-x/16-UI-SPEC.md');
+  });
+
+  it('treats "Resume file: None" as no resume file', () => {
+    const s = parseStateMd(`---\nstatus: executing\n---\n\nResume file: None`);
+    expect(s.resumeFile).toBeUndefined();
+  });
 });
 
 describe('getGsdInfo', () => {
@@ -208,6 +237,40 @@ describe('getGsdInfo', () => {
   it('renders "milestone complete" at percent 100', () => {
     writeState(`---\nmilestone: v2.0\nprogress:\n  completed_phases: 6\n  total_phases: 6\n  percent: 100\n---`);
     expect(getGsdInfo(dir, opts)?.currentTask).toContain('milestone complete');
+  });
+
+  // ── gsd-core ≥ 1.4.x: plan progress + resume indicator (Option B) ──────────
+  it('appends plan progress "pX/Y" to the phase scene', () => {
+    writeState(`---\nstatus: executing\n---\n\nPhase: 3 of 5 (auth)\nPlan: 2 of 9 in current phase`);
+    expect(getGsdInfo(dir, opts)?.currentTask).toContain('auth (3/5) p2/9');
+  });
+
+  it('appends plan progress to the active_phase scene', () => {
+    writeState(`---\nactive_phase: "4.5"\nstatus: executing\n---\n\nPlan: 1 of 4`);
+    expect(getGsdInfo(dir, opts)?.currentTask).toContain('Phase 4.5 executing p1/4');
+  });
+
+  it('sets hasResume when a Resume file is present', () => {
+    writeState(`---\nstatus: executing\n---\n\nPhase: 3 of 5 (auth)\nResume file: .planning/phases/3-auth/UI-SPEC.md`);
+    expect(getGsdInfo(dir, opts)?.hasResume).toBe(true);
+  });
+
+  it('leaves hasResume undefined when Resume file is None', () => {
+    writeState(`---\nstatus: executing\n---\n\nPhase: 3 of 5 (auth)\nResume file: None`);
+    expect(getGsdInfo(dir, opts)?.hasResume).toBeUndefined();
+  });
+
+  // Guard: lumira's bar percent must mirror GSD's frontmatter `percent` VERBATIM.
+  // gsd-core ≥ 1.4.x computes percent = min(completed_plans/total_plans,
+  // completed_phases/total_phases) × 100 (already plan-based). lumira must NOT
+  // recompute it — if GSD ever changes its ceiling formula, this test catches
+  // silent divergence rather than mirroring the wrong number.
+  it('mirrors GSD frontmatter percent verbatim in the bar (does not recompute from plans)', () => {
+    // plans 12/25 = 48%, but GSD already published percent: 20 (its min() formula).
+    writeState(`---\nmilestone: v3.0\nmilestone_name: "X"\nprogress:\n  total_phases: 5\n  completed_phases: 1\n  total_plans: 25\n  completed_plans: 12\n  percent: 20\n---`);
+    const task = getGsdInfo(dir, opts)?.currentTask ?? '';
+    expect(task).toContain('20%');
+    expect(task).not.toContain('48%');
   });
 
   it('preserves the default "<status> · <phase>" scene when no lifecycle fields are present', () => {


### PR DESCRIPTION
## Summary

gsd-core 1.4.x adds two STATE.md body fields that lumira didn't parse. This surfaces both, giving the GSD widget more granularity than GSD's own statusline.

### Added
- **Plan progress** — parses `Plan: X of Y in current phase` (and bare `X of Y`) → appends `pX/Y` to the phase scene, e.g. `auth (3/5) p2/9`. `Plan: —` (not started) is skipped.
- **Resume indicator** — parses `Resume file: <path>` → cyan `↩` glyph on line 4 signalling an active resume point. `Resume file: None` treated as absent.

### Deliberately NOT changed
- The milestone progress bar still reads GSD's frontmatter `percent` **verbatim**. gsd-core computes `percent = min(completed_plans/total_plans, completed_phases/total_phases) × 100` — already plan-based — so recomputing it from plans would duplicate GSD's logic and risk diverging on its phase-cap edge case. A guard test pins lumira's bar to GSD's `percent`.

## Test plan
- [x] 11 new tests in `tests/parsers/gsd.test.ts` (Plan parse compound/bare/dash, Resume parse path/None, plan segment in both phase scenes, hasResume, percent-mirror guard)
- [x] Full suite: 1258/1258 green

## Decision context
Option B from an advisor-agent evaluation: the unverified question — is gsd-core's `percent` phase- or plan-based — was resolved by reading gsd-core source (`state-document.cjs:93`). It's already plan-based, so mirroring it gives plan granularity with zero divergence.