### PR TITLE
feat(pr-widget): surface PR review state from CC >= 2.1.145 payload

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -282,6 +282,7 @@ const PRESET_DEFS: Record<NonNullable<HudConfig['preset']>, PresetDef> = {
     layout: 'auto',
     display: {
       agents: true,
+      pr: true,
       burnRate: false,
       duration: false,
       tokenSpeed: false,
@@ -328,6 +329,7 @@ const PRESET_DEFS: Record<NonNullable<HudConfig['preset']>, PresetDef> = {
       addedDirs: false,
       worktreeBreadcrumb: false,
       compactionCount: false,
+      pr: false,
     },
   },
 };

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -4,8 +4,8 @@
 // Platform-specific quirks are handled once here.
 // Renderers check field presence, not platform identity.
 
-import type { ClaudeCodeInput, QwenInput, RawInput } from './types.js';
-import { AUTO_COMPACT_THRESHOLD, AUTO_COMPACT_WARNING_GAP } from './types.js';
+import type { ClaudeCodeInput, QwenInput, RawInput, PrReviewState } from './types.js';
+import { AUTO_COMPACT_THRESHOLD, AUTO_COMPACT_WARNING_GAP, PR_REVIEW_STATES } from './types.js';
 
 export function isQwenInput(input: RawInput): input is QwenInput {
   const raw = input as unknown as Record<string, unknown>;
@@ -103,6 +103,9 @@ export interface NormalizedInput {
   /** Cache hit rate percentage (Claude only) */
   cacheHitRate?: number;
 
+  /** Open PR for the current branch (Claude only, CC ≥ 2.1.145) */
+  pr?: { number: number; url?: string; reviewState?: PrReviewState };
+
   /** Escape hatch: access raw platform data for platform-specific widgets */
   raw: RawInput;
 }
@@ -122,6 +125,9 @@ export function sanitizeTermString(s: string): string {
 
 /** Allowed values for the reasoning effort level field (CC ≥ 2.1.x). */
 const VALID_EFFORT_LEVELS = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
+
+/** Allowed values for PR review state (CC ≥ 2.1.145). */
+const VALID_PR_REVIEW_STATES = new Set<string>(PR_REVIEW_STATES);
 
 type CurrentUsageObject = { input_tokens?: number; output_tokens?: number; cache_read_input_tokens?: number; cache_creation_input_tokens?: number };
 
@@ -282,6 +288,29 @@ export function normalize(input: RawInput): NormalizedInput {
     ? Math.min(100, Math.round((cached / cacheTurnDenominator) * 100))
     : undefined;
 
+  // PR widget (Claude only, CC ≥ 2.1.145).
+  // number must be a positive integer — drop the whole object if invalid.
+  // url: sanitize then accept only https:// scheme (OSC 8 injection guard).
+  // reviewState: sanitize then gate against the PR_REVIEW_STATES allowlist.
+  let pr: NormalizedInput['pr'];
+  if (claude?.pr != null) {
+    const rawPr = claude.pr;
+    const n = rawPr.number;
+    if (typeof n === 'number' && Number.isInteger(n) && n > 0) {
+      let prUrl: string | undefined;
+      if (typeof rawPr.url === 'string') {
+        const sanitized = sanitizeTermString(rawPr.url);
+        if (sanitized.startsWith('https://')) prUrl = sanitized;
+      }
+      let prReviewState: PrReviewState | undefined;
+      if (typeof rawPr.review_state === 'string') {
+        const sanitized = sanitizeTermString(rawPr.review_state);
+        if (VALID_PR_REVIEW_STATES.has(sanitized)) prReviewState = sanitized as PrReviewState;
+      }
+      pr = { number: n, url: prUrl, reviewState: prReviewState };
+    }
+  }
+
   return {
     platform,
     model: sanitizeTermString(modelName),
@@ -329,6 +358,7 @@ export function normalize(input: RawInput): NormalizedInput {
     })(),
     rateLimits,
     cacheHitRate,
+    pr,
     raw: input,
   };
 }

--- a/src/render/icons.ts
+++ b/src/render/icons.ts
@@ -21,6 +21,8 @@ export interface IconSet {
   car: string;
   turtle: string;
   lightning: string;
+  /** Git pull-request glyph (CC ≥ 2.1.145 PR widget). */
+  pr: string;
   /**
    * Battery glyph keyed by usedPercentage. Replaces the bolt prefix on
    * rate-limit segments with a visual fuel gauge so the icon itself signals
@@ -92,6 +94,7 @@ export const NERD_ICONS: IconSet = {
   car:       '🏎️',  // racing car — pace-ahead indicator
   turtle:    '🐢',  // turtle — pace-behind indicator
   lightning: '⚡',  // lightning bolt — cache hit rate
+  pr:        '',  // nf-cod-git_pull_request
   battery:   nerdBattery,
 };
 
@@ -116,6 +119,7 @@ export const EMOJI_ICONS: IconSet = {
   car:       '\u{1F3CE}️', // 🏎️ — racing car
   turtle:    '\u{1F422}',  // 🐢 — turtle
   lightning: '⚡',         // ⚡ — cache hit rate
+  pr:        '\u{1F500}',  // 🔀 — twisted rightwards arrows (PR)
   battery:   (pct: number) => {
     if (!Number.isFinite(pct) || pct < 0) return '\u{1F50B}'; // 🔋 — no data / invalid input
     if (Math.round(pct) >= 100) return '\u{1F480}';            // 💀 — quota exhausted
@@ -145,6 +149,7 @@ export const NO_ICONS: IconSet = {
   car:       '',
   turtle:    '',
   lightning: '',
+  pr:        'PR',
   // No-icon mode keeps the legacy bolt fallback (currently empty) so users who
   // opted out of icons see no shape change from this feature.
   battery:   () => '',

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -7,6 +7,7 @@ import { formatTokens, formatCost, formatBurnRate } from '../utils/format.js';
 import { getConfigHealth } from '../parsers/config-health.js';
 import { computePaceDelta, formatPaceDelta } from './pace.js';
 import { computeQuotaProjection, formatProjectionWarning } from './quota-projection.js';
+import { hyperlink } from './hyperlink.js';
 import type { RenderContext } from '../types.js';
 
 const SEVEN_DAY_WINDOW_SEC = 7 * 24 * 3600;
@@ -119,6 +120,20 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
     } else {
       leftParts.push(c.dim(`MCP ${total}`));
     }
+  }
+
+  // PR widget (CC ≥ 2.1.145)
+  if (display.pr && input.pr) {
+    const { number, url, reviewState } = input.pr;
+    const stateStr = reviewState ?? '';
+    const colorFn: (s: string) => string =
+      reviewState === 'approved'          ? c.green  :
+      reviewState === 'pending'           ? c.yellow :
+      reviewState === 'changes_requested' ? c.orange :
+      c.dim; // draft or unknown
+    const text = `${icons.pr} #${number}${stateStr ? ` ${stateStr}` : ''}`;
+    const colored = colorFn(text);
+    leftParts.push(url ? hyperlink(url, colored) : colored);
   }
 
   // Qwen metrics (shared helper)

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -36,6 +36,21 @@ function getCacheHitBg(rate: number, palette: PowerlinePalette): RGB {
   }
 }
 
+// Maps PR review state to a powerline bg slot (urgency via background, not text color).
+// approved  → dirBg   (neutral — PR is ready, low urgency)
+// pending   → taskBg  (warm — waiting on reviewers)
+// changes_requested → branchDirtyBg (hot — action needed from author)
+// draft     → dirBg   (neutral — not ready for review)
+function getPrReviewBg(reviewState: string | undefined, palette: PowerlinePalette): RGB {
+  switch (reviewState) {
+    case 'changes_requested': return palette.branchDirtyBg;
+    case 'pending':           return palette.taskBg;
+    case 'approved':
+    case 'draft':
+    default:                  return palette.dirBg;
+  }
+}
+
 // Maps the API latency tier (SSOT in colors.ts) to a powerline bg slot.
 // healthy/notable → dirBg (neutral; api is fast or only slightly slow)
 // warn            → taskBg (warm; api is dominating session time)
@@ -240,6 +255,15 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
     const errors = mcp.servers.filter(s => s.status === 'error').length;
     const mcpText = errors > 0 ? `MCP ${total - errors}/${total}` : `MCP ${total}`;
     segments.push({ text: mcpText, bg: palette.taskBg, fg: palette.fg, priority: 50 });
+  }
+
+  // PR widget (CC ≥ 2.1.145)
+  if (display.pr && input.pr) {
+    const { number, reviewState } = input.pr;
+    const stateStr = reviewState ?? '';
+    const text = `${icons.pr} #${number}${stateStr ? ` ${stateStr}` : ''}`;
+    const bg = getPrReviewBg(reviewState, palette);
+    segments.push({ text, bg, fg: palette.fg, priority: 55 });
   }
 
   // Qwen metrics

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,8 @@ export interface ClaudeCodeInput {
   effort?: { level?: string };
   /** Modern (≥ 2.1.x) — extended thinking enabled state. */
   thinking?: { enabled?: boolean };
+  /** Modern (≥ 2.1.145) — open PR for the current branch. */
+  pr?: { number?: number; url?: string; review_state?: string };
 }
 
 export interface RateLimitWindow {
@@ -276,6 +278,9 @@ export const CUSTOM_COMMAND_COLORS = ['dim', 'green', 'yellow', 'orange', 'red',
  * `POWERLINE_STYLES` in `src/render/powerline.ts` — that map's keys
  * MUST match this list.
  */
+export const PR_REVIEW_STATES = ['approved', 'pending', 'changes_requested', 'draft'] as const;
+export type PrReviewState = typeof PR_REVIEW_STATES[number];
+
 export const POWERLINE_STYLE_NAMES = [
   'arrow', 'flame', 'slant', 'round', 'diamond', 'compatible', 'plain', 'auto',
 ] as const;
@@ -315,6 +320,7 @@ export interface DisplayToggles {
   addedDirs: boolean;
   worktreeBreadcrumb: boolean;
   compactionCount: boolean;
+  pr: boolean;
   /**
    * Percentage at which the context bar turns orange and shows the fire icon. Default 65. Clamped [0,100].
    * Setting this ≤ 50 collapses the yellow zone; the bar jumps green→orange directly at this value.
@@ -406,6 +412,7 @@ export const DEFAULT_DISPLAY: DisplayToggles = {
   addedDirs: true,
   worktreeBreadcrumb: true,
   compactionCount: true,
+  pr: true,
   contextWarningThreshold: DEFAULT_CONTEXT_WARNING_THRESHOLD,
   contextCriticalThreshold: DEFAULT_CONTEXT_CRITICAL_THRESHOLD,
 };

--- a/tests/normalize-pr.test.ts
+++ b/tests/normalize-pr.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { normalize } from '../src/normalize.js';
+import type { ClaudeCodeInput, QwenInput } from '../src/types.js';
+
+const baseClaudeInput: ClaudeCodeInput = {
+  model: 'Claude Sonnet 4.6',
+  session_id: 'test-123',
+  context_window: {
+    used_percentage: 30,
+    remaining_percentage: 70,
+    total_input_tokens: 50000,
+    total_output_tokens: 5000,
+  },
+  cost: { total_cost_usd: 0.5, total_duration_ms: 60000 },
+  workspace: { current_dir: '/home/user/project' },
+};
+
+describe('normalize — PR widget (CC ≥ 2.1.145)', () => {
+  it('full payload maps all fields', () => {
+    const input: ClaudeCodeInput = {
+      ...baseClaudeInput,
+      pr: { number: 174, url: 'https://github.com/org/repo/pull/174', review_state: 'approved' },
+    };
+    const result = normalize(input);
+    expect(result.pr).toEqual({ number: 174, url: 'https://github.com/org/repo/pull/174', reviewState: 'approved' });
+  });
+
+  it.each([
+    { value: 0, label: 'zero' },
+    { value: -1, label: 'negative' },
+    { value: 1.5, label: 'float' },
+    { value: NaN, label: 'NaN' },
+    { value: 'abc' as unknown as number, label: 'string' },
+  ])('invalid numbers drops pr: $label', ({ value }) => {
+    const input: ClaudeCodeInput = { ...baseClaudeInput, pr: { number: value } };
+    const result = normalize(input);
+    expect(result.pr).toBeUndefined();
+  });
+
+  it.each([
+    ['javascript:alert(1)'],
+    ['http://x.com'],
+    ['file:///etc/passwd'],
+    ['data:x'],
+  ])('bad URL schemes drops url but keeps widget: %s', (badUrl) => {
+    const input: ClaudeCodeInput = { ...baseClaudeInput, pr: { number: 1, url: badUrl } };
+    const result = normalize(input);
+    expect(result.pr?.url).toBeUndefined();
+    expect(result.pr?.number).toBe(1);
+  });
+
+  it('control chars in url sanitized before scheme check', () => {
+    const input: ClaudeCodeInput = {
+      ...baseClaudeInput,
+      pr: { number: 1, url: 'https://\x1bgithub.com/org/repo/pull/1' },
+    };
+    const result = normalize(input);
+    expect(result.pr?.url).toBe('https://github.com/org/repo/pull/1');
+  });
+
+  it('unknown review_state dropped, number+url survive', () => {
+    const input: ClaudeCodeInput = {
+      ...baseClaudeInput,
+      pr: { number: 1, url: 'https://github.com/org/repo/pull/1', review_state: 'merged' },
+    };
+    const result = normalize(input);
+    expect(result.pr?.reviewState).toBeUndefined();
+    expect(result.pr?.number).toBe(1);
+    expect(result.pr?.url).toBeDefined();
+  });
+
+  it('Qwen never gets pr', () => {
+    const qwenInput: QwenInput = {
+      session_id: 'qwen-test',
+      version: '0.14.3',
+      model: { display_name: 'qwen-coder' },
+      context_window: {
+        context_window_size: 128000,
+        used_percentage: 20,
+        remaining_percentage: 80,
+        current_usage: 25600,
+        total_input_tokens: 25000,
+        total_output_tokens: 600,
+      },
+      metrics: {
+        models: {
+          'qwen-coder': {
+            api: { total_requests: 5, total_errors: 0, total_latency_ms: 3000 },
+            tokens: { prompt: 25000, completion: 600, total: 25600, cached: 0, thoughts: 0 },
+          },
+        },
+        files: { total_lines_added: 10, total_lines_removed: 2 },
+      },
+      workspace: { current_dir: '/home/user/project' },
+    };
+    const result = normalize(qwenInput);
+    expect(result.pr).toBeUndefined();
+  });
+});

--- a/tests/render/pr-line2.test.ts
+++ b/tests/render/pr-line2.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { renderLine2 } from '../../src/render/line2.js';
+import { createColors, stripAnsi } from '../../src/render/colors.js';
+import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '../../src/types.js';
+import type { ClaudeCodeInput, RenderContext } from '../../src/types.js';
+import { NERD_ICONS } from '../../src/render/icons.js';
+import { normalize } from '../../src/normalize.js';
+
+const c = createColors('named');
+
+const baseInput: ClaudeCodeInput = {
+  model: 'Claude Sonnet 4.6',
+  session_id: 'test-123',
+  context_window: { used_percentage: 30, remaining_percentage: 70, total_input_tokens: 50000, total_output_tokens: 5000 },
+  cost: { total_cost_usd: 0.5, total_duration_ms: 60000 },
+  workspace: { current_dir: '/home/user/project' },
+};
+
+function makeCtx(inputOverrides: Partial<ClaudeCodeInput> = {}, ctxOverrides: Partial<RenderContext> = {}): RenderContext {
+  return {
+    input: normalize({ ...baseInput, ...inputOverrides }),
+    git: EMPTY_GIT, transcript: EMPTY_TRANSCRIPT,
+    tokenSpeed: null, memory: null, gsd: null, mcp: null, cols: 120,
+    config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
+    icons: NERD_ICONS,
+    ...ctxOverrides,
+  };
+}
+
+describe('PR widget in line2', () => {
+  it('toggle off hides widget', () => {
+    const ctx = makeCtx(
+      { pr: { number: 174, url: 'https://github.com/org/repo/pull/174', review_state: 'approved' } },
+      { config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, pr: false } } },
+    );
+    const output = stripAnsi(renderLine2(ctx, c));
+    expect(output).not.toContain('#174');
+  });
+
+  it('PR with url renders hyperlink and number', () => {
+    process.env['FORCE_HYPERLINK'] = '1';
+    const ctx = makeCtx({
+      pr: { number: 174, url: 'https://github.com/org/repo/pull/174', review_state: 'approved' },
+    });
+    const output = renderLine2(ctx, c);
+    delete process.env['FORCE_HYPERLINK'];
+    expect(output).toContain('\x1b]8;;');
+    expect(stripAnsi(output)).toContain('#174');
+  });
+
+  it('PR without url: no hyperlink, number visible', () => {
+    const ctx = makeCtx({
+      pr: { number: 174, review_state: 'approved' },
+    });
+    const output = renderLine2(ctx, c);
+    expect(output).not.toContain('\x1b]8;;');
+    expect(stripAnsi(output)).toContain('#174');
+  });
+});

--- a/tests/render/pr-powerline-line2.test.ts
+++ b/tests/render/pr-powerline-line2.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { renderPowerlineLine2 } from '../../src/render/powerline-line2.js';
+import { createColors, stripAnsi } from '../../src/render/colors.js';
+import { resolveIcons } from '../../src/render/icons.js';
+import { normalize } from '../../src/normalize.js';
+import { DEFAULT_CONFIG, DEFAULT_DISPLAY, EMPTY_GIT, EMPTY_TRANSCRIPT } from '../../src/types.js';
+import type { RenderContext } from '../../src/types.js';
+
+const c = createColors('truecolor', null);
+
+function makeCtx(inputOverrides = {}, ctxOverrides: Partial<RenderContext> = {}): RenderContext {
+  const rawInput = {
+    model: 'Claude Sonnet 4.6',
+    session_id: 'test',
+    context_window: { used_percentage: 30, remaining_percentage: 70, total_input_tokens: 50000, total_output_tokens: 5000 },
+    cost: { total_cost_usd: 0.5, total_duration_ms: 60000 },
+    workspace: { current_dir: '/home/user/project' },
+    ...inputOverrides,
+  };
+  return {
+    input: normalize(rawInput),
+    git: { ...EMPTY_GIT },
+    transcript: { ...EMPTY_TRANSCRIPT },
+    tokenSpeed: null, memory: null, gsd: null, mcp: null,
+    cols: 120,
+    config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY } },
+    icons: resolveIcons('nerd'),
+    ...ctxOverrides,
+  };
+}
+
+describe('PR widget — powerline line2', () => {
+  it('toggle off hides widget', () => {
+    const ctx = makeCtx(
+      { pr: { number: 174, url: 'https://github.com/org/repo/pull/174', review_state: 'approved' } },
+      { config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, pr: false } } },
+    );
+    const out = renderPowerlineLine2(ctx, 'truecolor', null, c);
+    expect(stripAnsi(out)).not.toContain('#174');
+  });
+
+  it('PR present renders with truecolor bg and number', () => {
+    const ctx = makeCtx({ pr: { number: 174, review_state: 'approved' } });
+    const out = renderPowerlineLine2(ctx, 'truecolor', null, c);
+    expect(out).toContain('\x1b[48;2;');
+    expect(stripAnsi(out)).toContain('#174');
+  });
+});


### PR DESCRIPTION
## Summary

- Surfaces `pr.number`, `pr.url` and `pr.review_state` from Claude Code >= 2.1.145 stdin payload into Lumira statusline
- Classic renderer: `#174 approved` with OSC 8 hyperlink when url present; color-coded by state (green/yellow/orange/gray)
- Powerline renderer: bg palette slot (`dirBg`/`taskBg`/`branchDirtyBg`) at priority 55, between MCP and tokens
- Nerd (), emoji (🔀) and no-icon (`PR`) glyph sets
- `balanced` preset: `pr: true`; `minimal` preset: `pr: false`

## Security

- `url` rejected unless `https://` after `sanitizeTermString` — blocks `javascript:`, `http://`, `file://`, `data:` injection via OSC 8
- `review_state` gated against `PR_REVIEW_STATES` allowlist — unknown values drop silently, widget still renders with number
- Invalid `number` (non-integer, <= 0, wrong type) drops the entire widget

## Test plan

- [ ] Full test suite: 56 files, 1276 tests passing
- [ ] `tests/normalize-pr.test.ts` — security boundary: number validation, URL scheme check, allowlist, Qwen isolation
- [ ] `tests/render/pr-line2.test.ts` — toggle off, hyperlink on/off
- [ ] `tests/render/pr-powerline-line2.test.ts` — toggle off, truecolor bg present
