### PR TITLE
Group repo segment next to branch, before directory

### DIFF
--- a/dist/render/line1.js
+++ b/dist/render/line1.js
@@ -27,7 +27,19 @@ export function renderLine1(ctx, c) {
         }
         left.push(branchStr);
     }
-    // Directory
+    // Repo segment — owner/name from workspace.repo, clickable to open the repo
+    // on its host. Sits right after branch: both are git-identity (where you are
+    // in the DAG + which remote it tracks), so they stay grouped. Distinct from
+    // the directory breadcrumb below (a local path): this is the canonical remote
+    // identity, and surfaces the owner that the bare cwd basename can't.
+    if (display.repo && input.repo) {
+        const { owner, name, url } = input.repo;
+        const repoLen = cols < 80 ? 14 : cols < 120 ? 24 : 36;
+        const label = c.brightBlue(`${icons.repo} ${truncField(`${owner}/${name}`, repoLen)}`);
+        left.push(hyperlink(url, label));
+    }
+    // Directory — local filesystem context (where on disk), orthogonal to the
+    // git identity above. Rendered after repo so the two git segments group.
     if (display.directory) {
         const cwd = input.cwd;
         if (cwd) {
@@ -39,16 +51,6 @@ export function renderLine1(ctx, c) {
             // spaces and non-ASCII chars correctly.
             left.push(hyperlink(pathToFileURL(cwd).href, label));
         }
-    }
-    // Repo segment — owner/name from workspace.repo, clickable to open the repo
-    // on its host. Distinct from the directory breadcrumb above (a local path):
-    // this is the canonical remote identity, and surfaces the owner that the
-    // bare cwd basename can't.
-    if (display.repo && input.repo) {
-        const { owner, name, url } = input.repo;
-        const repoLen = cols < 80 ? 14 : cols < 120 ? 24 : 36;
-        const label = c.brightBlue(`${icons.repo} ${truncField(`${owner}/${name}`, repoLen)}`);
-        left.push(hyperlink(url, label));
     }
     // Added dirs badge — only when count > 0; warning color at >= 5
     if (display.addedDirs && input.addedDirsCount != null && input.addedDirsCount > 0) {

--- a/dist/render/powerline-line1.js
+++ b/dist/render/powerline-line1.js
@@ -69,6 +69,20 @@ function buildSegments(ctx, palette, c) {
             priority: 80,
         });
     }
+    if (display.repo && input.repo) {
+        const { owner, name, url } = input.repo;
+        // Priority 61 — above directory@60. Repo is git identity (owner/name of the
+        // remote), grouped with branch, so it survives narrow-terminal pressure a
+        // step longer than the local directory. Rendered before directory to keep
+        // the git-identity segments adjacent. Same dir-family background.
+        segments.push({
+            text: hyperlink(url, truncField(`${owner}/${name}`, 36)),
+            icon: icons.repo,
+            bg: palette.dirBg,
+            fg: palette.fg,
+            priority: 61,
+        });
+    }
     if (display.directory && input.cwd) {
         const dirName = basename(input.cwd) || input.cwd;
         segments.push({
@@ -77,19 +91,6 @@ function buildSegments(ctx, palette, c) {
             bg: palette.dirBg,
             fg: palette.fg,
             priority: 60,
-        });
-    }
-    if (display.repo && input.repo) {
-        const { owner, name, url } = input.repo;
-        // Priority 58 — below directory@60 and the addedDirs badge@59. Repo is the
-        // canonical remote identity (annotates the local dir), so it cedes first
-        // under narrow-terminal pressure. Same dir-family background as directory.
-        segments.push({
-            text: hyperlink(url, truncField(`${owner}/${name}`, 36)),
-            icon: icons.repo,
-            bg: palette.dirBg,
-            fg: palette.fg,
-            priority: 58,
         });
     }
     if (display.addedDirs && input.addedDirsCount != null && input.addedDirsCount > 0) {

--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -32,7 +32,20 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
     left.push(branchStr);
   }
 
-  // Directory
+  // Repo segment — owner/name from workspace.repo, clickable to open the repo
+  // on its host. Sits right after branch: both are git-identity (where you are
+  // in the DAG + which remote it tracks), so they stay grouped. Distinct from
+  // the directory breadcrumb below (a local path): this is the canonical remote
+  // identity, and surfaces the owner that the bare cwd basename can't.
+  if (display.repo && input.repo) {
+    const { owner, name, url } = input.repo;
+    const repoLen = cols < 80 ? 14 : cols < 120 ? 24 : 36;
+    const label = c.brightBlue(`${icons.repo} ${truncField(`${owner}/${name}`, repoLen)}`);
+    left.push(hyperlink(url, label));
+  }
+
+  // Directory — local filesystem context (where on disk), orthogonal to the
+  // git identity above. Rendered after repo so the two git segments group.
   if (display.directory) {
     const cwd = input.cwd;
     if (cwd) {
@@ -44,17 +57,6 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
       // spaces and non-ASCII chars correctly.
       left.push(hyperlink(pathToFileURL(cwd).href, label));
     }
-  }
-
-  // Repo segment — owner/name from workspace.repo, clickable to open the repo
-  // on its host. Distinct from the directory breadcrumb above (a local path):
-  // this is the canonical remote identity, and surfaces the owner that the
-  // bare cwd basename can't.
-  if (display.repo && input.repo) {
-    const { owner, name, url } = input.repo;
-    const repoLen = cols < 80 ? 14 : cols < 120 ? 24 : 36;
-    const label = c.brightBlue(`${icons.repo} ${truncField(`${owner}/${name}`, repoLen)}`);
-    left.push(hyperlink(url, label));
   }
 
   // Added dirs badge — only when count > 0; warning color at >= 5

--- a/src/render/powerline-line1.ts
+++ b/src/render/powerline-line1.ts
@@ -80,6 +80,21 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: import(
     });
   }
 
