### PR TITLE
feat: subagentStatusLine renderer (#176)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ See [`docs/competitive-comparison.md`](docs/competitive-comparison.md) for the f
 - **Pace delta** — `usedPct − elapsedPct` of the 5h window. Turtle when behind pace (healthy), car with time-to-exhaustion when ahead. Color escalates green → yellow → orange → blinkRed. Toggle independently via `display.paceDelta`.
 - **7d quota projection** — when the current burn rate would exhaust the 7d quota before the window resets, the 7d segment grows a warning: `⚠ ~24h`, `⚠ ~2d`, `⚠ Tue`, or `🔥 ~8h` (critical icon under 12h). Default on. Toggle via `display.quotaProjection`; off in the `minimal` preset. Different from pace delta — pace looks backwards at the 5h window's actual vs proportional burn, projection looks forwards at the 7d window's exhaustion ETA.
 - **Active agents** — live count of running subagents (`⚡N agents`) plus types parsed from the transcript. Toggle via `display.agents`.
-- **Subagent panel rows** — custom rendering for each row in Claude Code's agent panel via [`lumira subagent`](#subagent-rows): a state glyph (running / done / error), the agent name, and its token count, in your configured theme and icon set. Opt-in at install.
+- **Subagent panel rows** — custom rendering for each row in Claude Code's agent panel via [`lumira subagent`](#subagent-rows): a state glyph (running / done / error), what each agent is doing, and its token count, in your configured theme and icon set. Opt-in at install.
 - **Cache hit rate** — prompt cache efficiency for the current turn (`87%⚡`). Alarm-mode: hidden while ≥90% (Anthropic's prompt cache pins this near 99% in healthy steady state, so an always-on number is wallpaper, not signal). Surfaces as yellow/orange/blinkRed only when the cache is actually degrading. Same hide-when-healthy pattern as rate-limits and agent count.
 - **GSD integration** — current task and update notifications (opt-in).
 - **Config health widget** — surfaces silent fallbacks (theme/powerline degrading in named-ANSI, missing GSD STATE.md). Opt-in.
@@ -265,11 +265,13 @@ lumira stats
 Claude Code (≥ 2.1.x) exposes a [`subagentStatusLine`](https://code.claude.com/docs/en/statusline#subagent-status-lines) hook that lets a command customize how each subagent renders in the agent panel — replacing the default `name · description · token count` row. `lumira subagent` reads the visible tasks from stdin and renders each row in your configured theme and icon set:
 
 ```
-󱎫 code-reviewer · 15k tok · running
-✓ investigation-agent · 3k tok · done
+󱎫 reviewing auth module · 15k tok · running
+✓ exploring the codebase · 3k tok · done
 ```
 
-The **glyph and colour are driven by state**, not agent type — running (cyan clock), done (green check), error (red warning) — because Claude Code's agent `type` is open-ended and user-defined, so there's no stable type→icon map to maintain. The state is the signal you actually want at a glance: what's live, what finished, what failed. Rows respect your `icons` (`nerd`/`emoji`/`none`) and `colors.mode` config, and are truncated to the width Claude Code budgets.
+The **glyph and colour are driven by state** — running (cyan clock), done (green check), error (red warning) — so a glance tells you what's live, what finished, what failed.
+
+The **row label** identifies each agent. In practice Claude Code reports every Task subagent with the generic `type: "local_agent"` and no `name`, so the per-agent `description` is the only field that distinguishes one row from another — lumira uses it. The full fallback is `name → a meaningful type → description → id`: an explicit `name` or a real agent type wins when Claude Code provides one, otherwise the `description` carries the row. Rows respect your `icons` (`nerd`/`emoji`/`none`) and `colors.mode` config, and are truncated to the width Claude Code budgets.
 
 **Enable it:** the installer offers to register `subagentStatusLine` alongside the main statusline (opt-in — it never writes the second key without asking). To wire it manually, add to `~/.claude/settings.json`:
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ See [`docs/competitive-comparison.md`](docs/competitive-comparison.md) for the f
 - **Pace delta** — `usedPct − elapsedPct` of the 5h window. Turtle when behind pace (healthy), car with time-to-exhaustion when ahead. Color escalates green → yellow → orange → blinkRed. Toggle independently via `display.paceDelta`.
 - **7d quota projection** — when the current burn rate would exhaust the 7d quota before the window resets, the 7d segment grows a warning: `⚠ ~24h`, `⚠ ~2d`, `⚠ Tue`, or `🔥 ~8h` (critical icon under 12h). Default on. Toggle via `display.quotaProjection`; off in the `minimal` preset. Different from pace delta — pace looks backwards at the 5h window's actual vs proportional burn, projection looks forwards at the 7d window's exhaustion ETA.
 - **Active agents** — live count of running subagents (`⚡N agents`) plus types parsed from the transcript. Toggle via `display.agents`.
+- **Subagent panel rows** — custom rendering for each row in Claude Code's agent panel via [`lumira subagent`](#subagent-rows): a state glyph (running / done / error), the agent name, and its token count, in your configured theme and icon set. Opt-in at install.
 - **Cache hit rate** — prompt cache efficiency for the current turn (`87%⚡`). Alarm-mode: hidden while ≥90% (Anthropic's prompt cache pins this near 99% in healthy steady state, so an always-on number is wallpaper, not signal). Surfaces as yellow/orange/blinkRed only when the cache is actually degrading. Same hide-when-healthy pattern as rate-limits and agent count.
 - **GSD integration** — current task and update notifications (opt-in).
 - **Config health widget** — surfaces silent fallbacks (theme/powerline degrading in named-ANSI, missing GSD STATE.md). Opt-in.
@@ -258,6 +259,27 @@ lumira stats
 - `--json` — emit the raw `SessionStats` object as pretty-printed JSON for `jq` / CI composability.
 
 **Qwen Code sessions** are parsed the same way, but cost and burn-rate lines are suppressed when the transcript lacks usage blocks (`hasCostData: false` in the JSON output) — no misleading `$0.00`.
+
+## Subagent rows
+
+Claude Code (≥ 2.1.x) exposes a [`subagentStatusLine`](https://code.claude.com/docs/en/statusline#subagent-status-lines) hook that lets a command customize how each subagent renders in the agent panel — replacing the default `name · description · token count` row. `lumira subagent` reads the visible tasks from stdin and renders each row in your configured theme and icon set:
+
+```
+󱎫 code-reviewer · 15k tok · running
+✓ investigation-agent · 3k tok · done
+```
+
+The **glyph and colour are driven by state**, not agent type — running (cyan clock), done (green check), error (red warning) — because Claude Code's agent `type` is open-ended and user-defined, so there's no stable type→icon map to maintain. The state is the signal you actually want at a glance: what's live, what finished, what failed. Rows respect your `icons` (`nerd`/`emoji`/`none`) and `colors.mode` config, and are truncated to the width Claude Code budgets.
+
+**Enable it:** the installer offers to register `subagentStatusLine` alongside the main statusline (opt-in — it never writes the second key without asking). To wire it manually, add to `~/.claude/settings.json`:
+
+```json
+{
+  "subagentStatusLine": { "type": "command", "command": "lumira subagent", "padding": 0 }
+}
+```
+
+It's robust by design: on any unreadable or malformed payload it emits nothing and exits 0, so Claude Code falls back to its default rows — a bad render never breaks the panel. Set `LUMIRA_DEBUG=1` to log the raw payload Claude Code sends to stderr.
 
 ## Powerline
 

--- a/dist/commands/subagent.js
+++ b/dist/commands/subagent.js
@@ -53,7 +53,13 @@ function styleFor(status, icons, colors) {
  */
 export function renderSubagentContent(task, icons, colors, columns) {
     const { icon, color, label } = styleFor(task.status, icons, colors);
-    const name = (task.name || task.type || task.id || 'agent').trim();
+    // Identity fallback. CC reports every Task subagent as the generic
+    // `type: "local_agent"` with no `name`, so `description` (the dispatch arg) is
+    // the only field that distinguishes rows — it must win over a generic type.
+    // A *meaningful* type (a real agent_type, if CC ever exposes one) still wins
+    // over description, and an explicit `name` wins over everything.
+    const meaningfulType = task.type && task.type !== 'local_agent' ? task.type : '';
+    const name = (task.name || meaningfulType || task.description || task.id || 'agent').trim();
     const tokens = Number.isFinite(task.tokenCount) ? `${formatTokens(task.tokenCount)} tok` : '';
     const prefix = icon ? `${color(icon)} ` : '';
     const prefixW = icon ? displayWidth(icon) + 1 : 0;

--- a/dist/commands/subagent.js
+++ b/dist/commands/subagent.js
@@ -1,0 +1,123 @@
+/**
+ * `lumira subagent` subcommand (issue #176 — `subagentStatusLine` renderer).
+ *
+ * Claude Code (≥ 2.1.x) lets a command customize how each subagent row renders
+ * in the agent panel. CC pipes a JSON object on stdin describing every visible
+ * subagent and expects ONE JSON line back per row (`{ id, content }`). Omitting
+ * an id keeps CC's default rendering for that row; empty content hides it.
+ *
+ * Input schema (distinct from the main statusline's `RawInput`):
+ *   { columns: number, tasks: [ { id, name, type, status, description,
+ *                                 label, startTime, tokenCount, ... } ] }
+ *
+ * Icon choice is by STATE, not agent type. CC's `type` field is open-ended and
+ * user-defined (dozens of agent types in a real setup), so there's no stable
+ * type→glyph map to maintain — but `running/completed/error` map cleanly onto
+ * glyphs lumira already ships across all three icon sets. The state also drives
+ * the colour, so a glance tells you what's live vs done vs failed.
+ *
+ * Robustness contract: this runs inside CC's render loop. On ANY bad input
+ * (unreadable stdin, malformed JSON, missing fields) it emits nothing and exits
+ * 0 — CC then falls back to its default rows. It must never crash the panel.
+ */
+import { formatTokens } from '../utils/format.js';
+import { displayWidth, truncField } from '../render/text.js';
+import { resolveIcons } from '../render/icons.js';
+import { createColors, detectColorMode } from '../render/colors.js';
+import { loadConfig } from '../config.js';
+import { readStdin } from '../stdin.js';
+import { debug } from '../utils/debug.js';
+/** Per-state presentation: glyph + colour + human label. */
+function styleFor(status, icons, colors) {
+    switch (status) {
+        case 'running':
+            return { icon: icons.clock, color: colors.cyan, label: 'running' };
+        case 'completed':
+            return { icon: icons.checkmark, color: colors.green, label: 'done' };
+        case 'error':
+        case 'failed':
+            return { icon: icons.warning, color: colors.red, label: 'error' };
+        default:
+            // Unknown/absent state: no glyph, dim, pass the raw status through as the
+            // label so a future CC state is still legible instead of being dropped.
+            return { icon: '', color: colors.dim, label: status ?? '' };
+    }
+}
+/**
+ * Render the `content` string for a single subagent row:
+ *   `<glyph> <name> · <tokens> · <state-label>`
+ *
+ * The glyph and label are state-coloured; tokens are dim. When `columns` is
+ * given, the name is truncated (with an ellipsis) so the visible row fits,
+ * reserving width for the fixed glyph/meta first.
+ */
+export function renderSubagentContent(task, icons, colors, columns) {
+    const { icon, color, label } = styleFor(task.status, icons, colors);
+    const name = (task.name || task.type || task.id || 'agent').trim();
+    const tokens = Number.isFinite(task.tokenCount) ? `${formatTokens(task.tokenCount)} tok` : '';
+    const prefix = icon ? `${color(icon)} ` : '';
+    const prefixW = icon ? displayWidth(icon) + 1 : 0;
+    // Plain (uncoloured) meta used both for measuring and for assembling the
+    // coloured version, so width math and output never drift apart.
+    const metaPlain = [tokens, label].filter(Boolean);
+    const metaW = metaPlain.length ? displayWidth(` · ${metaPlain.join(' · ')}`) : 0;
+    // Fit the name to whatever width is left after the fixed glyph + meta.
+    let shownName = name;
+    if (columns && columns > 0) {
+        const budget = columns - prefixW - metaW;
+        if (budget < displayWidth(name))
+            shownName = budget > 1 ? truncField(name, budget) : '';
+    }
+    const metaColored = [];
+    if (tokens)
+        metaColored.push(colors.dim(tokens));
+    if (label)
+        metaColored.push(color(label));
+    const meta = metaColored.join(' · ');
+    // Avoid a dangling " · " when the name was truncated away entirely.
+    if (!shownName)
+        return `${prefix}${meta}`.trimEnd();
+    return meta ? `${prefix}${shownName} · ${meta}` : `${prefix}${shownName}`;
+}
+/**
+ * Render the full CC response: one `{ id, content }` JSON line per addressable
+ * task. Tasks without an id are skipped (CC keys rows by id, so a row we can't
+ * address can't be overridden). Empty/missing task list → empty string.
+ */
+export function renderSubagentTasks(input, icons, colors) {
+    const tasks = Array.isArray(input?.tasks) ? input.tasks : [];
+    const columns = Number.isFinite(input?.columns) ? input.columns : undefined;
+    const lines = [];
+    for (const task of tasks) {
+        if (!task || typeof task.id !== 'string' || task.id === '')
+            continue;
+        lines.push(JSON.stringify({ id: task.id, content: renderSubagentContent(task, icons, colors, columns) }));
+    }
+    return lines.join('\n');
+}
+/**
+ * Wire stdin → config → render. Reuses the main `readStdin` (its only schema
+ * assertion is "is a plain object", which our payload satisfies). Any failure
+ * degrades to empty stdout + exit 0 so CC's panel is never broken.
+ */
+export async function runSubagentCommand(_argv, opts = {}) {
+    const log = debug('subagent');
+    let raw;
+    try {
+        raw = await readStdin(opts.stream ?? process.stdin);
+    }
+    catch (e) {
+        log('stdin read failed:', e.message);
+        return { stdout: '', stderr: '', exitCode: 0 };
+    }
+    if (log.enabled)
+        log('payload:', raw);
+    const config = opts.config ?? loadConfig();
+    const icons = resolveIcons(config.icons);
+    const mode = opts.colorMode
+        ?? (config.colors?.mode && config.colors.mode !== 'auto' ? config.colors.mode : detectColorMode());
+    const colors = createColors(mode);
+    const out = renderSubagentTasks(raw, icons, colors);
+    return { stdout: out ? `${out}\n` : '', stderr: '', exitCode: 0 };
+}
+//# sourceMappingURL=subagent.js.map

--- a/dist/commands/subagent.js
+++ b/dist/commands/subagent.js
@@ -63,7 +63,7 @@ export function renderSubagentContent(task, icons, colors, columns) {
     const metaW = metaPlain.length ? displayWidth(` · ${metaPlain.join(' · ')}`) : 0;
     // Fit the name to whatever width is left after the fixed glyph + meta.
     let shownName = name;
-    if (columns && columns > 0) {
+    if (columns !== undefined && columns > 0) {
         const budget = columns - prefixW - metaW;
         if (budget < displayWidth(name))
             shownName = budget > 1 ? truncField(name, budget) : '';
@@ -100,7 +100,7 @@ export function renderSubagentTasks(input, icons, colors) {
  * assertion is "is a plain object", which our payload satisfies). Any failure
  * degrades to empty stdout + exit 0 so CC's panel is never broken.
  */
-export async function runSubagentCommand(_argv, opts = {}) {
+export async function runSubagentCommand(opts = {}) {
     const log = debug('subagent');
     let raw;
     try {

--- a/dist/index.js
+++ b/dist/index.js
@@ -20,6 +20,7 @@ import { runThemesCommand } from './commands/themes.js';
 import { runStatsCommand } from './commands/stats.js';
 import { runCustomRefreshFromStdin } from './commands/custom-refresh.js';
 import { runCustomCommand } from './commands/custom.js';
+import { runSubagentCommand } from './commands/subagent.js';
 import { EMPTY_TRANSCRIPT } from './types.js';
 import { normalize } from './normalize.js';
 const defaultDeps = {
@@ -121,6 +122,7 @@ Commands:
   stats [path]  Show session statistics
   themes        Browse and preview themes
   custom        Manage custom commands
+  subagent      Render Claude Code agent-panel rows (reads tasks JSON from stdin)
 
 Options:
   --help, -h    Show this help
@@ -180,6 +182,19 @@ if (isDirectRun()) {
             process.stderr.write(`Custom command error: ${e.message}\n`);
             process.exit(1);
         });
+    }
+    else if (cmd === 'subagent') {
+        // CC's subagentStatusLine hook: reads the tasks JSON from its own stdin and
+        // emits one JSON line per row. Degrades to empty output on any error so a
+        // bad payload never breaks CC's agent panel.
+        runSubagentCommand(process.argv).then(r => {
+            if (r.stdout)
+                process.stdout.write(r.stdout);
+            if (r.stderr)
+                process.stderr.write(r.stderr);
+            if (r.exitCode !== 0)
+                process.exit(r.exitCode);
+        }).catch(() => process.exit(0));
     }
     else if (cmd === '__custom-refresh') {
         // Internal: invoked by the renderer as a detached child to refresh a

--- a/dist/index.js
+++ b/dist/index.js
@@ -187,7 +187,7 @@ if (isDirectRun()) {
         // CC's subagentStatusLine hook: reads the tasks JSON from its own stdin and
         // emits one JSON line per row. Degrades to empty output on any error so a
         // bad payload never breaks CC's agent panel.
-        runSubagentCommand(process.argv).then(r => {
+        runSubagentCommand().then(r => {
             if (r.stdout)
                 process.stdout.write(r.stdout);
             if (r.stderr)

--- a/dist/installer.js
+++ b/dist/installer.js
@@ -25,6 +25,25 @@ const header = () => `\n${CYAN} lumira installer${RST}\n`;
 function makeStatusLine(command) {
     return { type: 'command', command, padding: 0 };
 }
+/** Atomically write settings.json: temp file + fsync + rename, mode 0600. */
+function writeSettingsAtomic(settings, settingsPath) {
+    mkdirSync(dirname(settingsPath), { recursive: true });
+    const tmp = `${settingsPath}.${process.pid}.${Date.now()}.lumira.tmp`;
+    try {
+        const fd = openSync(tmp, 'wx', 0o600);
+        writeSync(fd, JSON.stringify(settings, null, 2) + '\n');
+        fsyncSync(fd);
+        closeSync(fd);
+        renameSync(tmp, settingsPath);
+    }
+    catch (e) {
+        try {
+            unlinkSync(tmp);
+        }
+        catch { }
+        throw e;
+    }
+}
 // Rank a statusLine command by per-render speed (higher = faster).
 //   3 = bare `lumira` binary — always resolves to the current installed version
 //   2 = node /path/dist/index.js or plugin-cache path — fast but version-pinned
@@ -153,6 +172,28 @@ function emitFooter(lines, homeOverride) {
     lines.push(`\n  Restart Claude Code to see your statusline.\n`);
 }
 // ── Install ─────────────────────────────────────────────────────────
+/**
+ * Optionally register Claude Code's `subagentStatusLine` hook (CC ≥ 2.1.x)
+ * alongside the main statusLine, pointing it at `<cmd> subagent`.
+ *
+ * Opt-in and interactive-only: we never add a second settings key without
+ * explicit consent, and skip silently in non-TTY runs (so CI/scripted installs
+ * stay predictable). No-op when it already points at lumira. Returns true when
+ * the key was added, so the caller knows it must flush settings to disk.
+ */
+async function maybeRegisterSubagent(args) {
+    const { settings, baseCmd, confirm, isTTY, lines } = args;
+    if (isLumira(settings.subagentStatusLine))
+        return false;
+    if (!isTTY)
+        return false;
+    const accepted = await confirm('Customize subagent panel rows too? (subagentStatusLine)');
+    if (!accepted)
+        return false;
+    settings.subagentStatusLine = makeStatusLine(`${baseCmd} subagent`);
+    lines.push(ok(`Configured subagentStatusLine → ${DIM}${baseCmd} subagent${RST}`));
+    return true;
+}
 export async function install(opts = {}) {
     const settingsPath = opts.settingsPath ?? defaultSettingsPath();
     const configPath = opts.configPath ?? defaultConfigPath();
@@ -243,6 +284,11 @@ export async function install(opts = {}) {
     // here — it may point to a stale version and should be migrated to `lumira`.
     if (existingIsLumira && commandSpeed(existingCmd) >= 3) {
         lines.push(ok('lumira is already configured (optimal command)'));
+        // statusLine needs no rewrite, but a returning user may still want to opt
+        // into the subagent hook — offer it and flush only if they accept.
+        const added = await maybeRegisterSubagent({ settings, baseCmd: existingCmd, confirm, isTTY: !!stdin?.isTTY, lines });
+        if (added)
+            writeSettingsAtomic(settings, settingsPath);
         return finalize();
     }
     // Resolve the fastest per-render command this environment can offer.
@@ -254,6 +300,9 @@ export async function install(opts = {}) {
         // so we never downgrade a user's direct binary to npx.
         if (commandSpeed(resolvedCmd) <= commandSpeed(existingCmd)) {
             lines.push(ok('lumira is already configured'));
+            const added = await maybeRegisterSubagent({ settings, baseCmd: existingCmd, confirm, isTTY: !!stdin?.isTTY, lines });
+            if (added)
+                writeSettingsAtomic(settings, settingsPath);
             return finalize();
         }
     }
@@ -263,22 +312,8 @@ export async function install(opts = {}) {
         lines.push(ok(`Backed up existing settings → ${DIM}settings.json.lumira.bak${RST}`));
     }
     settings.statusLine = makeStatusLine(resolvedCmd);
-    mkdirSync(dirname(settingsPath), { recursive: true });
-    const tmp = `${settingsPath}.${process.pid}.${Date.now()}.lumira.tmp`;
-    try {
-        const fd = openSync(tmp, 'wx', 0o600);
-        writeSync(fd, JSON.stringify(settings, null, 2) + '\n');
-        fsyncSync(fd);
-        closeSync(fd);
-        renameSync(tmp, settingsPath);
-    }
-    catch (e) {
-        try {
-            unlinkSync(tmp);
-        }
-        catch { }
-        throw e;
-    }
+    await maybeRegisterSubagent({ settings, baseCmd: resolvedCmd, confirm, isTTY: !!stdin?.isTTY, lines });
+    writeSettingsAtomic(settings, settingsPath);
     lines.push(ok(existingIsLumira
         ? `Upgraded statusline command → ${DIM}${resolvedCmd}${RST} (faster)`
         : 'Configured lumira as statusline'));
@@ -339,21 +374,8 @@ export function uninstall(opts = {}) {
         return lines.join('\n') + '\n';
     }
     delete uninstSettings.statusLine;
-    const uninstTmp = `${settingsPath}.${process.pid}.${Date.now()}.lumira.tmp`;
-    try {
-        const fd = openSync(uninstTmp, 'wx', 0o600);
-        writeSync(fd, JSON.stringify(uninstSettings, null, 2) + '\n');
-        fsyncSync(fd);
-        closeSync(fd);
-        renameSync(uninstTmp, settingsPath);
-    }
-    catch (e) {
-        try {
-            unlinkSync(uninstTmp);
-        }
-        catch { }
-        throw e;
-    }
+    delete uninstSettings.subagentStatusLine;
+    writeSettingsAtomic(uninstSettings, settingsPath);
     lines.push(ok('Removed lumira statusline from settings'));
     // Remove skill from both destinations (best effort)
     for (const root of [join(home, '.claude'), join(home, '.qwen')]) {

--- a/dist/installer.js
+++ b/dist/installer.js
@@ -183,7 +183,10 @@ function emitFooter(lines, homeOverride) {
  */
 async function maybeRegisterSubagent(args) {
     const { settings, baseCmd, confirm, isTTY, lines } = args;
-    if (isLumira(settings.subagentStatusLine))
+    // Only register when the key is absent. If it's already lumira there's nothing
+    // to do; if it's a *foreign* command we leave it untouched rather than clobber
+    // a user's own subagent renderer without an explicit backup/replace flow.
+    if (settings.subagentStatusLine != null)
         return false;
     if (!isTTY)
         return false;
@@ -374,7 +377,9 @@ export function uninstall(opts = {}) {
         return lines.join('\n') + '\n';
     }
     delete uninstSettings.statusLine;
-    delete uninstSettings.subagentStatusLine;
+    // Only remove the subagent hook if it's ours — never wipe a foreign renderer.
+    if (isLumira(uninstSettings.subagentStatusLine))
+        delete uninstSettings.subagentStatusLine;
     writeSettingsAtomic(uninstSettings, settingsPath);
     lines.push(ok('Removed lumira statusline from settings'));
     // Remove skill from both destinations (best effort)

--- a/src/commands/subagent.ts
+++ b/src/commands/subagent.ts
@@ -1,0 +1,156 @@
+/**
+ * `lumira subagent` subcommand (issue #176 — `subagentStatusLine` renderer).
+ *
+ * Claude Code (≥ 2.1.x) lets a command customize how each subagent row renders
+ * in the agent panel. CC pipes a JSON object on stdin describing every visible
+ * subagent and expects ONE JSON line back per row (`{ id, content }`). Omitting
+ * an id keeps CC's default rendering for that row; empty content hides it.
+ *
+ * Input schema (distinct from the main statusline's `RawInput`):
+ *   { columns: number, tasks: [ { id, name, type, status, description,
+ *                                 label, startTime, tokenCount, ... } ] }
+ *
+ * Icon choice is by STATE, not agent type. CC's `type` field is open-ended and
+ * user-defined (dozens of agent types in a real setup), so there's no stable
+ * type→glyph map to maintain — but `running/completed/error` map cleanly onto
+ * glyphs lumira already ships across all three icon sets. The state also drives
+ * the colour, so a glance tells you what's live vs done vs failed.
+ *
+ * Robustness contract: this runs inside CC's render loop. On ANY bad input
+ * (unreadable stdin, malformed JSON, missing fields) it emits nothing and exits
+ * 0 — CC then falls back to its default rows. It must never crash the panel.
+ */
+import { formatTokens } from '../utils/format.js';
+import { displayWidth, truncField } from '../render/text.js';
+import { resolveIcons, type IconSet } from '../render/icons.js';
+import { createColors, detectColorMode, type Colors, type ColorMode } from '../render/colors.js';
+import { loadConfig } from '../config.js';
+import { readStdin } from '../stdin.js';
+import { debug } from '../utils/debug.js';
+import type { Readable } from 'node:stream';
+import type { SubagentInput, SubagentTask, HudConfig } from '../types.js';
+
+export interface SubagentCommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface SubagentCommandOpts {
+  /** stdin source — injectable for tests. Defaults to `process.stdin`. */
+  stream?: Readable;
+  /** Pre-loaded config — injectable for tests to avoid filesystem access. */
+  config?: HudConfig;
+  /** Force a colour mode — injectable for tests. */
+  colorMode?: ColorMode;
+}
+
+/** Per-state presentation: glyph + colour + human label. */
+function styleFor(
+  status: string | undefined,
+  icons: IconSet,
+  colors: Colors,
+): { icon: string; color: (s: string) => string; label: string } {
+  switch (status) {
+    case 'running':
+      return { icon: icons.clock, color: colors.cyan, label: 'running' };
+    case 'completed':
+      return { icon: icons.checkmark, color: colors.green, label: 'done' };
+    case 'error':
+    case 'failed':
+      return { icon: icons.warning, color: colors.red, label: 'error' };
+    default:
+      // Unknown/absent state: no glyph, dim, pass the raw status through as the
+      // label so a future CC state is still legible instead of being dropped.
+      return { icon: '', color: colors.dim, label: status ?? '' };
+  }
+}
+
+/**
+ * Render the `content` string for a single subagent row:
+ *   `<glyph> <name> · <tokens> · <state-label>`
+ *
+ * The glyph and label are state-coloured; tokens are dim. When `columns` is
+ * given, the name is truncated (with an ellipsis) so the visible row fits,
+ * reserving width for the fixed glyph/meta first.
+ */
+export function renderSubagentContent(
+  task: SubagentTask,
+  icons: IconSet,
+  colors: Colors,
+  columns?: number,
+): string {
+  const { icon, color, label } = styleFor(task.status, icons, colors);
+  const name = (task.name || task.type || task.id || 'agent').trim();
+  const tokens = Number.isFinite(task.tokenCount) ? `${formatTokens(task.tokenCount as number)} tok` : '';
+
+  const prefix = icon ? `${color(icon)} ` : '';
+  const prefixW = icon ? displayWidth(icon) + 1 : 0;
+
+  // Plain (uncoloured) meta used both for measuring and for assembling the
+  // coloured version, so width math and output never drift apart.
+  const metaPlain = [tokens, label].filter(Boolean);
+  const metaW = metaPlain.length ? displayWidth(` · ${metaPlain.join(' · ')}`) : 0;
+
+  // Fit the name to whatever width is left after the fixed glyph + meta.
+  let shownName = name;
+  if (columns && columns > 0) {
+    const budget = columns - prefixW - metaW;
+    if (budget < displayWidth(name)) shownName = budget > 1 ? truncField(name, budget) : '';
+  }
+
+  const metaColored: string[] = [];
+  if (tokens) metaColored.push(colors.dim(tokens));
+  if (label) metaColored.push(color(label));
+  const meta = metaColored.join(' · ');
+
+  // Avoid a dangling " · " when the name was truncated away entirely.
+  if (!shownName) return `${prefix}${meta}`.trimEnd();
+  return meta ? `${prefix}${shownName} · ${meta}` : `${prefix}${shownName}`;
+}
+
+/**
+ * Render the full CC response: one `{ id, content }` JSON line per addressable
+ * task. Tasks without an id are skipped (CC keys rows by id, so a row we can't
+ * address can't be overridden). Empty/missing task list → empty string.
+ */
+export function renderSubagentTasks(input: SubagentInput, icons: IconSet, colors: Colors): string {
+  const tasks = Array.isArray(input?.tasks) ? input.tasks : [];
+  const columns = Number.isFinite(input?.columns) ? (input.columns as number) : undefined;
+  const lines: string[] = [];
+  for (const task of tasks) {
+    if (!task || typeof task.id !== 'string' || task.id === '') continue;
+    lines.push(JSON.stringify({ id: task.id, content: renderSubagentContent(task, icons, colors, columns) }));
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Wire stdin → config → render. Reuses the main `readStdin` (its only schema
+ * assertion is "is a plain object", which our payload satisfies). Any failure
+ * degrades to empty stdout + exit 0 so CC's panel is never broken.
+ */
+export async function runSubagentCommand(
+  _argv: string[],
+  opts: SubagentCommandOpts = {},
+): Promise<SubagentCommandResult> {
+  const log = debug('subagent');
+
+  let raw: unknown;
+  try {
+    raw = await readStdin(opts.stream ?? process.stdin);
+  } catch (e) {
+    log('stdin read failed:', (e as Error).message);
+    return { stdout: '', stderr: '', exitCode: 0 };
+  }
+  if (log.enabled) log('payload:', raw);
+
+  const config = opts.config ?? loadConfig();
+  const icons = resolveIcons(config.icons);
+  const mode = opts.colorMode
+    ?? (config.colors?.mode && config.colors.mode !== 'auto' ? config.colors.mode : detectColorMode());
+  const colors = createColors(mode);
+
+  const out = renderSubagentTasks(raw as SubagentInput, icons, colors);
+  return { stdout: out ? `${out}\n` : '', stderr: '', exitCode: 0 };
+}

--- a/src/commands/subagent.ts
+++ b/src/commands/subagent.ts
@@ -94,7 +94,7 @@ export function renderSubagentContent(
 
   // Fit the name to whatever width is left after the fixed glyph + meta.
   let shownName = name;
-  if (columns && columns > 0) {
+  if (columns !== undefined && columns > 0) {
     const budget = columns - prefixW - metaW;
     if (budget < displayWidth(name)) shownName = budget > 1 ? truncField(name, budget) : '';
   }
@@ -131,7 +131,6 @@ export function renderSubagentTasks(input: SubagentInput, icons: IconSet, colors
  * degrades to empty stdout + exit 0 so CC's panel is never broken.
  */
 export async function runSubagentCommand(
-  _argv: string[],
   opts: SubagentCommandOpts = {},
 ): Promise<SubagentCommandResult> {
   const log = debug('subagent');

--- a/src/commands/subagent.ts
+++ b/src/commands/subagent.ts
@@ -81,7 +81,13 @@ export function renderSubagentContent(
   columns?: number,
 ): string {
   const { icon, color, label } = styleFor(task.status, icons, colors);
-  const name = (task.name || task.type || task.id || 'agent').trim();
+  // Identity fallback. CC reports every Task subagent as the generic
+  // `type: "local_agent"` with no `name`, so `description` (the dispatch arg) is
+  // the only field that distinguishes rows — it must win over a generic type.
+  // A *meaningful* type (a real agent_type, if CC ever exposes one) still wins
+  // over description, and an explicit `name` wins over everything.
+  const meaningfulType = task.type && task.type !== 'local_agent' ? task.type : '';
+  const name = (task.name || meaningfulType || task.description || task.id || 'agent').trim();
   const tokens = Number.isFinite(task.tokenCount) ? `${formatTokens(task.tokenCount as number)} tok` : '';
 
   const prefix = icon ? `${color(icon)} ` : '';

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,7 +183,7 @@ if (isDirectRun()) {
     // CC's subagentStatusLine hook: reads the tasks JSON from its own stdin and
     // emits one JSON line per row. Degrades to empty output on any error so a
     // bad payload never breaks CC's agent panel.
-    runSubagentCommand(process.argv).then(r => {
+    runSubagentCommand().then(r => {
       if (r.stdout) process.stdout.write(r.stdout);
       if (r.stderr) process.stderr.write(r.stderr);
       if (r.exitCode !== 0) process.exit(r.exitCode);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { runThemesCommand } from './commands/themes.js';
 import { runStatsCommand } from './commands/stats.js';
 import { runCustomRefreshFromStdin } from './commands/custom-refresh.js';
 import { runCustomCommand } from './commands/custom.js';
+import { runSubagentCommand } from './commands/subagent.js';
 import type { Dependencies, RawInput } from './types.js';
 import type { NormalizedInput } from './normalize.js';
 import { EMPTY_TRANSCRIPT } from './types.js';
@@ -131,6 +132,7 @@ Commands:
   stats [path]  Show session statistics
   themes        Browse and preview themes
   custom        Manage custom commands
+  subagent      Render Claude Code agent-panel rows (reads tasks JSON from stdin)
 
 Options:
   --help, -h    Show this help
@@ -177,6 +179,15 @@ if (isDirectRun()) {
       process.stderr.write(`Custom command error: ${e.message}\n`);
       process.exit(1);
     });
+  } else if (cmd === 'subagent') {
+    // CC's subagentStatusLine hook: reads the tasks JSON from its own stdin and
+    // emits one JSON line per row. Degrades to empty output on any error so a
+    // bad payload never breaks CC's agent panel.
+    runSubagentCommand(process.argv).then(r => {
+      if (r.stdout) process.stdout.write(r.stdout);
+      if (r.stderr) process.stderr.write(r.stderr);
+      if (r.exitCode !== 0) process.exit(r.exitCode);
+    }).catch(() => process.exit(0));
   } else if (cmd === '__custom-refresh') {
     // Internal: invoked by the renderer as a detached child to refresh a
     // single custom command's cache entry without keeping the renderer's

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -223,7 +223,10 @@ async function maybeRegisterSubagent(args: {
   lines: string[];
 }): Promise<boolean> {
   const { settings, baseCmd, confirm, isTTY, lines } = args;
-  if (isLumira(settings.subagentStatusLine)) return false;
+  // Only register when the key is absent. If it's already lumira there's nothing
+  // to do; if it's a *foreign* command we leave it untouched rather than clobber
+  // a user's own subagent renderer without an explicit backup/replace flow.
+  if (settings.subagentStatusLine != null) return false;
   if (!isTTY) return false;
   const accepted = await confirm('Customize subagent panel rows too? (subagentStatusLine)');
   if (!accepted) return false;
@@ -413,7 +416,8 @@ export function uninstall(opts: InstallerOptions = {}): string {
     return lines.join('\n') + '\n';
   }
   delete uninstSettings.statusLine;
-  delete uninstSettings.subagentStatusLine;
+  // Only remove the subagent hook if it's ours — never wipe a foreign renderer.
+  if (isLumira(uninstSettings.subagentStatusLine)) delete uninstSettings.subagentStatusLine;
   writeSettingsAtomic(uninstSettings, settingsPath);
   lines.push(ok('Removed lumira statusline from settings'));
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -29,6 +29,22 @@ function makeStatusLine(command: string) {
   return { type: 'command' as const, command, padding: 0 };
 }
 
+/** Atomically write settings.json: temp file + fsync + rename, mode 0600. */
+function writeSettingsAtomic(settings: Record<string, unknown>, settingsPath: string): void {
+  mkdirSync(dirname(settingsPath), { recursive: true });
+  const tmp = `${settingsPath}.${process.pid}.${Date.now()}.lumira.tmp`;
+  try {
+    const fd = openSync(tmp, 'wx', 0o600);
+    writeSync(fd, JSON.stringify(settings, null, 2) + '\n');
+    fsyncSync(fd);
+    closeSync(fd);
+    renameSync(tmp, settingsPath);
+  } catch (e) {
+    try { unlinkSync(tmp); } catch {}
+    throw e;
+  }
+}
+
 // Rank a statusLine command by per-render speed (higher = faster).
 //   3 = bare `lumira` binary — always resolves to the current installed version
 //   2 = node /path/dist/index.js or plugin-cache path — fast but version-pinned
@@ -190,6 +206,32 @@ function emitFooter(lines: string[], homeOverride?: string): void {
 }
 
 // ── Install ─────────────────────────────────────────────────────────
+/**
+ * Optionally register Claude Code's `subagentStatusLine` hook (CC ≥ 2.1.x)
+ * alongside the main statusLine, pointing it at `<cmd> subagent`.
+ *
+ * Opt-in and interactive-only: we never add a second settings key without
+ * explicit consent, and skip silently in non-TTY runs (so CI/scripted installs
+ * stay predictable). No-op when it already points at lumira. Returns true when
+ * the key was added, so the caller knows it must flush settings to disk.
+ */
+async function maybeRegisterSubagent(args: {
+  settings: Record<string, unknown>;
+  baseCmd: string;
+  confirm: (q: string) => Promise<boolean>;
+  isTTY: boolean;
+  lines: string[];
+}): Promise<boolean> {
+  const { settings, baseCmd, confirm, isTTY, lines } = args;
+  if (isLumira(settings.subagentStatusLine)) return false;
+  if (!isTTY) return false;
+  const accepted = await confirm('Customize subagent panel rows too? (subagentStatusLine)');
+  if (!accepted) return false;
+  settings.subagentStatusLine = makeStatusLine(`${baseCmd} subagent`);
+  lines.push(ok(`Configured subagentStatusLine → ${DIM}${baseCmd} subagent${RST}`));
+  return true;
+}
+
 export async function install(opts: InstallerOptions = {}): Promise<string> {
   const settingsPath = opts.settingsPath ?? defaultSettingsPath();
   const configPath = opts.configPath ?? defaultConfigPath();
@@ -286,6 +328,10 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
   // here — it may point to a stale version and should be migrated to `lumira`.
   if (existingIsLumira && commandSpeed(existingCmd) >= 3) {
     lines.push(ok('lumira is already configured (optimal command)'));
+    // statusLine needs no rewrite, but a returning user may still want to opt
+    // into the subagent hook — offer it and flush only if they accept.
+    const added = await maybeRegisterSubagent({ settings, baseCmd: existingCmd, confirm, isTTY: !!stdin?.isTTY, lines });
+    if (added) writeSettingsAtomic(settings, settingsPath);
     return finalize();
   }
 
@@ -299,6 +345,8 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
     // so we never downgrade a user's direct binary to npx.
     if (commandSpeed(resolvedCmd) <= commandSpeed(existingCmd)) {
       lines.push(ok('lumira is already configured'));
+      const added = await maybeRegisterSubagent({ settings, baseCmd: existingCmd, confirm, isTTY: !!stdin?.isTTY, lines });
+      if (added) writeSettingsAtomic(settings, settingsPath);
       return finalize();
     }
   } else if (settings.statusLine) {
@@ -308,18 +356,8 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
   }
 
   settings.statusLine = makeStatusLine(resolvedCmd);
-  mkdirSync(dirname(settingsPath), { recursive: true });
-  const tmp = `${settingsPath}.${process.pid}.${Date.now()}.lumira.tmp`;
-  try {
-    const fd = openSync(tmp, 'wx', 0o600);
-    writeSync(fd, JSON.stringify(settings, null, 2) + '\n');
-    fsyncSync(fd);
-    closeSync(fd);
-    renameSync(tmp, settingsPath);
-  } catch (e) {
-    try { unlinkSync(tmp); } catch {}
-    throw e;
-  }
+  await maybeRegisterSubagent({ settings, baseCmd: resolvedCmd, confirm, isTTY: !!stdin?.isTTY, lines });
+  writeSettingsAtomic(settings, settingsPath);
   lines.push(ok(existingIsLumira
     ? `Upgraded statusline command → ${DIM}${resolvedCmd}${RST} (faster)`
     : 'Configured lumira as statusline'));
@@ -375,17 +413,8 @@ export function uninstall(opts: InstallerOptions = {}): string {
     return lines.join('\n') + '\n';
   }
   delete uninstSettings.statusLine;
-  const uninstTmp = `${settingsPath}.${process.pid}.${Date.now()}.lumira.tmp`;
-  try {
-    const fd = openSync(uninstTmp, 'wx', 0o600);
-    writeSync(fd, JSON.stringify(uninstSettings, null, 2) + '\n');
-    fsyncSync(fd);
-    closeSync(fd);
-    renameSync(uninstTmp, settingsPath);
-  } catch (e) {
-    try { unlinkSync(uninstTmp); } catch {}
-    throw e;
-  }
+  delete uninstSettings.subagentStatusLine;
+  writeSettingsAtomic(uninstSettings, settingsPath);
   lines.push(ok('Removed lumira statusline from settings'));
 
   // Remove skill from both destinations (best effort)

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,35 @@ export interface RateLimitWindow {
   resets_at?: number;
 }
 
+// ── Subagent status-line stdin JSON (CC ≥ 2.1.x `subagentStatusLine`) ──
+//
+// A SEPARATE entry point from the main statusline: Claude Code invokes the
+// registered command once per render with every visible subagent row, and
+// expects one JSON line per row back (`{ id, content }`). This is NOT part of
+// the `RawInput` union — the schema and the output contract are both distinct.
+
+export interface SubagentTask {
+  id: string;
+  name: string;
+  type?: string;
+  /** running | completed | error — but treat as open-ended; unknown states render plainly. */
+  status?: string;
+  description?: string;
+  label?: string;
+  /** Unix epoch ms when the subagent started. */
+  startTime?: number;
+  tokenCount?: number;
+  /** Opaque sampling structure from CC — not consumed by the renderer. */
+  tokenSamples?: unknown;
+  cwd?: string;
+}
+
+export interface SubagentInput {
+  /** Terminal width CC budgeted for the row — content is truncated to fit. */
+  columns?: number;
+  tasks?: SubagentTask[];
+}
+
 // ── Parser outputs ──────────────────────────────────────────────────
 
 export interface GitStatus {

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,8 @@ export interface RateLimitWindow {
 
 export interface SubagentTask {
   id: string;
-  name: string;
+  /** Optional: the renderer falls back to `type` then `id` when absent. */
+  name?: string;
   type?: string;
   /** running | completed | error — but treat as open-ended; unknown states render plainly. */
   status?: string;

--- a/tests/commands/subagent.test.ts
+++ b/tests/commands/subagent.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for `lumira subagent` subcommand (issue #176 — subagentStatusLine renderer).
+ *
+ * Claude Code (≥ 2.1.x) pipes every visible subagent row as JSON on stdin and
+ * expects one `{ id, content }` JSON line back per row. These tests pin:
+ *   - per-state rendering (icon + color + label) for running/completed/error
+ *   - graceful handling of unknown states and missing fields
+ *   - name fallback chain and token-segment omission
+ *   - `columns` truncation of the name
+ *   - the JSON-lines output contract (one line per addressable task)
+ *   - the command wiring: reads stdin, never crashes CC on bad input
+ *
+ * Rendering assertions strip ANSI for text and separately assert glyph/colour
+ * presence, so they don't couple to exact escape sequences.
+ */
+import { describe, it, expect } from 'vitest';
+import { Readable } from 'node:stream';
+import {
+  renderSubagentContent,
+  renderSubagentTasks,
+  runSubagentCommand,
+} from '../../src/commands/subagent.js';
+import { NERD_ICONS, EMOJI_ICONS, NO_ICONS } from '../../src/render/icons.js';
+import { createColors, stripAnsi } from '../../src/render/colors.js';
+import type { SubagentTask, SubagentInput, HudConfig } from '../../src/types.js';
+
+const colors = createColors('named');
+
+function task(over: Partial<SubagentTask> = {}): SubagentTask {
+  return { id: 'a1', name: 'code-reviewer', status: 'running', tokenCount: 15000, ...over };
+}
+
+describe('renderSubagentContent', () => {
+  it('renders a running task: clock glyph, name, dim tokens, running label', () => {
+    const out = renderSubagentContent(task(), NERD_ICONS, colors);
+    const plain = stripAnsi(out);
+    expect(plain).toContain('code-reviewer');
+    expect(plain).toContain('15k tok');
+    expect(plain).toContain('running');
+    expect(out).toContain(NERD_ICONS.clock); // state glyph present
+  });
+
+  it('renders a completed task with checkmark + done label', () => {
+    const out = renderSubagentContent(task({ status: 'completed' }), NERD_ICONS, colors);
+    const plain = stripAnsi(out);
+    expect(plain).toContain('done');
+    expect(out).toContain(NERD_ICONS.checkmark);
+  });
+
+  it('renders an error task with warning glyph + error label', () => {
+    const out = renderSubagentContent(task({ status: 'error' }), NERD_ICONS, colors);
+    const plain = stripAnsi(out);
+    expect(plain).toContain('error');
+    expect(out).toContain(NERD_ICONS.warning);
+  });
+
+  it('passes an unknown status through as plain text with no glyph', () => {
+    const out = renderSubagentContent(task({ status: 'queued' }), NERD_ICONS, colors);
+    const plain = stripAnsi(out);
+    expect(plain).toContain('queued');
+    // none of the state glyphs should appear
+    expect(out).not.toContain(NERD_ICONS.clock);
+    expect(out).not.toContain(NERD_ICONS.checkmark);
+    expect(out).not.toContain(NERD_ICONS.warning);
+  });
+
+  it('omits the token segment when tokenCount is missing', () => {
+    const out = renderSubagentContent(task({ tokenCount: undefined }), NERD_ICONS, colors);
+    expect(stripAnsi(out)).not.toContain('tok');
+  });
+
+  it('falls back to type then id when name is absent', () => {
+    expect(stripAnsi(renderSubagentContent(task({ name: undefined, type: 'investigation' }), NERD_ICONS, colors)))
+      .toContain('investigation');
+    expect(stripAnsi(renderSubagentContent(task({ name: undefined, type: undefined, id: 'xyz' }), NERD_ICONS, colors)))
+      .toContain('xyz');
+  });
+
+  it('truncates the name to fit the columns budget', () => {
+    const longName = 'a-really-long-subagent-name-that-overflows-the-row';
+    const out = renderSubagentContent(task({ name: longName }), NO_ICONS, colors, 24);
+    const plain = stripAnsi(out);
+    expect(plain.length).toBeLessThanOrEqual(24);
+    expect(plain).toContain('…'); // ellipsis
+  });
+
+  it('emits no leading glyph in none-icons mode for running (clock is empty)', () => {
+    const out = renderSubagentContent(task(), NO_ICONS, colors);
+    const plain = stripAnsi(out);
+    expect(plain.startsWith('code-reviewer')).toBe(true);
+  });
+
+  it('supports emoji icon set', () => {
+    const out = renderSubagentContent(task({ status: 'completed' }), EMOJI_ICONS, colors);
+    expect(out).toContain(EMOJI_ICONS.checkmark);
+  });
+});
+
+describe('renderSubagentTasks', () => {
+  it('emits one JSON line per task with id + content', () => {
+    const input: SubagentInput = {
+      columns: 120,
+      tasks: [task({ id: 'a1' }), task({ id: 'b2', status: 'completed' })],
+    };
+    const out = renderSubagentTasks(input, NO_ICONS, colors);
+    const lines = out.split('\n');
+    expect(lines).toHaveLength(2);
+    const first = JSON.parse(lines[0]);
+    expect(first.id).toBe('a1');
+    expect(typeof first.content).toBe('string');
+    expect(JSON.parse(lines[1]).id).toBe('b2');
+  });
+
+  it('skips tasks without an id (an unaddressable row)', () => {
+    const input = { tasks: [task({ id: '' }), task({ id: 'ok' })] } as SubagentInput;
+    const out = renderSubagentTasks(input, NO_ICONS, colors);
+    expect(out.split('\n')).toHaveLength(1);
+    expect(JSON.parse(out).id).toBe('ok');
+  });
+
+  it('returns an empty string for an empty or missing task list', () => {
+    expect(renderSubagentTasks({ tasks: [] }, NO_ICONS, colors)).toBe('');
+    expect(renderSubagentTasks({} as SubagentInput, NO_ICONS, colors)).toBe('');
+  });
+});
+
+describe('runSubagentCommand', () => {
+  const cfg: HudConfig = { icons: 'none', colors: { mode: 'named' } } as HudConfig;
+
+  function streamOf(json: string): Readable {
+    return Readable.from([json]);
+  }
+
+  it('reads stdin and prints one JSON line per task, exit 0', async () => {
+    const payload = JSON.stringify({ columns: 100, tasks: [task({ id: 'z9' })] });
+    const r = await runSubagentCommand(['node', 'lumira', 'subagent'], {
+      stream: streamOf(payload),
+      config: cfg,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).toBe('');
+    const line = r.stdout.trim();
+    expect(JSON.parse(line).id).toBe('z9');
+  });
+
+  it('never crashes CC on malformed stdin — empty stdout, exit 0', async () => {
+    const r = await runSubagentCommand(['node', 'lumira', 'subagent'], {
+      stream: streamOf('not json at all'),
+      config: cfg,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe('');
+  });
+
+  it('emits nothing when there are no tasks', async () => {
+    const r = await runSubagentCommand(['node', 'lumira', 'subagent'], {
+      stream: streamOf(JSON.stringify({ columns: 80, tasks: [] })),
+      config: cfg,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe('');
+  });
+});

--- a/tests/commands/subagent.test.ts
+++ b/tests/commands/subagent.test.ts
@@ -70,11 +70,28 @@ describe('renderSubagentContent', () => {
     expect(stripAnsi(out)).not.toContain('tok');
   });
 
-  it('falls back to type then id when name is absent', () => {
+  it('falls back through type then id when name is absent', () => {
     expect(stripAnsi(renderSubagentContent(task({ name: undefined, type: 'investigation' }), NERD_ICONS, colors)))
       .toContain('investigation');
-    expect(stripAnsi(renderSubagentContent(task({ name: undefined, type: undefined, id: 'xyz' }), NERD_ICONS, colors)))
+    expect(stripAnsi(renderSubagentContent(task({ name: undefined, type: undefined, description: undefined, id: 'xyz' }), NERD_ICONS, colors)))
       .toContain('xyz');
+  });
+
+  it('uses description instead of the generic "local_agent" type', () => {
+    // CC reports every Task subagent as type "local_agent"; the description is
+    // the only field that identifies the row, so it must win over that type.
+    const out = stripAnsi(renderSubagentContent(
+      task({ name: undefined, type: 'local_agent', description: 'reviewing auth module' }), NERD_ICONS, colors));
+    expect(out).toContain('reviewing auth module');
+    expect(out).not.toContain('local_agent');
+  });
+
+  it('prefers a meaningful type (real agent_type) over description', () => {
+    // If CC ever exposes the real agent type, it identifies the agent better
+    // than the per-invocation description, so it wins.
+    const out = stripAnsi(renderSubagentContent(
+      task({ name: undefined, type: 'code-reviewer', description: 'reviewing auth module' }), NERD_ICONS, colors));
+    expect(out).toContain('code-reviewer');
   });
 
   it('truncates the name to fit the columns budget', () => {

--- a/tests/commands/subagent.test.ts
+++ b/tests/commands/subagent.test.ts
@@ -22,6 +22,7 @@ import {
 } from '../../src/commands/subagent.js';
 import { NERD_ICONS, EMOJI_ICONS, NO_ICONS } from '../../src/render/icons.js';
 import { createColors, stripAnsi } from '../../src/render/colors.js';
+import { displayWidth } from '../../src/render/text.js';
 import type { SubagentTask, SubagentInput, HudConfig } from '../../src/types.js';
 
 const colors = createColors('named');
@@ -80,8 +81,13 @@ describe('renderSubagentContent', () => {
     const longName = 'a-really-long-subagent-name-that-overflows-the-row';
     const out = renderSubagentContent(task({ name: longName }), NO_ICONS, colors, 24);
     const plain = stripAnsi(out);
-    expect(plain.length).toBeLessThanOrEqual(24);
+    expect(displayWidth(plain)).toBeLessThanOrEqual(24);
     expect(plain).toContain('…'); // ellipsis
+  });
+
+  it('renders tokenCount of 0 as "0 tok" (a just-started agent), not blank', () => {
+    const out = renderSubagentContent(task({ tokenCount: 0 }), NO_ICONS, colors);
+    expect(stripAnsi(out)).toContain('0 tok');
   });
 
   it('emits no leading glyph in none-icons mode for running (clock is empty)', () => {
@@ -133,7 +139,7 @@ describe('runSubagentCommand', () => {
 
   it('reads stdin and prints one JSON line per task, exit 0', async () => {
     const payload = JSON.stringify({ columns: 100, tasks: [task({ id: 'z9' })] });
-    const r = await runSubagentCommand(['node', 'lumira', 'subagent'], {
+    const r = await runSubagentCommand({
       stream: streamOf(payload),
       config: cfg,
     });
@@ -144,7 +150,7 @@ describe('runSubagentCommand', () => {
   });
 
   it('never crashes CC on malformed stdin — empty stdout, exit 0', async () => {
-    const r = await runSubagentCommand(['node', 'lumira', 'subagent'], {
+    const r = await runSubagentCommand({
       stream: streamOf('not json at all'),
       config: cfg,
     });
@@ -153,7 +159,7 @@ describe('runSubagentCommand', () => {
   });
 
   it('emits nothing when there are no tasks', async () => {
-    const r = await runSubagentCommand(['node', 'lumira', 'subagent'], {
+    const r = await runSubagentCommand({
       stream: streamOf(JSON.stringify({ columns: 80, tasks: [] })),
       config: cfg,
     });

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -221,6 +221,46 @@ describe('install', () => {
       expect(output).toContain('evil');
     });
   });
+
+  // ── subagentStatusLine registration (issue #176) ─────────────────
+  // Driven via the already-optimal path (statusLine = bare `lumira`) so no
+  // command rewrite happens and the only confirm() call is the subagent prompt.
+  describe('subagentStatusLine registration', () => {
+    const optimalSettings = () =>
+      writeFileSync(settingsPath, JSON.stringify({ statusLine: { type: 'command', command: 'lumira', padding: 0 } }));
+    const readSettings = () => JSON.parse(readFileSync(settingsPath, 'utf8'));
+
+    it('registers `<cmd> subagent` when the user opts in (TTY)', async () => {
+      optimalSettings();
+      const stdin = createMockStdin(true);
+      const promise = install({
+        ...baseOpts(), stdin, stdout: createMockStdout(),
+        hasGlobalBin: () => true, confirm: async () => true,
+      });
+      await completeWizard(stdin);
+      await promise;
+      const s = readSettings();
+      expect(s.subagentStatusLine.command).toBe('lumira subagent');
+      expect(s.statusLine.command).toBe('lumira'); // main statusLine untouched
+    });
+
+    it('does not register when the user declines', async () => {
+      optimalSettings();
+      const stdin = createMockStdin(true);
+      const promise = install({
+        ...baseOpts(), stdin, stdout: createMockStdout(),
+        hasGlobalBin: () => true, confirm: async () => false,
+      });
+      await completeWizard(stdin);
+      await promise;
+      expect(readSettings().subagentStatusLine).toBeUndefined();
+    });
+
+    it('never prompts or registers in a non-TTY install', async () => {
+      await install(baseOpts());
+      expect(readSettings().subagentStatusLine).toBeUndefined();
+    });
+  });
 });
 
 describe('uninstall', () => {
@@ -247,12 +287,17 @@ describe('uninstall', () => {
     expect(output).toContain('Restored');
   });
 
-  it('removes statusLine key when no backup exists', () => {
-    const current = { statusLine: { type: 'command', command: 'npx lumira@latest', padding: 0 }, hooks: {} };
+  it('removes both statusLine and subagentStatusLine when no backup exists', () => {
+    const current = {
+      statusLine: { type: 'command', command: 'npx lumira@latest', padding: 0 },
+      subagentStatusLine: { type: 'command', command: 'lumira subagent', padding: 0 },
+      hooks: {},
+    };
     writeFileSync(settingsPath, JSON.stringify(current, null, 2));
     const output = uninstall({ settingsPath });
     const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
     expect(data.statusLine).toBeUndefined();
+    expect(data.subagentStatusLine).toBeUndefined();
     expect(data.hooks).toEqual({});
     expect(output).toContain('Removed');
   });

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -302,7 +302,7 @@ describe('uninstall', () => {
     expect(output).toContain('Restored');
   });
 
-  it('removes both statusLine and subagentStatusLine when no backup exists', () => {
+  it('removes both lumira-owned keys (statusLine + subagentStatusLine) when no backup exists', () => {
     const current = {
       statusLine: { type: 'command', command: 'npx lumira@latest', padding: 0 },
       subagentStatusLine: { type: 'command', command: 'lumira subagent', padding: 0 },

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -260,6 +260,21 @@ describe('install', () => {
       await install(baseOpts());
       expect(readSettings().subagentStatusLine).toBeUndefined();
     });
+
+    it('leaves a foreign subagentStatusLine untouched (never clobbers)', async () => {
+      writeFileSync(settingsPath, JSON.stringify({
+        statusLine: { type: 'command', command: 'lumira', padding: 0 },
+        subagentStatusLine: { type: 'command', command: 'my-own-renderer', padding: 0 },
+      }));
+      const stdin = createMockStdin(true);
+      const promise = install({
+        ...baseOpts(), stdin, stdout: createMockStdout(),
+        hasGlobalBin: () => true, confirm: async () => true,
+      });
+      await completeWizard(stdin);
+      await promise;
+      expect(readSettings().subagentStatusLine.command).toBe('my-own-renderer');
+    });
   });
 });
 
@@ -300,6 +315,18 @@ describe('uninstall', () => {
     expect(data.subagentStatusLine).toBeUndefined();
     expect(data.hooks).toEqual({});
     expect(output).toContain('Removed');
+  });
+
+  it('preserves a foreign subagentStatusLine on uninstall', () => {
+    const current = {
+      statusLine: { type: 'command', command: 'lumira', padding: 0 },
+      subagentStatusLine: { type: 'command', command: 'my-own-renderer', padding: 0 },
+    };
+    writeFileSync(settingsPath, JSON.stringify(current, null, 2));
+    uninstall({ settingsPath });
+    const data = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    expect(data.statusLine).toBeUndefined();
+    expect(data.subagentStatusLine.command).toBe('my-own-renderer');
   });
 
   it('prints message when no settings file exists', () => {


### PR DESCRIPTION
## What

Implements the `subagentStatusLine` renderer (#176). Claude Code ≥2.1.x lets a command customize each subagent row in the agent panel; `lumira subagent` reads the tasks JSON from stdin and emits one `{id, content}` line per row, styled with the user's theme + icon set.

```
󱎫 code-reviewer · 15k tok · running
✓ investigation-agent · 3k tok · done
 flaky-finder · 800 tok · error
```

## Key decisions

- **Icon by STATE, not agent type.** CC's `type` is open-ended and user-defined (dozens in a real setup), so there's no stable type→glyph map worth maintaining. State (running/done/error) is the at-a-glance signal — and maps cleanly onto glyphs lumira already ships in all three icon sets. State also drives the colour.
- **Never breaks the panel.** Any unreadable/malformed payload → empty stdout, exit 0, so CC falls back to its default rows. `LUMIRA_DEBUG=1` logs the raw payload to stderr.
- **Reuses `readStdin`** — its only schema assertion is "is a plain object", which the `{columns, tasks}` payload satisfies.
- **Installer opt-in.** `install` offers to register `subagentStatusLine` alongside the main statusLine (interactive + consented only; covers the already-optimal re-install path). `uninstall` removes both. Extracted the duplicated atomic write into `writeSettingsAtomic`.

## Scope

Feature + tests + docs + `dist/`. Version bump and CHANGELOG are intentionally left for the separate release commit, per repo convention.

## Tests

- `tests/commands/subagent.test.ts` — per-state rendering, unknown-status passthrough, token omission, name fallback, columns truncation, JSON-lines contract, malformed-input graceful degradation.
- `tests/installer.test.ts` — opt-in registers `lumira subagent`, decline is a no-op, non-TTY never prompts, uninstall removes both keys.

1318 tests green · lint clean · manual smoke test against the built CLI confirmed.