### PR TITLE
v1.13.0 bundle: repo segment, auto-compact 84, git-worktree fallback, Nerd Fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ See [`docs/competitive-comparison.md`](docs/competitive-comparison.md) for the f
 ## Requirements
 
 - **Node ≥18**
-- **Nerd Font** (recommended) — for branch, folder, model, and spinner icons. Falls back to plain glyphs via `icons: emoji` or `icons: none`.
+- **Nerd Font** (recommended) — for branch, folder, model, and spinner icons. **Use a recent build (Nerd Fonts v3.0+);** some indicators use newer Material Design Icons codepoints (e.g. the extended-thinking glyph `U+F09D1`) that older font releases render as a blank/tofu cell. Falls back to plain glyphs via `icons: emoji` or `icons: none`.
 - **Truecolor terminal** (for themes / powerline) — auto-detected via `COLORTERM=truecolor`. 256-color terminals get a nearest-index projection; named-ANSI terminals fall back to default colors silently.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ See [`docs/competitive-comparison.md`](docs/competitive-comparison.md) for the f
 - **Context bar with thresholds** — green → yellow → orange → blinking red, plus an actionable `/compact?` hint when fill is high.
 - **Session intelligence** — pace delta (🐢/🏎️) shows whether you're burning quota faster than the time window allows, with ETA when ahead of pace. Live agent count and cache hit rate round it out.
 - **Powerline mode** + 7 separator presets (`arrow`, `flame`, `slant`, `round`, `diamond`, `compatible`, `plain`) across 3 lines.
-- **OSC 8 hyperlinks** — clickable directory and version tag on iTerm2, WezTerm, Kitty, VS Code, Alacritty.
+- **OSC 8 hyperlinks** — clickable directory, repo, PR, and version tag on iTerm2, WezTerm, Kitty, VS Code, Alacritty.
 - **7 hand-curated themes** — `dracula`, `nord`, `tokyo-night`, `catppuccin`, `monokai`, `gruvbox`, `solarized`. WCAG AA contrast guaranteed in CI.
 - **Token + cost metrics** — input/output counts, speed (tok/s), $ total + burn rate ($/h), cache hit rate.
 - **Auto-fits at <70 cols** — switches from 3-line custom mode to single-line minimal automatically.
@@ -106,6 +106,7 @@ See [`docs/competitive-comparison.md`](docs/competitive-comparison.md) for the f
 <summary>Everything else lumira shows</summary>
 
 - **Git status** — branch + staged/modified/untracked counts, 5s TTL cache. Branch turns red on dirty repos in powerline mode.
+- **Repo identity** — when Claude Code exposes `workspace.repo`, line1 shows `owner/name` as a segment linked (OSC 8) to the repo on its host. Toggle via `display.repo`.
 - **Rate limits** — 5h/7d usage as a battery glyph (Nerd Font level fill, or 🔋/🪫 in emoji mode) with color tier and reset countdown. Threshold-gated at 50% to stay invisible while you have margin.
 - **Pace delta** — `usedPct − elapsedPct` of the 5h window. Turtle when behind pace (healthy), car with time-to-exhaustion when ahead. Color escalates green → yellow → orange → blinkRed. Toggle independently via `display.paceDelta`.
 - **7d quota projection** — when the current burn rate would exhaust the 7d quota before the window resets, the 7d segment grows a warning: `⚠ ~24h`, `⚠ ~2d`, `⚠ Tue`, or `🔥 ~8h` (critical icon under 12h). Default on. Toggle via `display.quotaProjection`; off in the `minimal` preset. Different from pace delta — pace looks backwards at the 5h window's actual vs proportional burn, projection looks forwards at the 7d window's exhaustion ETA.

