### PR TITLE
chore(release): v1.14.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Real-time statusline HUD for Claude Code and Qwen Code — analytics, quota projection, themes, powerline",
-    "version": "1.13.0"
+    "version": "1.14.0"
   },
   "plugins": [
     {
       "name": "lumira",
       "source": "./",
       "description": "Real-time statusline HUD for Claude Code and Qwen Code. Session analytics, API latency widget, 7-day quota projection, auto-compact warnings, 7 themes, powerline support. Zero runtime dependencies. Run /lumira:setup after install to activate.",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "author": {
         "name": "Carlos Cativo"
       },
@@ -32,5 +32,5 @@
       ]
     }
   ],
-  "version": "1.13.0"
+  "version": "1.14.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Real-time statusline HUD for Claude Code and Qwen Code — session analytics, API latency, 7-day quota projection, auto-compact warnings, 7 themes, powerline. Zero runtime deps.",
   "author": {
     "name": "Carlos Cativo"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-06-29
+
+### Added
+
+- **Subagent status-line renderer (`lumira subagent`).** Implements Claude Code's `subagentStatusLine` hook (CC ≥ 2.1.x): reads the visible subagents from stdin and emits one styled row each — a state glyph (running/done/error), the agent identifier, and its token count — honoring the user's theme, `icons`, and `colors.mode`, truncated to the width CC budgets. Rows are identified by `description`: CC reports every Task subagent as the generic `type: "local_agent"` with no `name` (verified by capturing the real payload), so the description is the only distinguishing field. The fallback `name → meaningful type → description → id` still surfaces a real name/type when CC provides one. Degrades to empty output on any unreadable/malformed payload so a bad render never breaks the agent panel; `LUMIRA_DEBUG=1` logs the raw payload to stderr. (#182)
+- **Opt-in `subagentStatusLine` installer registration.** `lumira install` offers to register the hook alongside the main statusLine (interactive and consented only; it never overwrites a foreign `subagentStatusLine`). `uninstall` removes it only when it points at lumira. (#182)
+
 ## [1.13.0] - 2026-06-29
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lumira",
-  "version": "1.9.0",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lumira",
-      "version": "1.9.0",
+      "version": "1.14.0",
       "license": "MIT",
       "bin": {
         "lumira": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Real-time statusline HUD for Claude Code and Qwen Code. Includes session analytics CLI, API latency overhead widget, 7d quota projection, auto-compact proximity warnings, themes, and powerline. Zero deps.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release v1.14.0 — **subagentStatusLine renderer** (#182).

Bumps `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `package-lock.json` to 1.14.0 and adds the CHANGELOG entry. (Also corrects package-lock, which was stale at 1.9.0.)

Merging this + pushing tag `v1.14.0` triggers the auto-release (CI gate → GitHub Release → npm publish).