### PR TITLE
fix(installer): migrate stale plugin-cache path to bare lumira binary

### DIFF
--- a/dist/installer.js
+++ b/dist/installer.js
@@ -26,16 +26,24 @@ function makeStatusLine(command) {
     return { type: 'command', command, padding: 0 };
 }
 // Rank a statusLine command by per-render speed (higher = faster).
-//   2 = direct binary  (`lumira`, `node …/dist/index.js`, ${CLAUDE_PLUGIN_ROOT})
+//   3 = bare `lumira` binary — always resolves to the current installed version
+//   2 = node /path/dist/index.js or plugin-cache path — fast but version-pinned
 //   1 = npx, cached    (`npx lumira`)
 //   0 = npx, registry  (`npx lumira@latest` / any pinned `@version`)
 // Used to decide migration: only ever rewrite TOWARD a faster form.
+// Speed 3 vs 2 distinction matters: a plugin-cache path (speed 2) can point to
+// a stale version even after `npm i -g lumira`, so the installer must migrate it
+// to the bare `lumira` binary when the global bin is available.
 export function commandSpeed(command) {
     const c = command.trim();
     // `npx` as a bare word or a path basename (e.g. /usr/local/bin/npx, …\npx).
     if (/(^|[\s/\\])npx(\s|$)/.test(c)) {
         return /@(latest|\d)/.test(c) ? 0 : 1;
     }
+    // Bare `lumira` (or platform-specific forms like `lumira.cmd`) — always current.
+    if (/^lumira(\.cmd|\.exe)?$/.test(c))
+        return 3;
+    // node /path/dist/index.js or plugin-cache — version-pinned, may be stale.
     return 2;
 }
 // Is `lumira` resolvable as a global bin on PATH?