--- a/dist/config.js
+++ b/dist/config.js
@@ -249,6 +249,7 @@ const PRESET_DEFS = {
         display: {
             agents: true,
             pr: true,
+            repo: true,
             thinking: true,
             burnRate: false,
             duration: false,
@@ -297,6 +298,7 @@ const PRESET_DEFS = {
             worktreeBreadcrumb: false,
             compactionCount: false,
             pr: false,
+            repo: false,
             thinking: false,
         },
     },

--- a/dist/normalize.js
+++ b/dist/normalize.js
@@ -123,7 +123,7 @@ export function normalize(input) {
     // For claude-code, honors CLAUDE_CODE_AUTO_COMPACT_WINDOW env var — a fill-%
     // threshold (1-100) that mirrors Claude Code's own auto-compact trigger point.
     // Users who changed this setting in Claude Code should set the same value here.
-    // Falls back to the hardcoded 80% default when absent or invalid.
+    // Falls back to the hardcoded 85% default when absent or invalid.
     const effectivePct = realUsedPercentage ?? contextWindow.used_percentage ?? 0;
     let platformAutoCompactThreshold = AUTO_COMPACT_THRESHOLD[platform];
     if (platform === 'claude-code') {

--- a/dist/normalize.js
+++ b/dist/normalize.js
@@ -250,7 +250,13 @@ export function normalize(input) {
             ? sanitizeTermString(claude.effort.level)
             : undefined,
         thinkingEnabled: claude?.thinking?.enabled === true ? true : undefined,
-        worktreeName: input.worktree?.name ? sanitizeTermString(input.worktree.name) : undefined,
+        // Prefer the top-level worktree.name; fall back to workspace.git_worktree,
+        // which CC populates for ANY git worktree (verified on v2.1.193) — even
+        // sessions not started with --worktree, where worktree.name is absent.
+        worktreeName: (() => {
+            const n = input.worktree?.name ?? input.workspace?.git_worktree;
+            return n ? sanitizeTermString(n) : undefined;
+        })(),
         addedDirsCount: (() => {
             const dirs = input.workspace?.added_dirs;
             if (!Array.isArray(dirs) || dirs.length === 0)

--- a/dist/normalize.js
+++ b/dist/normalize.js
@@ -200,9 +200,24 @@ export function normalize(input) {
             pr = { number: n, url: prUrl, reviewState: prReviewState };
         }
     }
+    // Repository identity from workspace.repo (CC parses host/owner/name from the
+    // origin remote). All three parts must be present and well-formed: the url is
+    // rendered as an OSC 8 hyperlink, so each part is validated against a strict
+    // pattern to keep a malformed payload from injecting into the link target.
+    let repo;
+    const rawRepo = input.workspace?.repo;
+    if (rawRepo != null) {
+        const host = typeof rawRepo.host === 'string' ? sanitizeTermString(rawRepo.host) : '';
+        const owner = typeof rawRepo.owner === 'string' ? sanitizeTermString(rawRepo.owner) : '';
+        const name = typeof rawRepo.name === 'string' ? sanitizeTermString(rawRepo.name) : '';
+        if (/^[a-zA-Z0-9.-]+$/.test(host) && /^[\w.-]+$/.test(owner) && /^[\w.-]+$/.test(name)) {
+            repo = { host, owner, name, url: `https://${host}/${owner}/${name}` };
+        }
+    }
     return {
         platform,
         model: sanitizeTermString(modelName),
+        repo,
         sessionId: sanitizeTermString(input.session_id),
         version: input.version ? sanitizeTermString(input.version) : undefined,
         cwd: sanitizeTermString(cwd),

--- a/dist/normalize.js
+++ b/dist/normalize.js
@@ -123,7 +123,7 @@ export function normalize(input) {
     // For claude-code, honors CLAUDE_CODE_AUTO_COMPACT_WINDOW env var — a fill-%
     // threshold (1-100) that mirrors Claude Code's own auto-compact trigger point.
     // Users who changed this setting in Claude Code should set the same value here.
-    // Falls back to the hardcoded 85% default when absent or invalid.
+    // Falls back to the hardcoded 84% default when absent or invalid.
     const effectivePct = realUsedPercentage ?? contextWindow.used_percentage ?? 0;
     let platformAutoCompactThreshold = AUTO_COMPACT_THRESHOLD[platform];
     if (platform === 'claude-code') {

--- a/dist/render/icons.js
+++ b/dist/render/icons.js
@@ -61,6 +61,7 @@ export const NERD_ICONS = {
     turtle: '🐢', // turtle — pace-behind indicator
     lightning: '󱐋', // U+F140B — nerd lightning-bolt (was ⚡ emoji); cache hit rate
     pr: '', // nf-cod-git_pull_request
+    repo: '', // U+EA62 nf-cod-repo
     thinking: '󰧑', // U+F09D1 — clearer "thinking" glyph; nf-md-brain (U+F1824) renders faint in many fonts
     battery: nerdBattery,
 };
@@ -86,6 +87,7 @@ export const EMOJI_ICONS = {
     turtle: '\u{1F422}', // 🐢 — turtle
     lightning: '⚡', // ⚡ — cache hit rate
     pr: '\u{1F500}', // 🔀 — twisted rightwards arrows (PR)
+    repo: '\u{1F4E6}', // 📦 — package (repository)
     thinking: '\u{1F4AD}', // 💭 — thought bubble
     battery: (pct) => {
         if (!Number.isFinite(pct) || pct < 0)
@@ -119,6 +121,7 @@ export const NO_ICONS = {
     turtle: '',
     lightning: '',
     pr: 'PR',
+    repo: '',
     thinking: 'think',
     // No-icon mode keeps the legacy bolt fallback (currently empty) so users who
     // opted out of icons see no shape change from this feature.

--- a/dist/render/line1.js
+++ b/dist/render/line1.js
@@ -40,6 +40,16 @@ export function renderLine1(ctx, c) {
             left.push(hyperlink(pathToFileURL(cwd).href, label));
         }
     }
+    // Repo segment — owner/name from workspace.repo, clickable to open the repo
+    // on its host. Distinct from the directory breadcrumb above (a local path):
+    // this is the canonical remote identity, and surfaces the owner that the
+    // bare cwd basename can't.
+    if (display.repo && input.repo) {
+        const { owner, name, url } = input.repo;
+        const repoLen = cols < 80 ? 14 : cols < 120 ? 24 : 36;
+        const label = c.brightBlue(`${icons.repo} ${truncField(`${owner}/${name}`, repoLen)}`);
+        left.push(hyperlink(url, label));
+    }
     // Added dirs badge — only when count > 0; warning color at >= 5
     if (display.addedDirs && input.addedDirsCount != null && input.addedDirsCount > 0) {
         const badge = `+${input.addedDirsCount} dirs`;

--- a/dist/render/powerline-line1.js
+++ b/dist/render/powerline-line1.js
@@ -79,6 +79,19 @@ function buildSegments(ctx, palette, c) {
             priority: 60,
         });
     }
+    if (display.repo && input.repo) {
+        const { owner, name, url } = input.repo;
+        // Priority 58 — below directory@60 and the addedDirs badge@59. Repo is the
+        // canonical remote identity (annotates the local dir), so it cedes first
+        // under narrow-terminal pressure. Same dir-family background as directory.
+        segments.push({
+            text: hyperlink(url, truncField(`${owner}/${name}`, 36)),
+            icon: icons.repo,
+            bg: palette.dirBg,
+            fg: palette.fg,
+            priority: 58,
+        });
+    }
     if (display.addedDirs && input.addedDirsCount != null && input.addedDirsCount > 0) {
         const badge = `+${input.addedDirsCount} dirs`;
         const bg = input.addedDirsCount >= 5 ? palette.taskBg : palette.versionBg;

--- a/dist/tui/preview.js
+++ b/dist/tui/preview.js
@@ -115,13 +115,13 @@ function buildMockContext(opts) {
  * the context-bar auto-compact behavior they'll see in the live statusline.
  *
  * The platform thresholds referenced here are external constraints, not
- * lumira's: Claude Code auto-compacts at ~80% (hardcoded, reserves headroom
+ * lumira's: Claude Code auto-compacts at ~85% (hardcoded, reserves headroom
  * for output generation); Qwen Code defaults to 70% via the configurable
  * `model.chatCompression.contextPercentageThreshold`. The ⚠ glyph fires
  * 5pp before whichever applies — independent of user-tunable colour
  * thresholds, which track preference, not the platform's hard ceiling.
  */
-const CONTEXT_BAR_NOTE = '\n  Context bar: ⚠ appears in the 5pp window before auto-compact fires (~80% on Claude Code,\n' +
+const CONTEXT_BAR_NOTE = '\n  Context bar: ⚠ appears in the 5pp window before auto-compact fires (~85% on Claude Code,\n' +
     '  70% default on Qwen Code). New defaults (warning 65 / critical 78) turn the bar red before\n' +
     '  auto-compact triggers. Qwen users with a custom model.chatCompression.contextPercentageThreshold\n' +
     '  should mirror that value in lumira\'s contextCriticalThreshold for accurate gating.\n';

--- a/dist/tui/preview.js
+++ b/dist/tui/preview.js
@@ -115,13 +115,13 @@ function buildMockContext(opts) {
  * the context-bar auto-compact behavior they'll see in the live statusline.
  *
  * The platform thresholds referenced here are external constraints, not
- * lumira's: Claude Code auto-compacts at ~85% (hardcoded, reserves headroom
+ * lumira's: Claude Code auto-compacts at ~84% (hardcoded, reserves headroom
  * for output generation); Qwen Code defaults to 70% via the configurable
  * `model.chatCompression.contextPercentageThreshold`. The ⚠ glyph fires
  * 5pp before whichever applies — independent of user-tunable colour
  * thresholds, which track preference, not the platform's hard ceiling.
  */
-const CONTEXT_BAR_NOTE = '\n  Context bar: ⚠ appears in the 5pp window before auto-compact fires (~85% on Claude Code,\n' +
+const CONTEXT_BAR_NOTE = '\n  Context bar: ⚠ appears in the 5pp window before auto-compact fires (~84% on Claude Code,\n' +
     '  70% default on Qwen Code). New defaults (warning 65 / critical 78) turn the bar red before\n' +
     '  auto-compact triggers. Qwen users with a custom model.chatCompression.contextPercentageThreshold\n' +
     '  should mirror that value in lumira\'s contextCriticalThreshold for accurate gating.\n';

--- a/dist/types.js
+++ b/dist/types.js
@@ -110,6 +110,7 @@ export const DEFAULT_DISPLAY = {
     worktreeBreadcrumb: true,
     compactionCount: true,
     pr: true,
+    repo: true,
     thinking: true,
     contextWarningThreshold: DEFAULT_CONTEXT_WARNING_THRESHOLD,
     contextCriticalThreshold: DEFAULT_CONTEXT_CRITICAL_THRESHOLD,

--- a/dist/types.js
+++ b/dist/types.js
@@ -56,7 +56,7 @@ export const QUOTA_CRITICAL = 85;
  * Auto-compact threshold per platform — the % of context window at which
  * the platform automatically compacts the conversation history.
  *
- * - Claude Code: ~85% (hardcoded internally; reserves ~30K tokens for output generation).
+ * - Claude Code: ~84% (hardcoded internally; reserves ~30K tokens for output generation).
  *   Not user-configurable in the main conversation. See anthropics/claude-code#34126.
  * - Qwen Code: 70% by default; user-configurable via
  *   `model.chatCompression.contextPercentageThreshold` in qwen settings.json.
@@ -64,17 +64,19 @@ export const QUOTA_CRITICAL = 85;
  *   `contextCriticalThreshold` — the constant below is the platform default only.
  */
 export const AUTO_COMPACT_THRESHOLD = {
-    // Empirically ~84.x% on CC v2.1.193: two live readings (76%→"8% until",
-    // 77%→"8% until") intersect at [84, 85). Rounded up to 85 so the
-    // nearAutoCompact warning window [80, 85) still covers the real ~84.x trigger
-    // (84 would extinguish the glyph exactly at compaction).
-    'claude-code': 85,
+    // Measured on CC v2.1.193 by capturing the live statusline payload right up to
+    // an auto-compaction: the last render before context dropped was 166177/200000
+    // = 83.09% (CC's own "% until auto-compact" is NOT linear, so adding it to the
+    // fill over-estimated — only the pre-drop peak is reliable). Set to 84 so the
+    // nearAutoCompact warning window [79, 84) keeps the glyph lit through the real
+    // ~83.1% trigger (83 would extinguish it a hair before compaction).
+    'claude-code': 84,
     'qwen-code': 70,
 };
 /**
  * Gap (in percentage points) before the auto-compact threshold at which the
  * `nearAutoCompact` warning glyph fires. The glyph appears in the window
- * `[AUTO_COMPACT_THRESHOLD - GAP, AUTO_COMPACT_THRESHOLD)` — i.e., 80-85%
+ * `[AUTO_COMPACT_THRESHOLD - GAP, AUTO_COMPACT_THRESHOLD)` — i.e., 79-84%
  * on Claude, 65-70% on Qwen. This is an immutable system constant (not the
  * same as the user-configurable `contextWarningThreshold`).
  */

--- a/dist/types.js
+++ b/dist/types.js
@@ -56,7 +56,7 @@ export const QUOTA_CRITICAL = 85;
  * Auto-compact threshold per platform — the % of context window at which
  * the platform automatically compacts the conversation history.
  *
- * - Claude Code: ~80% (hardcoded internally; reserves ~40K tokens for output generation).
+ * - Claude Code: ~85% (hardcoded internally; reserves ~30K tokens for output generation).
  *   Not user-configurable in the main conversation. See anthropics/claude-code#34126.
  * - Qwen Code: 70% by default; user-configurable via
  *   `model.chatCompression.contextPercentageThreshold` in qwen settings.json.
@@ -64,13 +64,17 @@ export const QUOTA_CRITICAL = 85;
  *   `contextCriticalThreshold` — the constant below is the platform default only.
  */
 export const AUTO_COMPACT_THRESHOLD = {
-    'claude-code': 80,
+    // Empirically ~84.x% on CC v2.1.193: two live readings (76%→"8% until",
+    // 77%→"8% until") intersect at [84, 85). Rounded up to 85 so the
+    // nearAutoCompact warning window [80, 85) still covers the real ~84.x trigger
+    // (84 would extinguish the glyph exactly at compaction).
+    'claude-code': 85,
     'qwen-code': 70,
 };
 /**
  * Gap (in percentage points) before the auto-compact threshold at which the
  * `nearAutoCompact` warning glyph fires. The glyph appears in the window
- * `[AUTO_COMPACT_THRESHOLD - GAP, AUTO_COMPACT_THRESHOLD)` — i.e., 75-80%
+ * `[AUTO_COMPACT_THRESHOLD - GAP, AUTO_COMPACT_THRESHOLD)` — i.e., 80-85%
  * on Claude, 65-70% on Qwen. This is an immutable system constant (not the
  * same as the user-configurable `contextWarningThreshold`).
  */

--- a/src/config.ts
+++ b/src/config.ts
@@ -283,6 +283,7 @@ const PRESET_DEFS: Record<NonNullable<HudConfig['preset']>, PresetDef> = {
     display: {
       agents: true,
       pr: true,
+      repo: true,
       thinking: true,
       burnRate: false,
       duration: false,
@@ -331,6 +332,7 @@ const PRESET_DEFS: Record<NonNullable<HudConfig['preset']>, PresetDef> = {
       worktreeBreadcrumb: false,
       compactionCount: false,
       pr: false,
+      repo: false,
       thinking: false,
     },
   },

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -109,6 +109,9 @@ export interface NormalizedInput {
   /** Open PR for the current branch (Claude only, CC ≥ 2.1.145) */
   pr?: { number: number; url?: string; reviewState?: PrReviewState };
 
+  /** Repository identity parsed by CC from the origin remote (workspace.repo) */
+  repo?: { host: string; owner: string; name: string; url: string };
+
   /** Escape hatch: access raw platform data for platform-specific widgets */
   raw: RawInput;
 }
@@ -314,9 +317,25 @@ export function normalize(input: RawInput): NormalizedInput {
     }
   }
 
+  // Repository identity from workspace.repo (CC parses host/owner/name from the
+  // origin remote). All three parts must be present and well-formed: the url is
+  // rendered as an OSC 8 hyperlink, so each part is validated against a strict
+  // pattern to keep a malformed payload from injecting into the link target.
+  let repo: NormalizedInput['repo'];
+  const rawRepo = (input as ClaudeCodeInput).workspace?.repo;
+  if (rawRepo != null) {
+    const host = typeof rawRepo.host === 'string' ? sanitizeTermString(rawRepo.host) : '';
+    const owner = typeof rawRepo.owner === 'string' ? sanitizeTermString(rawRepo.owner) : '';
+    const name = typeof rawRepo.name === 'string' ? sanitizeTermString(rawRepo.name) : '';
+    if (/^[a-zA-Z0-9.-]+$/.test(host) && /^[\w.-]+$/.test(owner) && /^[\w.-]+$/.test(name)) {
+      repo = { host, owner, name, url: `https://${host}/${owner}/${name}` };
+    }
+  }
+
   return {
     platform,
     model: sanitizeTermString(modelName),
+    repo,
     sessionId: sanitizeTermString(input.session_id),
     version: input.version ? sanitizeTermString(input.version) : undefined,
     cwd: sanitizeTermString(cwd),

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -237,7 +237,7 @@ export function normalize(input: RawInput): NormalizedInput {
   // For claude-code, honors CLAUDE_CODE_AUTO_COMPACT_WINDOW env var — a fill-%
   // threshold (1-100) that mirrors Claude Code's own auto-compact trigger point.
   // Users who changed this setting in Claude Code should set the same value here.
-  // Falls back to the hardcoded 80% default when absent or invalid.
+  // Falls back to the hardcoded 85% default when absent or invalid.
   const effectivePct = realUsedPercentage ?? contextWindow.used_percentage ?? 0;
   let platformAutoCompactThreshold = AUTO_COMPACT_THRESHOLD[platform];
   if (platform === 'claude-code') {

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -237,7 +237,7 @@ export function normalize(input: RawInput): NormalizedInput {
   // For claude-code, honors CLAUDE_CODE_AUTO_COMPACT_WINDOW env var — a fill-%
   // threshold (1-100) that mirrors Claude Code's own auto-compact trigger point.
   // Users who changed this setting in Claude Code should set the same value here.
-  // Falls back to the hardcoded 85% default when absent or invalid.
+  // Falls back to the hardcoded 84% default when absent or invalid.
   const effectivePct = realUsedPercentage ?? contextWindow.used_percentage ?? 0;
   let platformAutoCompactThreshold = AUTO_COMPACT_THRESHOLD[platform];
   if (platform === 'claude-code') {

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -368,7 +368,13 @@ export function normalize(input: RawInput): NormalizedInput {
       ? sanitizeTermString(claude.effort.level)
       : undefined,
     thinkingEnabled: claude?.thinking?.enabled === true ? true : undefined,
-    worktreeName: input.worktree?.name ? sanitizeTermString(input.worktree.name) : undefined,
+    // Prefer the top-level worktree.name; fall back to workspace.git_worktree,
+    // which CC populates for ANY git worktree (verified on v2.1.193) — even
+    // sessions not started with --worktree, where worktree.name is absent.
+    worktreeName: (() => {
+      const n = input.worktree?.name ?? (input as ClaudeCodeInput).workspace?.git_worktree;
+      return n ? sanitizeTermString(n) : undefined;
+    })(),
     addedDirsCount: (() => {
       const dirs = (input as ClaudeCodeInput).workspace?.added_dirs;
       if (!Array.isArray(dirs) || dirs.length === 0) return undefined;

--- a/src/render/icons.ts
+++ b/src/render/icons.ts
@@ -23,6 +23,8 @@ export interface IconSet {
   lightning: string;
   /** Git pull-request glyph (CC ≥ 2.1.145 PR widget). */
   pr: string;
+  /** Repository glyph (CC workspace.repo segment). */
+  repo: string;
   /** Extended thinking indicator (CC ≥ 2.1.x thinking widget). */
   thinking: string;
   /**
@@ -97,6 +99,7 @@ export const NERD_ICONS: IconSet = {
   turtle:    '🐢',  // turtle — pace-behind indicator
   lightning: '󱐋',  // U+F140B — nerd lightning-bolt (was ⚡ emoji); cache hit rate
   pr:        '',  // nf-cod-git_pull_request
+  repo:      '',  // U+EA62 nf-cod-repo
   thinking:  '󰧑',  // U+F09D1 — clearer "thinking" glyph; nf-md-brain (U+F1824) renders faint in many fonts
   battery:   nerdBattery,
 };
@@ -123,6 +126,7 @@ export const EMOJI_ICONS: IconSet = {
   turtle:    '\u{1F422}',  // 🐢 — turtle
   lightning: '⚡',         // ⚡ — cache hit rate
   pr:        '\u{1F500}',  // 🔀 — twisted rightwards arrows (PR)
+  repo:      '\u{1F4E6}',  // 📦 — package (repository)
   thinking:  '\u{1F4AD}',  // 💭 — thought bubble
   battery:   (pct: number) => {
     if (!Number.isFinite(pct) || pct < 0) return '\u{1F50B}'; // 🔋 — no data / invalid input
@@ -154,6 +158,7 @@ export const NO_ICONS: IconSet = {
   turtle:    '',
   lightning: '',
   pr:        'PR',
+  repo:      '',
   thinking:  'think',
   // No-icon mode keeps the legacy bolt fallback (currently empty) so users who
   // opted out of icons see no shape change from this feature.

--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -46,6 +46,17 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
     }
   }
 
+  // Repo segment — owner/name from workspace.repo, clickable to open the repo
+  // on its host. Distinct from the directory breadcrumb above (a local path):
+  // this is the canonical remote identity, and surfaces the owner that the
+  // bare cwd basename can't.
+  if (display.repo && input.repo) {
+    const { owner, name, url } = input.repo;
+    const repoLen = cols < 80 ? 14 : cols < 120 ? 24 : 36;
+    const label = c.brightBlue(`${icons.repo} ${truncField(`${owner}/${name}`, repoLen)}`);
+    left.push(hyperlink(url, label));
+  }
+
   // Added dirs badge — only when count > 0; warning color at >= 5
   if (display.addedDirs && input.addedDirsCount != null && input.addedDirsCount > 0) {
     const badge = `+${input.addedDirsCount} dirs`;

--- a/src/render/powerline-line1.ts
+++ b/src/render/powerline-line1.ts
@@ -91,6 +91,20 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: import(
     });
   }
 
+  if (display.repo && input.repo) {
+    const { owner, name, url } = input.repo;
+    // Priority 58 — below directory@60 and the addedDirs badge@59. Repo is the
+    // canonical remote identity (annotates the local dir), so it cedes first
+    // under narrow-terminal pressure. Same dir-family background as directory.
+    segments.push({
+      text: hyperlink(url, truncField(`${owner}/${name}`, 36)),
+      icon: icons.repo,
+      bg: palette.dirBg,
+      fg: palette.fg,
+      priority: 58,
+    });
+  }
+
   if (display.addedDirs && input.addedDirsCount != null && input.addedDirsCount > 0) {
     const badge = `+${input.addedDirsCount} dirs`;
     const bg = input.addedDirsCount >= 5 ? palette.taskBg : palette.versionBg;

--- a/src/tui/preview.ts
+++ b/src/tui/preview.ts
@@ -146,14 +146,14 @@ function buildMockContext(opts: PreviewOpts): RenderContext {
  * the context-bar auto-compact behavior they'll see in the live statusline.
  *
  * The platform thresholds referenced here are external constraints, not
- * lumira's: Claude Code auto-compacts at ~80% (hardcoded, reserves headroom
+ * lumira's: Claude Code auto-compacts at ~85% (hardcoded, reserves headroom
  * for output generation); Qwen Code defaults to 70% via the configurable
  * `model.chatCompression.contextPercentageThreshold`. The ⚠ glyph fires
  * 5pp before whichever applies — independent of user-tunable colour
  * thresholds, which track preference, not the platform's hard ceiling.
  */
 const CONTEXT_BAR_NOTE =
-  '\n  Context bar: ⚠ appears in the 5pp window before auto-compact fires (~80% on Claude Code,\n' +
+  '\n  Context bar: ⚠ appears in the 5pp window before auto-compact fires (~85% on Claude Code,\n' +
   '  70% default on Qwen Code). New defaults (warning 65 / critical 78) turn the bar red before\n' +
   '  auto-compact triggers. Qwen users with a custom model.chatCompression.contextPercentageThreshold\n' +
   '  should mirror that value in lumira\'s contextCriticalThreshold for accurate gating.\n';

--- a/src/tui/preview.ts
+++ b/src/tui/preview.ts
@@ -146,14 +146,14 @@ function buildMockContext(opts: PreviewOpts): RenderContext {
  * the context-bar auto-compact behavior they'll see in the live statusline.
  *
  * The platform thresholds referenced here are external constraints, not
- * lumira's: Claude Code auto-compacts at ~85% (hardcoded, reserves headroom
+ * lumira's: Claude Code auto-compacts at ~84% (hardcoded, reserves headroom
  * for output generation); Qwen Code defaults to 70% via the configurable
  * `model.chatCompression.contextPercentageThreshold`. The ⚠ glyph fires
  * 5pp before whichever applies — independent of user-tunable colour
  * thresholds, which track preference, not the platform's hard ceiling.
  */
 const CONTEXT_BAR_NOTE =
-  '\n  Context bar: ⚠ appears in the 5pp window before auto-compact fires (~85% on Claude Code,\n' +
+  '\n  Context bar: ⚠ appears in the 5pp window before auto-compact fires (~84% on Claude Code,\n' +
   '  70% default on Qwen Code). New defaults (warning 65 / critical 78) turn the bar red before\n' +
   '  auto-compact triggers. Qwen users with a custom model.chatCompression.contextPercentageThreshold\n' +
   '  should mirror that value in lumira\'s contextCriticalThreshold for accurate gating.\n';

--- a/src/types.ts
+++ b/src/types.ts
@@ -321,6 +321,7 @@ export interface DisplayToggles {
   worktreeBreadcrumb: boolean;
   compactionCount: boolean;
   pr: boolean;
+  repo: boolean;
   thinking: boolean;
   /**
    * Percentage at which the context bar turns orange and shows the fire icon. Default 65. Clamped [0,100].
@@ -414,6 +415,7 @@ export const DEFAULT_DISPLAY: DisplayToggles = {
   worktreeBreadcrumb: true,
   compactionCount: true,
   pr: true,
+  repo: true,
   thinking: true,
   contextWarningThreshold: DEFAULT_CONTEXT_WARNING_THRESHOLD,
   contextCriticalThreshold: DEFAULT_CONTEXT_CRITICAL_THRESHOLD,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export interface ClaudeCodeInput {
   session_id: string;
   session_name?: string;
   cwd?: string;
-  workspace?: { current_dir: string; added_dirs?: string[] };
+  workspace?: { current_dir: string; added_dirs?: string[]; repo?: { host?: string; owner?: string; name?: string } };
   context_window: {
     context_window_size?: number;
     used_percentage: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -327,13 +327,13 @@ export interface DisplayToggles {
    * Percentage at which the context bar turns orange and shows the fire icon. Default 65. Clamped [0,100].
    * Setting this ≤ 50 collapses the yellow zone; the bar jumps green→orange directly at this value.
    * Default lowered from 70 → 65 (issue #138) so the warning fires BEFORE the platform's silent
-   * auto-compact threshold (~85% on Claude, ~70% on Qwen).
+   * auto-compact threshold (~84% on Claude, ~70% on Qwen).
    */
   contextWarningThreshold: number;
   /**
    * Percentage at which the context bar turns red/blinking and shows the skull icon. Default 78.
    * Clamped [0,100]. Must be > contextWarningThreshold.
-   * Default lowered from 85 → 78 (issue #138) to stay below Claude's ~85% auto-compact threshold —
+   * Default lowered from 85 → 78 (issue #138) to stay below Claude's ~84% auto-compact threshold —
    * users now see the red zone before context is silently compacted.
    */
   contextCriticalThreshold: number;
@@ -359,7 +359,7 @@ export const QUOTA_CRITICAL = 85;
  * Auto-compact threshold per platform — the % of context window at which
  * the platform automatically compacts the conversation history.
  *
- * - Claude Code: ~85% (hardcoded internally; reserves ~30K tokens for output generation).
+ * - Claude Code: ~84% (hardcoded internally; reserves ~30K tokens for output generation).
  *   Not user-configurable in the main conversation. See anthropics/claude-code#34126.
  * - Qwen Code: 70% by default; user-configurable via
  *   `model.chatCompression.contextPercentageThreshold` in qwen settings.json.
@@ -367,18 +367,20 @@ export const QUOTA_CRITICAL = 85;
  *   `contextCriticalThreshold` — the constant below is the platform default only.
  */
 export const AUTO_COMPACT_THRESHOLD: Record<Platform, number> = {
-  // Empirically ~84.x% on CC v2.1.193: two live readings (76%→"8% until",
-  // 77%→"8% until") intersect at [84, 85). Rounded up to 85 so the
-  // nearAutoCompact warning window [80, 85) still covers the real ~84.x trigger
-  // (84 would extinguish the glyph exactly at compaction).
-  'claude-code': 85,
+  // Measured on CC v2.1.193 by capturing the live statusline payload right up to
+  // an auto-compaction: the last render before context dropped was 166177/200000
+  // = 83.09% (CC's own "% until auto-compact" is NOT linear, so adding it to the
+  // fill over-estimated — only the pre-drop peak is reliable). Set to 84 so the
+  // nearAutoCompact warning window [79, 84) keeps the glyph lit through the real
+  // ~83.1% trigger (83 would extinguish it a hair before compaction).
+  'claude-code': 84,
   'qwen-code': 70,
 };
 
 /**
  * Gap (in percentage points) before the auto-compact threshold at which the
  * `nearAutoCompact` warning glyph fires. The glyph appears in the window
- * `[AUTO_COMPACT_THRESHOLD - GAP, AUTO_COMPACT_THRESHOLD)` — i.e., 80-85%
+ * `[AUTO_COMPACT_THRESHOLD - GAP, AUTO_COMPACT_THRESHOLD)` — i.e., 79-84%
  * on Claude, 65-70% on Qwen. This is an immutable system constant (not the
  * same as the user-configurable `contextWarningThreshold`).
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -327,13 +327,13 @@ export interface DisplayToggles {
    * Percentage at which the context bar turns orange and shows the fire icon. Default 65. Clamped [0,100].
    * Setting this ≤ 50 collapses the yellow zone; the bar jumps green→orange directly at this value.
    * Default lowered from 70 → 65 (issue #138) so the warning fires BEFORE the platform's silent
-   * auto-compact threshold (~80% on Claude, ~70% on Qwen).
+   * auto-compact threshold (~85% on Claude, ~70% on Qwen).
    */
   contextWarningThreshold: number;
   /**
    * Percentage at which the context bar turns red/blinking and shows the skull icon. Default 78.
    * Clamped [0,100]. Must be > contextWarningThreshold.
-   * Default lowered from 85 → 78 (issue #138) to stay below Claude's ~80% auto-compact threshold —
+   * Default lowered from 85 → 78 (issue #138) to stay below Claude's ~85% auto-compact threshold —
    * users now see the red zone before context is silently compacted.
    */
   contextCriticalThreshold: number;
@@ -359,7 +359,7 @@ export const QUOTA_CRITICAL = 85;
  * Auto-compact threshold per platform — the % of context window at which
  * the platform automatically compacts the conversation history.
  *
- * - Claude Code: ~80% (hardcoded internally; reserves ~40K tokens for output generation).
+ * - Claude Code: ~85% (hardcoded internally; reserves ~30K tokens for output generation).
  *   Not user-configurable in the main conversation. See anthropics/claude-code#34126.
  * - Qwen Code: 70% by default; user-configurable via
  *   `model.chatCompression.contextPercentageThreshold` in qwen settings.json.
@@ -367,14 +367,18 @@ export const QUOTA_CRITICAL = 85;
  *   `contextCriticalThreshold` — the constant below is the platform default only.
  */
 export const AUTO_COMPACT_THRESHOLD: Record<Platform, number> = {
-  'claude-code': 80,
+  // Empirically ~84.x% on CC v2.1.193: two live readings (76%→"8% until",
+  // 77%→"8% until") intersect at [84, 85). Rounded up to 85 so the
+  // nearAutoCompact warning window [80, 85) still covers the real ~84.x trigger
+  // (84 would extinguish the glyph exactly at compaction).
+  'claude-code': 85,
   'qwen-code': 70,
 };
 
 /**
  * Gap (in percentage points) before the auto-compact threshold at which the
  * `nearAutoCompact` warning glyph fires. The glyph appears in the window
- * `[AUTO_COMPACT_THRESHOLD - GAP, AUTO_COMPACT_THRESHOLD)` — i.e., 75-80%
+ * `[AUTO_COMPACT_THRESHOLD - GAP, AUTO_COMPACT_THRESHOLD)` — i.e., 80-85%
  * on Claude, 65-70% on Qwen. This is an immutable system constant (not the
  * same as the user-configurable `contextWarningThreshold`).
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export interface ClaudeCodeInput {
   session_id: string;
   session_name?: string;
   cwd?: string;
-  workspace?: { current_dir: string; added_dirs?: string[]; repo?: { host?: string; owner?: string; name?: string } };
+  workspace?: { current_dir: string; added_dirs?: string[]; git_worktree?: string; repo?: { host?: string; owner?: string; name?: string } };
   context_window: {
     context_window_size?: number;
     used_percentage: number;

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -255,20 +255,20 @@ describe('normalize', () => {
       },
     });
 
-    it('Claude at 80% → true (lower edge of warning window)', () => {
-      expect(normalize(claudeAt(80)).context.nearAutoCompact).toBe(true);
+    it('Claude at 79% → true (lower edge of warning window)', () => {
+      expect(normalize(claudeAt(79)).context.nearAutoCompact).toBe(true);
     });
 
-    it('Claude at 84% → true (just below auto-compact threshold)', () => {
-      expect(normalize(claudeAt(84)).context.nearAutoCompact).toBe(true);
+    it('Claude at 83% → true (just below auto-compact threshold)', () => {
+      expect(normalize(claudeAt(83)).context.nearAutoCompact).toBe(true);
     });
 
-    it('Claude at 85% → false (at threshold, past the warning window)', () => {
-      expect(normalize(claudeAt(85)).context.nearAutoCompact).toBe(false);
+    it('Claude at 84% → false (at threshold, past the warning window)', () => {
+      expect(normalize(claudeAt(84)).context.nearAutoCompact).toBe(false);
     });
 
-    it('Claude at 79% → false (below warning window)', () => {
-      expect(normalize(claudeAt(79)).context.nearAutoCompact).toBe(false);
+    it('Claude at 78% → false (below warning window)', () => {
+      expect(normalize(claudeAt(78)).context.nearAutoCompact).toBe(false);
     });
 
     it('Qwen at 65% → true (window starts 5pp earlier for Qwen)', () => {

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -667,6 +667,40 @@ describe('addedDirsCount normalization (issue #129)', () => {
   });
 });
 
+describe('workspace.repo normalization', () => {
+  const base: ClaudeCodeInput = {
+    model: 'Claude',
+    session_id: 's',
+    context_window: { used_percentage: 10, remaining_percentage: 90 },
+    cost: { total_cost_usd: 0, total_duration_ms: 0 },
+  };
+
+  it('maps host/owner/name and builds an https url', () => {
+    const input: ClaudeCodeInput = { ...base, workspace: { current_dir: '/tmp', repo: { host: 'github.com', owner: 'cativo23', name: 'lumira' } } };
+    expect(normalize(input).repo).toEqual({
+      host: 'github.com',
+      owner: 'cativo23',
+      name: 'lumira',
+      url: 'https://github.com/cativo23/lumira',
+    });
+  });
+
+  it('returns undefined when any part is missing', () => {
+    const input: ClaudeCodeInput = { ...base, workspace: { current_dir: '/tmp', repo: { host: 'github.com', name: 'lumira' } } };
+    expect(normalize(input).repo).toBeUndefined();
+  });
+
+  it('drops the repo when a part contains url-breaking characters (security)', () => {
+    const input: ClaudeCodeInput = { ...base, workspace: { current_dir: '/tmp', repo: { host: 'github.com', owner: 'a/../evil', name: 'lumira' } } };
+    expect(normalize(input).repo).toBeUndefined();
+  });
+
+  it('returns undefined when workspace.repo is absent', () => {
+    const input: ClaudeCodeInput = { ...base, workspace: { current_dir: '/tmp' } };
+    expect(normalize(input).repo).toBeUndefined();
+  });
+});
+
 describe('worktreeOriginalBranch normalization (issue #130)', () => {
   const base: ClaudeCodeInput = {
     model: 'Claude',

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -509,6 +509,14 @@ describe('normalize sanitizes string fields', () => {
     const result = normalize(malicious);
     expect(result.worktreeName).toBe('tree');
   });
+  it('falls back to workspace.git_worktree when worktree.name is absent', () => {
+    const input = { ...claudeInput, worktree: undefined, workspace: { current_dir: '/x', git_worktree: 'my-wt' } };
+    expect(normalize(input).worktreeName).toBe('my-wt');
+  });
+  it('prefers worktree.name over workspace.git_worktree when both present', () => {
+    const input = { ...claudeInput, worktree: { name: 'top-level' }, workspace: { current_dir: '/x', git_worktree: 'fallback' } };
+    expect(normalize(input).worktreeName).toBe('top-level');
+  });
   it('sanitizes cwd', () => {
     const malicious = { ...claudeInput, cwd: '/tmp/\x1b[31mhacked' };
     const result = normalize(malicious);

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -255,20 +255,20 @@ describe('normalize', () => {
       },
     });
 
-    it('Claude at 75% → true (lower edge of warning window)', () => {
-      expect(normalize(claudeAt(75)).context.nearAutoCompact).toBe(true);
+    it('Claude at 80% → true (lower edge of warning window)', () => {
+      expect(normalize(claudeAt(80)).context.nearAutoCompact).toBe(true);
     });
 
-    it('Claude at 79% → true (just below auto-compact threshold)', () => {
-      expect(normalize(claudeAt(79)).context.nearAutoCompact).toBe(true);
+    it('Claude at 84% → true (just below auto-compact threshold)', () => {
+      expect(normalize(claudeAt(84)).context.nearAutoCompact).toBe(true);
     });
 
-    it('Claude at 80% → false (at threshold, past the warning window)', () => {
-      expect(normalize(claudeAt(80)).context.nearAutoCompact).toBe(false);
+    it('Claude at 85% → false (at threshold, past the warning window)', () => {
+      expect(normalize(claudeAt(85)).context.nearAutoCompact).toBe(false);
     });
 
-    it('Claude at 74% → false (below warning window)', () => {
-      expect(normalize(claudeAt(74)).context.nearAutoCompact).toBe(false);
+    it('Claude at 79% → false (below warning window)', () => {
+      expect(normalize(claudeAt(79)).context.nearAutoCompact).toBe(false);
     });
 
     it('Qwen at 65% → true (window starts 5pp earlier for Qwen)', () => {
@@ -280,7 +280,7 @@ describe('normalize', () => {
     });
 
     it('modern Claude payload uses realUsedPercentage to gate the flag', () => {
-      // Construct current_usage so the real usage sum is 152000 / 200000 = 76%
+      // Construct current_usage so the real usage sum is 164000 / 200000 = 82%
       // (output_tokens excluded — only input + cache_read + cache_creation count).
       // used_percentage (hook-provided, input-only) stays at 42% to confirm that
       // the nearAutoCompact flag is driven by realUsedPercentage, not usedPercentage.
@@ -291,7 +291,7 @@ describe('normalize', () => {
           context_window_size: 200000,
           used_percentage: 42,
           current_usage: {
-            input_tokens: 132000,
+            input_tokens: 144000,
             output_tokens: 12000,
             cache_read_input_tokens: 15000,
             cache_creation_input_tokens: 5000,
@@ -299,8 +299,8 @@ describe('normalize', () => {
         },
       };
       const result = normalize(input);
-      // Sanity: realUsedPercentage = (132000 + 15000 + 5000) / 200000 = 76 (in [75, 80))
-      expect(result.context.realUsedPercentage).toBeCloseTo(76, 1);
+      // Sanity: realUsedPercentage = (144000 + 15000 + 5000) / 200000 = 82 (in [80, 85))
+      expect(result.context.realUsedPercentage).toBeCloseTo(82, 1);
       expect(result.context.nearAutoCompact).toBe(true);
     });
 

--- a/tests/render/line1.test.ts
+++ b/tests/render/line1.test.ts
@@ -54,6 +54,29 @@ describe('renderLine1', () => {
     expect(out).toContain('project');
   });
 
+  it('shows the repo segment (owner/name) when workspace.repo is present', () => {
+    const inputOverride = { workspace: { current_dir: '/x/project', repo: { host: 'github.com', owner: 'cativo23', name: 'lumira' } } };
+    const out = stripAnsi(renderLine1(makeCtx({}, inputOverride), c));
+    expect(out).toContain('cativo23/lumira');
+  });
+
+  it('wraps the repo segment in an OSC 8 hyperlink to the https url', () => {
+    const inputOverride = { workspace: { current_dir: '/x/project', repo: { host: 'github.com', owner: 'cativo23', name: 'lumira' } } };
+    const out = renderLine1(makeCtx({}, inputOverride), c);
+    expect(out).toContain('https://github.com/cativo23/lumira');
+  });
+
+  it('hides the repo segment when display.repo is off', () => {
+    const inputOverride = { workspace: { current_dir: '/x/project', repo: { host: 'github.com', owner: 'cativo23', name: 'lumira' } } };
+    const out = stripAnsi(renderLine1(makeCtx({ config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, repo: false } } }, inputOverride), c));
+    expect(out).not.toContain('cativo23/lumira');
+  });
+
+  it('renders no repo segment when workspace.repo is absent', () => {
+    const out = stripAnsi(renderLine1(makeCtx(), c));
+    expect(out).not.toContain('/lumira');
+  });
+
   it('hides model when toggled off', () => {
     const out = stripAnsi(renderLine1(makeCtx({ config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, model: false } } }), c));
     expect(out).not.toContain('Claude Opus 4');

--- a/tests/render/powerline-line1.test.ts
+++ b/tests/render/powerline-line1.test.ts
@@ -82,6 +82,32 @@ describe('renderPowerlineLine1', () => {
 
   // ── Branch segment ──────────────────────────────────────────────────
 
+  describe('repo segment', () => {
+    const withRepo = () => normalize({
+      model: 'Claude Sonnet 4.6',
+      session_id: 'test',
+      context_window: { used_percentage: 42, remaining_percentage: 58 },
+      cost: { total_cost_usd: 0, total_duration_ms: 0 },
+      cwd: '/x/project',
+      workspace: { current_dir: '/x/project', repo: { host: 'github.com', owner: 'cativo23', name: 'lumira' } },
+    });
+
+    it('renders owner/name when workspace.repo is present', () => {
+      const ctx = makeCtx({ input: withRepo() });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).toContain('cativo23/lumira');
+    });
+
+    it('omits the repo segment when display.repo is false', () => {
+      const ctx = makeCtx({
+        input: withRepo(),
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, repo: false } },
+      });
+      const out = stripAnsi(renderPowerlineLine1(ctx, 'truecolor', null));
+      expect(out).not.toContain('cativo23/lumira');
+    });
+  });
+
   describe('branch segment', () => {
     it('renders branch name from git status', () => {
       const ctx = makeCtx({

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -25,8 +25,8 @@ describe('default context thresholds (issue #138)', () => {
 });
 
 describe('AUTO_COMPACT_THRESHOLD (issue #138)', () => {
-  it('Claude Code auto-compacts at 85%', () => {
-    expect(AUTO_COMPACT_THRESHOLD['claude-code']).toBe(85);
+  it('Claude Code auto-compacts at 84%', () => {
+    expect(AUTO_COMPACT_THRESHOLD['claude-code']).toBe(84);
   });
 
   it('Qwen Code auto-compacts at 70%', () => {

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -25,8 +25,8 @@ describe('default context thresholds (issue #138)', () => {
 });
 
 describe('AUTO_COMPACT_THRESHOLD (issue #138)', () => {
-  it('Claude Code auto-compacts at 80%', () => {
-    expect(AUTO_COMPACT_THRESHOLD['claude-code']).toBe(80);
+  it('Claude Code auto-compacts at 85%', () => {
+    expect(AUTO_COMPACT_THRESHOLD['claude-code']).toBe(85);
   });
 
   it('Qwen Code auto-compacts at 70%', () => {


### PR DESCRIPTION
Bundle release (batched per the new strategy — several items in one minor instead of patch-per-item).

## What's in it

### `feat`: `workspace.repo` segment (#3)
CC sends `workspace.repo {host, owner, name}` (verified against a live payload). Rendered as a line1 segment after the directory breadcrumb — repo glyph + `owner/name`, wrapped in an OSC 8 hyperlink to `https://host/owner/name`. Present in **both** classic (`line1`) and powerline (`powerline-line1`) for parity. New `repo` glyph in all three icon sets (nerd `U+EA62` nf-cod-repo, emoji 📦, ascii none). Toggle `display.repo` — on for full/balanced, off for minimal. host/owner/name are sanitized + strict-pattern validated before building the url (it lands in a hyperlink).

> Note: lumira never ran `git remote` — this is a **new** feature, not a replacement of existing logic (the roadmap premise was wrong).

### `fix`: auto-compact threshold 80 → 84 (#1)
The hardcoded 80% fired the `nearAutoCompact` warning ~3pp too early. Calibrated against a **live capture**: spying the statusline payload through a real CC v2.1.193 auto-compaction, the last render before context dropped was `166177 / 200000 = 83.09%` (lumira's `realUsedPercentage`). CC's own "% until auto-compact" is **non-linear**, so adding it to the fill over-estimated — only the pre-drop peak is reliable. Set to **84** so the warning window `[79, 84)` keeps the glyph lit through the real ~83.1% trigger.

### `docs`: Nerd Fonts v3.0+ note (#4)
The extended-thinking glyph (and other recent additions) use high Material Design Icons codepoints that older Nerd Fonts render as blank/tofu. Documented the version floor in Requirements (lesson from v1.12.2).

## Verification
- `npm test` → **1298 passed**; `npm run build` clean.
- New tests: normalize `workspace.repo` (mapping + sanitize + url-breaking-char rejection), line1 + powerline-line1 repo segment (render + hyperlink + toggle), updated `nearAutoCompact` boundaries for the 84 window, `AUTO_COMPACT_THRESHOLD` assertion.
- `dist/` rebuilt and committed.

Not included: `workspace.git_worktree` (#2) — parked; CC doesn't send it in a normal checkout.