+  if (display.repo && input.repo) {
+    const { owner, name, url } = input.repo;
+    // Priority 61 — above directory@60. Repo is git identity (owner/name of the
+    // remote), grouped with branch, so it survives narrow-terminal pressure a
+    // step longer than the local directory. Rendered before directory to keep
+    // the git-identity segments adjacent. Same dir-family background.
+    segments.push({
+      text: hyperlink(url, truncField(`${owner}/${name}`, 36)),
+      icon: icons.repo,
+      bg: palette.dirBg,
+      fg: palette.fg,
+      priority: 61,
+    });
+  }
+
   if (display.directory && input.cwd) {
     const dirName = basename(input.cwd) || input.cwd;
     segments.push({
@@ -88,20 +103,6 @@ function buildSegments(ctx: RenderContext, palette: PowerlinePalette, c: import(
       bg: palette.dirBg,
       fg: palette.fg,
       priority: 60,
-    });
-  }
-
-  if (display.repo && input.repo) {
-    const { owner, name, url } = input.repo;
-    // Priority 58 — below directory@60 and the addedDirs badge@59. Repo is the
-    // canonical remote identity (annotates the local dir), so it cedes first
-    // under narrow-terminal pressure. Same dir-family background as directory.
-    segments.push({
-      text: hyperlink(url, truncField(`${owner}/${name}`, 36)),
-      icon: icons.repo,
-      bg: palette.dirBg,
-      fg: palette.fg,
-      priority: 58,
     });
   }
 

--- a/tests/render/line1.test.ts
+++ b/tests/render/line1.test.ts
@@ -66,6 +66,17 @@ describe('renderLine1', () => {
     expect(out).toContain('https://github.com/cativo23/lumira');
   });
 
+  it('renders repo immediately after branch, before directory', () => {
+    const inputOverride = { workspace: { current_dir: '/home/user/checkout', repo: { host: 'github.com', owner: 'cativo23', name: 'lumira' } } };
+    const out = stripAnsi(renderLine1(makeCtx({ git }, inputOverride), c));
+    const branchAt = out.indexOf('main');
+    const repoAt = out.indexOf('cativo23/lumira');
+    const dirAt = out.indexOf('checkout');
+    expect(branchAt).toBeGreaterThanOrEqual(0);
+    expect(repoAt).toBeGreaterThan(branchAt);
+    expect(dirAt).toBeGreaterThan(repoAt);
+  });
+
   it('hides the repo segment when display.repo is off', () => {
     const inputOverride = { workspace: { current_dir: '/x/project', repo: { host: 'github.com', owner: 'cativo23', name: 'lumira' } } };
     const out = stripAnsi(renderLine1(makeCtx({ config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, repo: false } } }, inputOverride), c));


### PR DESCRIPTION
## Qué

Reordena la línea 1 del statusline: `branch → repo → directory` (antes `branch → directory → repo`).

## Por qué

`branch` y `repo` son ambos **identidad git** (posición en el DAG + qué remote trackea el proyecto). `directory` es contexto de **filesystem local** (dónde estás en disco), ortogonal. Tener el directory en el medio separaba visualmente los dos segmentos git.

No son redundantes ni fusionables: el nombre del repo (`owner/name` del remote) diverge de la carpeta en casos reales — worktrees, clone renombrado, subdir de monorepo, forks. Cada uno aporta info distinta.

## Cambios

- `src/render/line1.ts` — bloque `repo` movido antes de `directory` (modo classic).
- `src/render/powerline-line1.ts` — idem, y `repo` sube a priority `61` (arriba de `directory@60`): bajo terminal angosto la identidad git (branch+repo) sobrevive un paso más que el path local.
- `tests/render/line1.test.ts` — nuevo test que fija el orden `branch → repo → directory`.

## Verificación

- `npx vitest run` → 1324/1324 ✓ (incluye el test de orden nuevo)
- `npm run build` → limpio
- Render real confirmado: `Claude Opus 4 │ <branch> │ cativo23/lumira │ lumira`