### PR TITLE
feat(thinking): surface extended thinking indicator from CC ≥ 2.1.x payload

### DIFF
--- a/dist/config.js
+++ b/dist/config.js
@@ -248,6 +248,8 @@ const PRESET_DEFS = {
         layout: 'auto',
         display: {
             agents: true,
+            pr: true,
+            thinking: true,
             burnRate: false,
             duration: false,
             tokenSpeed: false,
@@ -294,6 +296,8 @@ const PRESET_DEFS = {
             addedDirs: false,
             worktreeBreadcrumb: false,
             compactionCount: false,
+            pr: false,
+            thinking: false,
         },
     },
 };

--- a/dist/normalize.js
+++ b/dist/normalize.js
@@ -3,7 +3,7 @@
 // Single internal format that all renderers can consume.
 // Platform-specific quirks are handled once here.
 // Renderers check field presence, not platform identity.
-import { AUTO_COMPACT_THRESHOLD, AUTO_COMPACT_WARNING_GAP } from './types.js';
+import { AUTO_COMPACT_THRESHOLD, AUTO_COMPACT_WARNING_GAP, PR_REVIEW_STATES } from './types.js';
 export function isQwenInput(input) {
     const raw = input;
     if (!raw.metrics || typeof raw.metrics !== 'object' || !('models' in raw.metrics))
@@ -28,6 +28,8 @@ export function sanitizeTermString(s) {
 }
 /** Allowed values for the reasoning effort level field (CC ≥ 2.1.x). */
 const VALID_EFFORT_LEVELS = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
+/** Allowed values for PR review state (CC ≥ 2.1.145). */
+const VALID_PR_REVIEW_STATES = new Set(PR_REVIEW_STATES);
 /**
  * Sum input token categories from `context_window.current_usage` to compute
  * a real context usage total (input + cache_read + cache_creation).
@@ -174,6 +176,30 @@ export function normalize(input) {
     const cacheHitRate = (cached != null && cacheTurnDenominator && platform === 'claude-code')
         ? Math.min(100, Math.round((cached / cacheTurnDenominator) * 100))
         : undefined;
+    // PR widget (Claude only, CC ≥ 2.1.145).
+    // number must be a positive integer — drop the whole object if invalid.
+    // url: sanitize then accept only https:// scheme (OSC 8 injection guard).
+    // reviewState: sanitize then gate against the PR_REVIEW_STATES allowlist.
+    let pr;
+    if (claude?.pr != null) {
+        const rawPr = claude.pr;
+        const n = rawPr.number;
+        if (typeof n === 'number' && Number.isInteger(n) && n > 0) {
+            let prUrl;
+            if (typeof rawPr.url === 'string') {
+                const sanitized = sanitizeTermString(rawPr.url);
+                if (sanitized.startsWith('https://'))
+                    prUrl = sanitized;
+            }
+            let prReviewState;
+            if (typeof rawPr.review_state === 'string') {
+                const sanitized = sanitizeTermString(rawPr.review_state);
+                if (VALID_PR_REVIEW_STATES.has(sanitized))
+                    prReviewState = sanitized;
+            }
+            pr = { number: n, url: prUrl, reviewState: prReviewState };
+        }
+    }
     return {
         platform,
         model: sanitizeTermString(modelName),
@@ -208,6 +234,7 @@ export function normalize(input) {
         effortLevel: claude?.effort?.level && VALID_EFFORT_LEVELS.has(claude.effort.level)
             ? sanitizeTermString(claude.effort.level)
             : undefined,
+        thinkingEnabled: claude?.thinking?.enabled === true ? true : undefined,
         worktreeName: input.worktree?.name ? sanitizeTermString(input.worktree.name) : undefined,
         addedDirsCount: (() => {
             const dirs = input.workspace?.added_dirs;
@@ -223,6 +250,7 @@ export function normalize(input) {
         })(),
         rateLimits,
         cacheHitRate,
+        pr,
         raw: input,
     };
 }

--- a/dist/render/icons.js
+++ b/dist/render/icons.js
@@ -60,6 +60,8 @@ export const NERD_ICONS = {
     car: '🏎️', // racing car — pace-ahead indicator
     turtle: '🐢', // turtle — pace-behind indicator
     lightning: '⚡', // lightning bolt — cache hit rate
+    pr: '', // nf-cod-git_pull_request
+    thinking: '󱠤', // nf-md-brain
     battery: nerdBattery,
 };
 export const EMOJI_ICONS = {
@@ -83,6 +85,8 @@ export const EMOJI_ICONS = {
     car: '\u{1F3CE}️', // 🏎️ — racing car
     turtle: '\u{1F422}', // 🐢 — turtle
     lightning: '⚡', // ⚡ — cache hit rate
+    pr: '\u{1F500}', // 🔀 — twisted rightwards arrows (PR)
+    thinking: '\u{1F4AD}', // 💭 — thought bubble
     battery: (pct) => {
         if (!Number.isFinite(pct) || pct < 0)
             return '\u{1F50B}'; // 🔋 — no data / invalid input
@@ -114,6 +118,8 @@ export const NO_ICONS = {
     car: '',
     turtle: '',
     lightning: '',
+    pr: 'PR',
+    thinking: 'think',
     // No-icon mode keeps the legacy bolt fallback (currently empty) so users who
     // opted out of icons see no shape change from this feature.
     battery: () => '',

--- a/dist/render/line2.js
+++ b/dist/render/line2.js
@@ -7,6 +7,7 @@ import { formatTokens, formatCost, formatBurnRate } from '../utils/format.js';
 import { getConfigHealth } from '../parsers/config-health.js';
 import { computePaceDelta, formatPaceDelta } from './pace.js';
 import { computeQuotaProjection, formatProjectionWarning } from './quota-projection.js';
+import { hyperlink } from './hyperlink.js';
 const SEVEN_DAY_WINDOW_SEC = 7 * 24 * 3600;
 const SEVEN_DAY_MIN_ELAPSED_SEC = 3600; // 1h floor — see quota-projection.ts
 export function formatCountdown(resetsAt) {
@@ -114,6 +115,18 @@ export function renderLine2(ctx, c) {
         else {
             leftParts.push(c.dim(`MCP ${total}`));
         }
+    }
+    // PR widget (CC ≥ 2.1.145)
+    if (display.pr && input.pr) {
+        const { number, url, reviewState } = input.pr;
+        const stateStr = reviewState ?? '';
+        const colorFn = reviewState === 'approved' ? c.green :
+            reviewState === 'pending' ? c.yellow :
+                reviewState === 'changes_requested' ? c.orange :
+                    c.dim; // draft or unknown
+        const text = `${icons.pr} #${number}${stateStr ? ` ${stateStr}` : ''}`;
+        const colored = colorFn(text);
+        leftParts.push(url ? hyperlink(url, colored) : colored);
     }
     // Qwen metrics (shared helper)
     leftParts.push(...formatQwenMetrics(input, c, icons));
@@ -232,6 +245,9 @@ export function renderLine2(ctx, c) {
     const effort = input.effortLevel || thinkingEffort;
     if (display.effort && effort && effort !== 'medium') {
         rightParts.push(c.dim(`^${effort}`));
+    }
+    if (display.thinking && input.thinkingEnabled) {
+        rightParts.push(c.dim(icons.thinking));
     }
     // Config health hints (opt-in, default off). Sit on the right side as
     // auxiliary signals next to vim/effort, and are dropped silently when the

--- a/dist/render/powerline-line2.js
+++ b/dist/render/powerline-line2.js
@@ -21,6 +21,20 @@ function getCacheHitBg(rate, palette) {
         case 'critical': return palette.branchDirtyBg;
     }
 }
+// Maps PR review state to a powerline bg slot (urgency via background, not text color).
+// approved  → dirBg   (neutral — PR is ready, low urgency)
+// pending   → taskBg  (warm — waiting on reviewers)
+// changes_requested → branchDirtyBg (hot — action needed from author)
+// draft     → dirBg   (neutral — not ready for review)
+function getPrReviewBg(reviewState, palette) {
+    switch (reviewState) {
+        case 'changes_requested': return palette.branchDirtyBg;
+        case 'pending': return palette.taskBg;
+        case 'approved':
+        case 'draft':
+        default: return palette.dirBg;
+    }
+}
 // Maps the API latency tier (SSOT in colors.ts) to a powerline bg slot.
 // healthy/notable → dirBg (neutral; api is fast or only slightly slow)
 // warn            → taskBg (warm; api is dominating session time)
@@ -210,6 +224,14 @@ function buildSegments(ctx, palette, c) {
         const mcpText = errors > 0 ? `MCP ${total - errors}/${total}` : `MCP ${total}`;
         segments.push({ text: mcpText, bg: palette.taskBg, fg: palette.fg, priority: 50 });
     }
+    // PR widget (CC ≥ 2.1.145)
+    if (display.pr && input.pr) {
+        const { number, reviewState } = input.pr;
+        const stateStr = reviewState ?? '';
+        const text = `${icons.pr} #${number}${stateStr ? ` ${stateStr}` : ''}`;
+        const bg = getPrReviewBg(reviewState, palette);
+        segments.push({ text, bg, fg: palette.fg, priority: 55 });
+    }
     // Qwen metrics
     const qwenParts = formatQwenMetrics(input, c, icons);
     for (const part of qwenParts) {
@@ -223,6 +245,9 @@ function buildSegments(ctx, palette, c) {
     const effort = input.effortLevel || thinkingEffort;
     if (display.effort && effort && effort !== 'medium') {
         segments.push({ text: `^${effort}`, bg: palette.versionBg, fg: palette.fg, priority: 30 });
+    }
+    if (display.thinking && input.thinkingEnabled) {
+        segments.push({ text: icons.thinking, bg: palette.dirBg, fg: palette.fg, priority: 28 });
     }
     // Config health hints (opt-in, lowest priority — evicted first on narrow terminals)
     if (display.health && input.cwd) {

--- a/dist/render/powerline-line2.js
+++ b/dist/render/powerline-line2.js
@@ -246,6 +246,8 @@ function buildSegments(ctx, palette, c) {
     if (display.effort && effort && effort !== 'medium') {
         segments.push({ text: `^${effort}`, bg: palette.versionBg, fg: palette.fg, priority: 30 });
     }
+    // Extended thinking indicator — priority 28 (one below effort/vim at 30) so it
+    // evicts before them on narrow terminals; thinking is informational, not urgent.
     if (display.thinking && input.thinkingEnabled) {
         segments.push({ text: icons.thinking, bg: palette.dirBg, fg: palette.fg, priority: 28 });
     }

--- a/dist/types.js
+++ b/dist/types.js
@@ -38,6 +38,7 @@ export const CUSTOM_COMMAND_COLORS = ['dim', 'green', 'yellow', 'orange', 'red',
  * `POWERLINE_STYLES` in `src/render/powerline.ts` — that map's keys
  * MUST match this list.
  */
+export const PR_REVIEW_STATES = ['approved', 'pending', 'changes_requested', 'draft'];
 export const POWERLINE_STYLE_NAMES = [
     'arrow', 'flame', 'slant', 'round', 'diamond', 'compatible', 'plain', 'auto',
 ];
@@ -108,6 +109,8 @@ export const DEFAULT_DISPLAY = {
     addedDirs: true,
     worktreeBreadcrumb: true,
     compactionCount: true,
+    pr: true,
+    thinking: true,
     contextWarningThreshold: DEFAULT_CONTEXT_WARNING_THRESHOLD,
     contextCriticalThreshold: DEFAULT_CONTEXT_CRITICAL_THRESHOLD,
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -283,6 +283,7 @@ const PRESET_DEFS: Record<NonNullable<HudConfig['preset']>, PresetDef> = {
     display: {
       agents: true,
       pr: true,
+      thinking: true,
       burnRate: false,
       duration: false,
       tokenSpeed: false,
@@ -330,6 +331,7 @@ const PRESET_DEFS: Record<NonNullable<HudConfig['preset']>, PresetDef> = {
       worktreeBreadcrumb: false,
       compactionCount: false,
       pr: false,
+      thinking: false,
     },
   },
 };

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -94,6 +94,9 @@ export interface NormalizedInput {
   /** Reasoning effort level (≥ 2.1.x stdin, falls back to transcript regex) */
   effortLevel?: string;
 
+  /** Extended thinking enabled (Claude only, CC ≥ 2.1.x) */
+  thinkingEnabled?: boolean;
+
   /** Rate limits (Claude only) */
   rateLimits?: {
     fiveHour?: { usedPercentage: number; resetsAt?: number };
@@ -345,6 +348,7 @@ export function normalize(input: RawInput): NormalizedInput {
     effortLevel: claude?.effort?.level && VALID_EFFORT_LEVELS.has(claude.effort.level)
       ? sanitizeTermString(claude.effort.level)
       : undefined,
+    thinkingEnabled: claude?.thinking?.enabled === true ? true : undefined,
     worktreeName: input.worktree?.name ? sanitizeTermString(input.worktree.name) : undefined,
     addedDirsCount: (() => {
       const dirs = (input as ClaudeCodeInput).workspace?.added_dirs;

--- a/src/render/icons.ts
+++ b/src/render/icons.ts
@@ -23,6 +23,8 @@ export interface IconSet {
   lightning: string;
   /** Git pull-request glyph (CC ≥ 2.1.145 PR widget). */
   pr: string;
+  /** Extended thinking indicator (CC ≥ 2.1.x thinking widget). */
+  thinking: string;
   /**
    * Battery glyph keyed by usedPercentage. Replaces the bolt prefix on
    * rate-limit segments with a visual fuel gauge so the icon itself signals
@@ -95,6 +97,7 @@ export const NERD_ICONS: IconSet = {
   turtle:    '🐢',  // turtle — pace-behind indicator
   lightning: '⚡',  // lightning bolt — cache hit rate
   pr:        '',  // nf-cod-git_pull_request
+  thinking:  '󱠤',  // nf-md-brain
   battery:   nerdBattery,
 };
 
@@ -120,6 +123,7 @@ export const EMOJI_ICONS: IconSet = {
   turtle:    '\u{1F422}',  // 🐢 — turtle
   lightning: '⚡',         // ⚡ — cache hit rate
   pr:        '\u{1F500}',  // 🔀 — twisted rightwards arrows (PR)
+  thinking:  '\u{1F4AD}',  // 💭 — thought bubble
   battery:   (pct: number) => {
     if (!Number.isFinite(pct) || pct < 0) return '\u{1F50B}'; // 🔋 — no data / invalid input
     if (Math.round(pct) >= 100) return '\u{1F480}';            // 💀 — quota exhausted
@@ -150,6 +154,7 @@ export const NO_ICONS: IconSet = {
   turtle:    '',
   lightning: '',
   pr:        'PR',
+  thinking:  'think',
   // No-icon mode keeps the legacy bolt fallback (currently empty) so users who
   // opted out of icons see no shape change from this feature.
   battery:   () => '',

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -264,6 +264,10 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
     rightParts.push(c.dim(`^${effort}`));
   }
 
+  if (display.thinking && input.thinkingEnabled) {
+    rightParts.push(c.dim(icons.thinking));
+  }
+
   // Config health hints (opt-in, default off). Sit on the right side as
   // auxiliary signals next to vim/effort, and are dropped silently when the
   // projected line width would overflow `cols` — they are advisory, never

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -284,6 +284,10 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
     segments.push({ text: `^${effort}`, bg: palette.versionBg, fg: palette.fg, priority: 30 });
   }
 
+  if (display.thinking && input.thinkingEnabled) {
+    segments.push({ text: icons.thinking, bg: palette.dirBg, fg: palette.fg, priority: 28 });
+  }
+
   // Config health hints (opt-in, lowest priority — evicted first on narrow terminals)
   if (display.health && input.cwd) {
     const colorMode = ctx.config.colors.mode === 'auto' ? detectColorMode() : ctx.config.colors.mode;

--- a/src/render/powerline-line2.ts
+++ b/src/render/powerline-line2.ts
@@ -284,6 +284,8 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: Colors)
     segments.push({ text: `^${effort}`, bg: palette.versionBg, fg: palette.fg, priority: 30 });
   }
 
+  // Extended thinking indicator — priority 28 (one below effort/vim at 30) so it
+  // evicts before them on narrow terminals; thinking is informational, not urgent.
   if (display.thinking && input.thinkingEnabled) {
     segments.push({ text: icons.thinking, bg: palette.dirBg, fg: palette.fg, priority: 28 });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -321,6 +321,7 @@ export interface DisplayToggles {
   worktreeBreadcrumb: boolean;
   compactionCount: boolean;
   pr: boolean;
+  thinking: boolean;
   /**
    * Percentage at which the context bar turns orange and shows the fire icon. Default 65. Clamped [0,100].
    * Setting this ≤ 50 collapses the yellow zone; the bar jumps green→orange directly at this value.
@@ -413,6 +414,7 @@ export const DEFAULT_DISPLAY: DisplayToggles = {
   worktreeBreadcrumb: true,
   compactionCount: true,
   pr: true,
+  thinking: true,
   contextWarningThreshold: DEFAULT_CONTEXT_WARNING_THRESHOLD,
   contextCriticalThreshold: DEFAULT_CONTEXT_CRITICAL_THRESHOLD,
 };

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -123,6 +123,25 @@ describe('normalize', () => {
       expect(normalize(input2).effortLevel).toBeUndefined();
     });
 
+    it('sets thinkingEnabled to true when thinking.enabled is true (Claude)', () => {
+      const input = { ...claudeInput, thinking: { enabled: true } };
+      expect(normalize(input).thinkingEnabled).toBe(true);
+    });
+
+    it('does not set thinkingEnabled when thinking.enabled is false', () => {
+      const input = { ...claudeInput, thinking: { enabled: false } };
+      expect(normalize(input).thinkingEnabled).toBeUndefined();
+    });
+
+    it('does not set thinkingEnabled when thinking field is absent', () => {
+      expect(normalize(claudeInput).thinkingEnabled).toBeUndefined();
+    });
+
+    it('does not set thinkingEnabled for Qwen input', () => {
+      const input = { ...qwenInput, thinking: { enabled: true } } as unknown as typeof qwenInput;
+      expect(normalize(input).thinkingEnabled).toBeUndefined();
+    });
+
     it('window size is undefined for Claude', () => {
       const result = normalize(claudeInput);
       expect(result.context.windowSize).toBeUndefined();

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -291,6 +291,27 @@ describe('renderLine2', () => {
     expect(out).toContain('^low');
   });
 
+  it('shows thinking icon when thinking is enabled', () => {
+    const ctx = makeCtx({ icons: EMOJI_ICONS }, { thinking: { enabled: true } });
+    const out = stripAnsi(renderLine2(ctx, c));
+    expect(out).toContain('💭');
+  });
+
+  it('hides thinking icon when display.thinking is false', () => {
+    const ctx = makeCtx(
+      { icons: EMOJI_ICONS, config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, thinking: false } } },
+      { thinking: { enabled: true } },
+    );
+    const out = stripAnsi(renderLine2(ctx, c));
+    expect(out).not.toContain('💭');
+  });
+
+  it('hides thinking icon when thinking is not enabled', () => {
+    const ctx = makeCtx({ icons: EMOJI_ICONS });
+    const out = stripAnsi(renderLine2(ctx, c));
+    expect(out).not.toContain('💭');
+  });
+
   it('shows cache hit rate when current_usage provides per-turn token fields', () => {
     const inputOverride = {
       context_window: {

--- a/tests/render/powerline-line2.test.ts
+++ b/tests/render/powerline-line2.test.ts
@@ -818,4 +818,36 @@ describe('renderPowerlineLine2', () => {
       expect(raw).toContain(DIR_BG);
     });
   });
+
+  describe('thinking segment', () => {
+    const thinkingInput = {
+      model: 'Claude Sonnet 4.6',
+      session_id: 'test',
+      context_window: { used_percentage: 42, remaining_percentage: 58, total_input_tokens: 12000, total_output_tokens: 1800 },
+      cost: { total_cost_usd: 0.42, total_duration_ms: 185000 },
+      thinking: { enabled: true },
+    };
+
+    it('shows thinking segment when thinking is enabled', () => {
+      const ctx = makeCtx({ input: normalize(thinkingInput), icons: EMOJI_ICONS });
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).toContain('💭');
+    });
+
+    it('hides thinking segment when display.thinking is false', () => {
+      const ctx = makeCtx({
+        input: normalize(thinkingInput),
+        icons: EMOJI_ICONS,
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, thinking: false } },
+      });
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).not.toContain('💭');
+    });
+
+    it('hides thinking segment when thinking is not enabled', () => {
+      const ctx = makeCtx({ icons: EMOJI_ICONS });
+      const out = stripAnsi(renderPowerlineLine2(ctx, 'truecolor', null, c));
+      expect(out).not.toContain('💭');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a `💭` badge (nerd: `󱠤`, emoji: `💭`, none: `think`) to line2 and powerline-line2 when Claude Code ≥ 2.1.x sends `thinking.enabled: true` in the stdin payload
- Widget self-gates — zero output when field is absent (CC < 2.1.x) or `false`
- normalize maps `claude.thinking.enabled === true → thinkingEnabled` (Qwen path excluded; boolean needs no sanitization)
- Powerline segment after effort at priority 28; classic badge appended after `^effort` on the right side of line2
- Preset: `balanced` on, `minimal` off — consistent with `pr` and `effort`

## Test plan

- [x] TDD: 3 normalize cases (true/false/absent for Claude, Qwen excluded)
- [x] TDD: 3 line2 cases (shows/hides-by-toggle/hides-when-absent)
- [x] TDD: 3 powerline-line2 cases (shows/hides-by-toggle/hides-when-absent)
- [x] Full suite: 1286/1286 passing, 0 regressions