@@ -230,8 +238,10 @@ export async function install(opts = {}) {
     const existingCmd = existingIsLumira
         ? String(settings.statusLine.command ?? '')
         : '';
-    // Already on the fastest form (direct binary) — nothing to rewrite.
-    if (existingIsLumira && commandSpeed(existingCmd) >= 2) {
+    // Already on the bare `lumira` binary — optimal, nothing to rewrite.
+    // A node /path/dist/index.js or plugin-cache path (speed 2) is NOT skipped
+    // here — it may point to a stale version and should be migrated to `lumira`.
+    if (existingIsLumira && commandSpeed(existingCmd) >= 3) {
         lines.push(ok('lumira is already configured (optimal command)'));
         return finalize();
     }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -30,16 +30,23 @@ function makeStatusLine(command: string) {
 }
 
 // Rank a statusLine command by per-render speed (higher = faster).
-//   2 = direct binary  (`lumira`, `node …/dist/index.js`, ${CLAUDE_PLUGIN_ROOT})
+//   3 = bare `lumira` binary — always resolves to the current installed version
+//   2 = node /path/dist/index.js or plugin-cache path — fast but version-pinned
 //   1 = npx, cached    (`npx lumira`)
 //   0 = npx, registry  (`npx lumira@latest` / any pinned `@version`)
 // Used to decide migration: only ever rewrite TOWARD a faster form.
-export function commandSpeed(command: string): 0 | 1 | 2 {
+// Speed 3 vs 2 distinction matters: a plugin-cache path (speed 2) can point to
+// a stale version even after `npm i -g lumira`, so the installer must migrate it
+// to the bare `lumira` binary when the global bin is available.
+export function commandSpeed(command: string): 0 | 1 | 2 | 3 {
   const c = command.trim();
   // `npx` as a bare word or a path basename (e.g. /usr/local/bin/npx, …\npx).
   if (/(^|[\s/\\])npx(\s|$)/.test(c)) {
     return /@(latest|\d)/.test(c) ? 0 : 1;
   }
+  // Bare `lumira` (or platform-specific forms like `lumira.cmd`) — always current.
+  if (/^lumira(\.cmd|\.exe)?$/.test(c)) return 3;
+  // node /path/dist/index.js or plugin-cache — version-pinned, may be stale.
   return 2;
 }
 
@@ -274,8 +281,10 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
     ? String((settings.statusLine as Record<string, unknown>).command ?? '')
     : '';
 
-  // Already on the fastest form (direct binary) — nothing to rewrite.
-  if (existingIsLumira && commandSpeed(existingCmd) >= 2) {
+  // Already on the bare `lumira` binary — optimal, nothing to rewrite.
+  // A node /path/dist/index.js or plugin-cache path (speed 2) is NOT skipped
+  // here — it may point to a stale version and should be migrated to `lumira`.
+  if (existingIsLumira && commandSpeed(existingCmd) >= 3) {
     lines.push(ok('lumira is already configured (optimal command)'));
     return finalize();
   }

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -6,7 +6,7 @@ import { install, uninstall, commandSpeed } from '../src/installer.js';
 import { createMockStdin, createMockStdout } from './tui/_mock-stdin.js';
 
 describe('commandSpeed', () => {
-  // 0 = npx@registry (slow), 1 = npx cached, 2 = direct binary (fast)
+  // 0 = npx@registry, 1 = npx cached, 2 = node path (version-pinned), 3 = bare `lumira` (always current)
   it.each([
     ['npx lumira@latest', 0],
     ['npx -y lumira@latest', 0],
@@ -14,9 +14,9 @@ describe('commandSpeed', () => {
     ['npx lumira', 1],
     ['npx -y lumira', 1],
     ['/usr/local/bin/npx lumira', 1], // path-prefixed npx still counts as npx
-    ['lumira', 2],
     ['node /home/u/lumira/dist/index.js', 2],
     ['node "${CLAUDE_PLUGIN_ROOT}/dist/index.js"', 2],
+    ['lumira', 3],   // bare binary — always resolves to current installed version
   ])('ranks %j as speed %i', (cmd, rank) => {
     expect(commandSpeed(cmd as string)).toBe(rank);
   });
@@ -133,6 +133,16 @@ describe('install', () => {
       expect(readCmd()).toBe('lumira');
       expect(installGlobal).not.toHaveBeenCalled();
       expect(output).toContain('already configured');
+    });
+
+    it('migrates a plugin-cache node path to bare `lumira` when global bin exists', async () => {
+      // Regression: `node /plugin-cache/1.8.2/dist/index.js` was mistakenly
+      // classified as speed-2 (optimal) and skipped; now it migrates to `lumira`.
+      const staleCmd = 'node "/home/u/.claude/plugins/cache/lumira/lumira/1.8.2/dist/index.js"';
+      writeFileSync(settingsPath, JSON.stringify({ statusLine: { type: 'command', command: staleCmd } }));
+      const output = await install({ ...baseOpts(), hasGlobalBin: () => true });
+      expect(readCmd()).toBe('lumira');
+      expect(output).toContain('Upgraded');
     });
 
     it('does not downgrade or churn an equal `npx lumira` command', async () => {


### PR DESCRIPTION
## Problem

After `npm install -g lumira@latest`, running `npx lumira install` left the statusline pointing at the old plugin-cache path (`node /plugin-cache/1.8.2/dist/index.js`) instead of migrating it to the bare `lumira` binary.

Root cause: `commandSpeed()` returned `2` for both the bare `lumira` binary and any `node .../dist/index.js` path. The installer's short-circuit check (`>= 2`) treated the stale plugin-cache path as already optimal and exited early without rewriting it.

## Fix

Introduce **speed level 3** for the bare `lumira` binary (always resolves to the current installed version). Speed 2 now exclusively means version-pinned `node /path/dist/index.js` paths.

- Short-circuit now requires speed `>= 3` (bare `lumira` only)
- A plugin-cache path (speed 2) continues through migration and gets upgraded to `lumira` when the global bin is available
- Migration direction is preserved: speed 2 is never downgraded to speed 1 (`npx lumira`)

## Test plan

- [x] New regression test: plugin-cache path + global bin present → migrates to `lumira`
- [x] Existing test updated: `lumira` bare now expects speed 3 (not 2)
- [x] All 1287 tests passing