### PR TITLE
Replace faint/emoji glyphs with nerd glyphs; color thinking magenta

### DIFF
--- a/dist/render/icons.js
+++ b/dist/render/icons.js
@@ -59,9 +59,9 @@ export const NERD_ICONS = {
     checkmark: '✓', // checkmark
     car: '🏎️', // racing car — pace-ahead indicator
     turtle: '🐢', // turtle — pace-behind indicator
-    lightning: '⚡', // lightning bolt — cache hit rate
+    lightning: '󱐋', // U+F140B — nerd lightning-bolt (was ⚡ emoji); cache hit rate
     pr: '', // nf-cod-git_pull_request
-    thinking: '󱠤', // nf-md-brain
+    thinking: '󰧑', // U+F09D1 — clearer "thinking" glyph; nf-md-brain (U+F1824) renders faint in many fonts
     battery: nerdBattery,
 };
 export const EMOJI_ICONS = {

--- a/dist/render/line2.js
+++ b/dist/render/line2.js
@@ -247,7 +247,7 @@ export function renderLine2(ctx, c) {
         rightParts.push(c.dim(`^${effort}`));
     }
     if (display.thinking && input.thinkingEnabled) {
-        rightParts.push(c.dim(icons.thinking));
+        rightParts.push(c.magenta(icons.thinking));
     }
     // Config health hints (opt-in, default off). Sit on the right side as
     // auxiliary signals next to vim/effort, and are dropped silently when the

--- a/src/render/icons.ts
+++ b/src/render/icons.ts
@@ -95,9 +95,9 @@ export const NERD_ICONS: IconSet = {
   checkmark: '✓',  // checkmark
   car:       '🏎️',  // racing car — pace-ahead indicator
   turtle:    '🐢',  // turtle — pace-behind indicator
-  lightning: '⚡',  // lightning bolt — cache hit rate
+  lightning: '󱐋',  // U+F140B — nerd lightning-bolt (was ⚡ emoji); cache hit rate
   pr:        '',  // nf-cod-git_pull_request
-  thinking:  '󱠤',  // nf-md-brain
+  thinking:  '󰧑',  // U+F09D1 — clearer "thinking" glyph; nf-md-brain (U+F1824) renders faint in many fonts
   battery:   nerdBattery,
 };
 

--- a/src/render/line2.ts
+++ b/src/render/line2.ts
@@ -265,7 +265,7 @@ export function renderLine2(ctx: RenderContext, c: Colors): string {
   }
 
   if (display.thinking && input.thinkingEnabled) {
-    rightParts.push(c.dim(icons.thinking));
+    rightParts.push(c.magenta(icons.thinking));
   }
 
   // Config health hints (opt-in, default off). Sit on the right side as

--- a/tests/render/line2.test.ts
+++ b/tests/render/line2.test.ts
@@ -297,6 +297,13 @@ describe('renderLine2', () => {
     expect(out).toContain('💭');
   });
 
+  it('renders the thinking icon in magenta, not dim', () => {
+    const ctx = makeCtx({ icons: EMOJI_ICONS }, { thinking: { enabled: true } });
+    const out = renderLine2(ctx, c);
+    expect(out).toContain(c.magenta(EMOJI_ICONS.thinking));
+    expect(out).not.toContain(c.dim(EMOJI_ICONS.thinking));
+  });
+
   it('hides thinking icon when display.thinking is false', () => {
     const ctx = makeCtx(
       { icons: EMOJI_ICONS, config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, thinking: false } } },


### PR DESCRIPTION
## Why

While validating the extended-thinking badge (v1.12.0), we confirmed end-to-end that CC sends \`thinking.enabled: true\`, lumira normalizes it, and the badge renders — but it was effectively invisible in practice for two reasons:

1. **Glyph choice** — \`nf-md-brain\` (U+F1824) renders faint or as a near-blank cell in many Nerd Fonts. The lightning indicator used the \`⚡\` emoji even in **nerd** mode, inconsistent with the rest of the nerd glyphs.
2. **Color treatment** — the badge was wrapped in \`c.dim()\`, washing it out further.

Both are general issues, not local to one terminal (coverage for the new codepoints is identical to the old — the win is visual clarity).

## Changes

- \`fix(icons)\`: nerd set now uses **U+F09D1** (thinking) and **U+F140B** (lightning) instead of \`nf-md-brain\` and the \`⚡\` emoji. Emoji (\`💭\`/\`⚡\`) and ascii sets unchanged.
- \`fix(line2)\`: thinking indicator rendered in theme **magenta** instead of \`dim\`, so the state reads at a glance.

## Verification

- Real CC payload (captured via stdin spy) → renders the new glyph in magenta, no dim.
- New test asserts the badge is magenta, not dim.
- \`npm test\` → **1288/1288** green; \`npm run build\` clean.
- \`dist/\` rebuilt and committed (plugin clones the repo).

Powerline path untouched — it already colors via palette fg/bg, not dim.