### PR TITLE
Line 1 packed layout, full-width cols, box-drawing width fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Layout-cols headroom factor raised from 0.9 to 1.0 when stdout is non-TTY.** The statusline now uses the full detected terminal width. The previous 10% reservation assumed Claude Code appends chrome (separators, gutters) to the statusline's own row; inspecting a real render disproved that — CC's own hints ("bypass permissions …", "PR #…", "← for agents") render on a separate line below the statusline, never on its row. So the reserved 10% never held anything, showing up only as empty space at the far-right edge. Dropping it is safe because every renderer that treats `cols` as a width budget already subtracts a proven 4-column margin internally (`fitSegments` for line1/line2, `renderPowerline` for the powerline lines); that `-4` bug-fix margin is untouched.
+
 ## [1.14.0] - 2026-06-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ Create `~/.config/lumira/config.json`:
   "theme": "tokyo-night",
   "icons": "nerd",
   "style": "classic",
+  "line1Align": "justified",
   "powerline": { "style": "auto" },
   "gsd": false,
   "colors": { "mode": "auto" },
@@ -364,7 +365,7 @@ Create `~/.config/lumira/config.json`:
 }
 ```
 
-All fields are optional — defaults are shown above. `display.health` defaults to `false` (opt-in widget).
+All fields are optional — defaults are shown above. `display.health` defaults to `false` (opt-in widget). `line1Align` controls line 1's classic layout: `"justified"` (default) pins the left cluster to the start and the right cluster to the end; `"packed"` packs every segment tightly to the left with no forced middle gap, except the app version string, which stays pinned to the true right edge (the same idiom line 2 uses for its small right-anchored indicators). On a terminal too narrow to fit the version alongside the packed content, the version disappears entirely rather than truncating — an intentional all-or-nothing tradeoff. Powerline mode always packs.
 
 **Context bar thresholds** — `contextWarningThreshold` (default 70) and `contextCriticalThreshold` (default 85) control when the bar transitions through yellow/orange/red. Both are clamped to `[0, 100]` and `warning < critical` is required (invalid pairs fall back to defaults with a one-shot stderr warning). Lower them for earlier warnings, raise them if your workflow tolerates fuller buffers.
 

--- a/dist/config.js
+++ b/dist/config.js
@@ -196,6 +196,7 @@ function mergeConfig(rawIn) {
         raw = { ...raw, preset: 'minimal' };
     }
     const layout = ['multiline', 'singleline', 'auto'].includes(raw.layout) ? raw.layout : DEFAULT_CONFIG.layout;
+    const line1Align = ['justified', 'packed'].includes(raw.line1Align) ? raw.line1Align : DEFAULT_CONFIG.line1Align;
     const colors = { ...DEFAULT_CONFIG.colors };
     if (raw.colors && typeof raw.colors === 'object') {
         const m = raw.colors.mode;
@@ -204,6 +205,7 @@ function mergeConfig(rawIn) {
     }
     const result = {
         layout,
+        line1Align,
         gsd: typeof raw.gsd === 'boolean' ? raw.gsd : DEFAULT_CONFIG.gsd,
         display: { ...DEFAULT_DISPLAY },
         colors,

--- a/dist/render/line1.js
+++ b/dist/render/line1.js
@@ -6,7 +6,7 @@ import { hyperlink } from './hyperlink.js';
 import { formatDuration } from '../utils/format.js';
 import { isNamedAgentType } from '../parsers/subagents.js';
 export function renderLine1(ctx, c) {
-    const { input, git, transcript, config: { display }, cols, icons, memory, tokenSpeed } = ctx;
+    const { input, git, transcript, config: { display, line1Align }, cols, icons, memory, tokenSpeed } = ctx;
     const left = [];
     const right = [];
     // Model
@@ -120,8 +120,11 @@ export function renderLine1(ctx, c) {
         right.push(c.gray(input.outputStyle));
     }
     // Version — link to the Claude Code npm page for quick changelog lookup.
+    // Kept as its own segment (not pushed straight into `right`) because packed
+    // mode pins it alone to the true right edge while everything else packs left.
+    let versionSeg = null;
     if (display.version && input.version) {
-        right.push(hyperlink(`https://www.npmjs.com/package/@anthropic-ai/claude-code/v/${encodeURIComponent(input.version)}`, c.dim(`v${input.version}`)));
+        versionSeg = hyperlink(`https://www.npmjs.com/package/@anthropic-ai/claude-code/v/${encodeURIComponent(input.version)}`, c.dim(`v${input.version}`));
     }
     // Custom commands (issue #143 phase 3) — appended last on the left so they
     // sit after core widgets and evict first under fitSegments' narrow-cols
@@ -131,8 +134,18 @@ export function renderLine1(ctx, c) {
         if (seg)
             left.push(seg);
     }
-    if (left.length === 0 && right.length === 0)
+    if (left.length === 0 && right.length === 0 && !versionSeg)
         return '';
-    return fitSegments(left, right, SEP, cols);
+    // packed: pack every non-version segment tightly to the left with a single
+    // separator (no forced middle gap), leaving ONLY the version string pinned to
+    // the true right edge — the same idiom line2 uses for its small right-anchored
+    // cluster. fitSegments already leaves a gap before a short right array, and
+    // drops it whole when it can't fit (version vanishes rather than truncating on
+    // a narrow terminal — an accepted all-or-nothing tradeoff, see README).
+    if (line1Align === 'packed') {
+        return fitSegments(left.concat(right), versionSeg ? [versionSeg] : [], SEP, cols);
+    }
+    // justified: version rejoins the tail of the right cluster, pinned to the edge.
+    return fitSegments(left, versionSeg ? [...right, versionSeg] : right, SEP, cols);
 }
 //# sourceMappingURL=line1.js.map

--- a/dist/render/text.js
+++ b/dist/render/text.js
@@ -15,7 +15,11 @@ export function displayWidth(str) {
             w += 1;
             continue;
         }
-        if (cp >= 0x1F000 || (cp >= 0x2300 && cp <= 0x257F) || (cp >= 0x25A0 && cp <= 0x25FF) ||
+        // 0x2300–0x24FF covers wide Misc-Technical / Enclosed-Alphanumeric symbols
+        // but STOPS before the Box Drawing block (U+2500–U+257F), whose glyphs —
+        // including │ (U+2502), lumira's default SEP separator — are single-cell.
+        // Counting them as 2 over-reserved width on every separated line.
+        if (cp >= 0x1F000 || (cp >= 0x2300 && cp <= 0x24FF) || (cp >= 0x25A0 && cp <= 0x25FF) ||
             (cp >= 0x2600 && cp <= 0x27BF) || (cp >= 0x2B00 && cp <= 0x2BFF) ||
             (cp >= 0x4E00 && cp <= 0x9FFF) || (cp >= 0x3000 && cp <= 0x303F) || (cp >= 0xFF00 && cp <= 0xFFEF)) {
             w += 2;

--- a/dist/render/text.js
+++ b/dist/render/text.js
@@ -53,13 +53,21 @@ export function truncatePath(str, maxLen = 20) {
         return filename.slice(0, maxLen - 3) + '...';
     return '.../' + filename;
 }
+// The usable width for a status line: total cols minus a 4-cell right margin.
+// The margin absorbs terminals that reserve a trailing cell and prevents the
+// off-by-one wraps that motivated it. Kept as the single source of this
+// constant so callers computing leftover/fill width can't drift out of sync
+// with fitSegments' own bound.
+export function safeCols(cols) {
+    return Math.max(1, cols - 4);
+}
 export function fitSegments(left, right, sep, cols) {
-    const safeCols = Math.max(1, cols - 4);
+    const safe = safeCols(cols);
     for (let l = left.length; l >= 1; l--) {
         const lSlice = left.slice(0, l);
         const leftStr = lSlice.join(sep);
         const leftW = displayWidth(leftStr);
-        if (leftW > safeCols)
+        if (leftW > safe)
             continue;
         for (let r = right.length; r >= 0; r--) {
             const rSlice = right.slice(0, r);
@@ -67,8 +75,8 @@ export function fitSegments(left, right, sep, cols) {
                 return leftStr;
             const rightStr = rSlice.join(sep);
             const rightW = displayWidth(rightStr);
-            if (leftW + 1 + rightW <= safeCols) {
-                const gap = Math.max(1, safeCols - leftW - rightW);
+            if (leftW + 1 + rightW <= safe) {
+                const gap = Math.max(1, safe - leftW - rightW);
                 return leftStr + ' '.repeat(gap) + rightStr;
             }
         }
@@ -77,7 +85,7 @@ export function fitSegments(left, right, sep, cols) {
     // Safe because left[0] is the model name (~20 chars) — callers must ensure
     // the first segment is short enough to truncate gracefully.
     // Strip ANSI before hard-truncating to avoid cutting mid-escape-sequence.
-    return truncField(stripAnsi(left[0] ?? ''), safeCols);
+    return truncField(stripAnsi(left[0] ?? ''), safe);
 }
 export function padLine(left, right, cols) {
     const leftW = displayWidth(left);

--- a/dist/types.js
+++ b/dist/types.js
@@ -123,6 +123,7 @@ export const DEFAULT_DISPLAY = {
 };
 export const DEFAULT_CONFIG = {
     layout: 'auto',
+    line1Align: 'justified',
     // GSD on by default, mirroring GSD's own always-on statusline. Self-gates to
     // nothing when there's no .planning/STATE.md and no update-check cache, so
     // non-GSD users see no extra line and pay only a few cheap existsSync checks.

--- a/dist/utils/terminal.js
+++ b/dist/utils/terminal.js
@@ -46,12 +46,17 @@ export function getTermCols() {
     return 120;
 }
 // When stdout isn't a TTY (the statusline case — Claude Code pipes our output)
-// we still trust the resolved rawCols since proc-tree / COLUMNS / tput give the
-// real terminal width. The small 0.9 factor leaves 10% headroom for any chrome
-// the host renderer adds (separators, gutters) without aggressively starving
-// segments. Was 0.7 historically — too conservative for CC, where the
-// statusline uses the full terminal width.
-export function getLayoutCols(rawCols, isTTY, factor = 0.9) {
+// we trust the resolved rawCols since proc-tree / COLUMNS / tput give the real
+// terminal width, and use the full width (factor 1.0). Earlier versions reserved
+// headroom (0.7, then 0.9) on the theory that CC appends chrome (separators,
+// gutters) to the statusline's own row. Inspecting a real render showed that is
+// not the case: CC's own hints ("bypass permissions …", "PR #…", "← for agents")
+// render on a SEPARATE line below the statusline, never appended to its row — so
+// the reservation was speculative and only ever showed up as empty space at the
+// far-right edge. Every renderer that treats `cols` as a width budget already
+// protects itself: line1/line2 via fitSegments and the powerline lines via
+// renderPowerline both subtract a proven 4-column margin (see text.ts / powerline.ts).
+export function getLayoutCols(rawCols, isTTY, factor = 1.0) {
     if (isTTY)
         return rawCols;
     const clamped = Math.min(Math.max(factor, 0.3), 1.0);

--- a/src/config.ts
+++ b/src/config.ts
@@ -223,6 +223,7 @@ function mergeConfig(rawIn: Record<string, unknown>): HudConfig {
     raw = { ...raw, preset: 'minimal' };
   }
   const layout = (['multiline', 'singleline', 'auto'] as const).includes(raw.layout as never) ? raw.layout as HudConfig['layout'] : DEFAULT_CONFIG.layout;
+  const line1Align = (['justified', 'packed'] as const).includes(raw.line1Align as never) ? raw.line1Align as HudConfig['line1Align'] : DEFAULT_CONFIG.line1Align;
   const colors: ColorConfig = { ...DEFAULT_CONFIG.colors };
   if (raw.colors && typeof raw.colors === 'object') {
     const m = (raw.colors as Record<string, unknown>).mode;
@@ -230,6 +231,7 @@ function mergeConfig(rawIn: Record<string, unknown>): HudConfig {
   }
   const result: HudConfig = {
     layout,
+    line1Align,
     gsd: typeof raw.gsd === 'boolean' ? raw.gsd : DEFAULT_CONFIG.gsd,
     display: { ...DEFAULT_DISPLAY },
     colors,

--- a/src/render/line1.ts
+++ b/src/render/line1.ts
@@ -9,7 +9,7 @@ import type { Colors } from './colors.js';
 import type { RenderContext } from '../types.js';
 
 export function renderLine1(ctx: RenderContext, c: Colors): string {
-  const { input, git, transcript, config: { display }, cols, icons, memory, tokenSpeed } = ctx;
+  const { input, git, transcript, config: { display, line1Align }, cols, icons, memory, tokenSpeed } = ctx;
   const left: string[] = [];
   const right: string[] = [];
 
@@ -137,11 +137,14 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
   }
 
   // Version — link to the Claude Code npm page for quick changelog lookup.
+  // Kept as its own segment (not pushed straight into `right`) because packed
+  // mode pins it alone to the true right edge while everything else packs left.
+  let versionSeg: string | null = null;
   if (display.version && input.version) {
-    right.push(hyperlink(
+    versionSeg = hyperlink(
       `https://www.npmjs.com/package/@anthropic-ai/claude-code/v/${encodeURIComponent(input.version)}`,
       c.dim(`v${input.version}`),
-    ));
+    );
   }
 
   // Custom commands (issue #143 phase 3) — appended last on the left so they
@@ -152,6 +155,16 @@ export function renderLine1(ctx: RenderContext, c: Colors): string {
     if (seg) left.push(seg);
   }
 
-  if (left.length === 0 && right.length === 0) return '';
-  return fitSegments(left, right, SEP, cols);
+  if (left.length === 0 && right.length === 0 && !versionSeg) return '';
+  // packed: pack every non-version segment tightly to the left with a single
+  // separator (no forced middle gap), leaving ONLY the version string pinned to
+  // the true right edge — the same idiom line2 uses for its small right-anchored
+  // cluster. fitSegments already leaves a gap before a short right array, and
+  // drops it whole when it can't fit (version vanishes rather than truncating on
+  // a narrow terminal — an accepted all-or-nothing tradeoff, see README).
+  if (line1Align === 'packed') {
+    return fitSegments(left.concat(right), versionSeg ? [versionSeg] : [], SEP, cols);
+  }
+  // justified: version rejoins the tail of the right cluster, pinned to the edge.
+  return fitSegments(left, versionSeg ? [...right, versionSeg] : right, SEP, cols);
 }

--- a/src/render/text.ts
+++ b/src/render/text.ts
@@ -12,7 +12,11 @@ export function displayWidth(str: string): number {
     // below. Without this exclusion the catch-all `>= 0x1F000` would treat
     // them as 2 cells and break `fitSegments` layout calculations.
     if (cp >= 0xF0000 && cp <= 0xFFFFF) { w += 1; continue; }
-    if (cp >= 0x1F000 || (cp >= 0x2300 && cp <= 0x257F) || (cp >= 0x25A0 && cp <= 0x25FF) ||
+    // 0x2300–0x24FF covers wide Misc-Technical / Enclosed-Alphanumeric symbols
+    // but STOPS before the Box Drawing block (U+2500–U+257F), whose glyphs —
+    // including │ (U+2502), lumira's default SEP separator — are single-cell.
+    // Counting them as 2 over-reserved width on every separated line.
+    if (cp >= 0x1F000 || (cp >= 0x2300 && cp <= 0x24FF) || (cp >= 0x25A0 && cp <= 0x25FF) ||
         (cp >= 0x2600 && cp <= 0x27BF) || (cp >= 0x2B00 && cp <= 0x2BFF) ||
         (cp >= 0x4E00 && cp <= 0x9FFF) || (cp >= 0x3000 && cp <= 0x303F) || (cp >= 0xFF00 && cp <= 0xFFEF)) {
       w += 2;

--- a/src/render/text.ts
+++ b/src/render/text.ts
@@ -45,23 +45,32 @@ export function truncatePath(str: string, maxLen: number = 20): string {
   return '.../' + filename;
 }
 
+// The usable width for a status line: total cols minus a 4-cell right margin.
+// The margin absorbs terminals that reserve a trailing cell and prevents the
+// off-by-one wraps that motivated it. Kept as the single source of this
+// constant so callers computing leftover/fill width can't drift out of sync
+// with fitSegments' own bound.
+export function safeCols(cols: number): number {
+  return Math.max(1, cols - 4);
+}
+
 export function fitSegments(left: string[], right: string[], sep: string, cols: number): string {
-  const safeCols = Math.max(1, cols - 4);
+  const safe = safeCols(cols);
 
   for (let l = left.length; l >= 1; l--) {
     const lSlice = left.slice(0, l);
     const leftStr = lSlice.join(sep);
     const leftW = displayWidth(leftStr);
 
-    if (leftW > safeCols) continue;
+    if (leftW > safe) continue;
 
     for (let r = right.length; r >= 0; r--) {
       const rSlice = right.slice(0, r);
       if (rSlice.length === 0) return leftStr;
       const rightStr = rSlice.join(sep);
       const rightW = displayWidth(rightStr);
-      if (leftW + 1 + rightW <= safeCols) {
-        const gap = Math.max(1, safeCols - leftW - rightW);
+      if (leftW + 1 + rightW <= safe) {
+        const gap = Math.max(1, safe - leftW - rightW);
         return leftStr + ' '.repeat(gap) + rightStr;
       }
     }
@@ -71,7 +80,7 @@ export function fitSegments(left: string[], right: string[], sep: string, cols: 
   // Safe because left[0] is the model name (~20 chars) — callers must ensure
   // the first segment is short enough to truncate gracefully.
   // Strip ANSI before hard-truncating to avoid cutting mid-escape-sequence.
-  return truncField(stripAnsi(left[0] ?? ''), safeCols);
+  return truncField(stripAnsi(left[0] ?? ''), safe);
 }
 
 export function padLine(left: string, right: string, cols: number): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -220,6 +220,18 @@ export interface HudConfig {
   icons?: 'nerd' | 'emoji' | 'none';
   /** Visual style for line1 — 'classic' (pipe-separated) or 'powerline' (colored segments). */
   style?: 'classic' | 'powerline';
+  /**
+   * Line 1 layout mode (classic renderer only).
+   *   justified → left cluster pinned to the start, right cluster to the end,
+   *               with a flexible gap between (default; edge-to-edge look).
+   *   packed    → every segment packed tightly to the left with no forced
+   *               middle gap, EXCEPT the version string, which stays pinned to
+   *               the true right edge (mirrors line 2's small right cluster).
+   *               On a too-narrow terminal the version drops whole rather than
+   *               truncating — an accepted all-or-nothing tradeoff.
+   * Powerline mode always packs left-to-right, so this is a no-op there.
+   */
+  line1Align?: 'justified' | 'packed';
   powerline?: {
     /** Separator glyph preset. Defaults to 'auto' (nerd font → arrow, else compatible). */
     style?: PowerlineStyleName;
@@ -459,6 +471,7 @@ export const DEFAULT_DISPLAY: DisplayToggles = {
 
 export const DEFAULT_CONFIG: HudConfig = {
   layout: 'auto',
+  line1Align: 'justified',
   // GSD on by default, mirroring GSD's own always-on statusline. Self-gates to
   // nothing when there's no .planning/STATE.md and no update-check cache, so
   // non-GSD users see no extra line and pay only a few cheap existsSync checks.

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -41,12 +41,17 @@ export function getTermCols(): number {
 }
 
 // When stdout isn't a TTY (the statusline case — Claude Code pipes our output)
-// we still trust the resolved rawCols since proc-tree / COLUMNS / tput give the
-// real terminal width. The small 0.9 factor leaves 10% headroom for any chrome
-// the host renderer adds (separators, gutters) without aggressively starving
-// segments. Was 0.7 historically — too conservative for CC, where the
-// statusline uses the full terminal width.
-export function getLayoutCols(rawCols: number, isTTY: boolean, factor: number = 0.9): number {
+// we trust the resolved rawCols since proc-tree / COLUMNS / tput give the real
+// terminal width, and use the full width (factor 1.0). Earlier versions reserved
+// headroom (0.7, then 0.9) on the theory that CC appends chrome (separators,
+// gutters) to the statusline's own row. Inspecting a real render showed that is
+// not the case: CC's own hints ("bypass permissions …", "PR #…", "← for agents")
+// render on a SEPARATE line below the statusline, never appended to its row — so
+// the reservation was speculative and only ever showed up as empty space at the
+// far-right edge. Every renderer that treats `cols` as a width budget already
+// protects itself: line1/line2 via fitSegments and the powerline lines via
+// renderPowerline both subtract a proven 4-column margin (see text.ts / powerline.ts).
+export function getLayoutCols(rawCols: number, isTTY: boolean, factor: number = 1.0): number {
   if (isTTY) return rawCols;
   const clamped = Math.min(Math.max(factor, 0.3), 1.0);
   return Math.floor(rawCols * clamped);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -164,6 +164,26 @@ describe('loadConfig', () => {
       expect(loadConfig(dir).powerline?.style).toBe(s);
     }
   });
+  it('parses line1Align: "packed"', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"line1Align":"packed"}');
+    expect(loadConfig(dir).line1Align).toBe('packed');
+  });
+  it('parses line1Align: "justified"', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"line1Align":"justified"}');
+    expect(loadConfig(dir).line1Align).toBe('justified');
+  });
+  it('falls back to justified on an invalid line1Align value', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"line1Align":"bogus"}');
+    expect(loadConfig(dir).line1Align).toBe('justified');
+  });
+  it('defaults line1Align to justified when omitted', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{"style":"classic"}');
+    expect(loadConfig(dir).line1Align).toBe('justified');
+  });
 
   describe('context bar thresholds', () => {
     beforeEach(() => { _resetMigrationFlags(); });

--- a/tests/render/line1.test.ts
+++ b/tests/render/line1.test.ts
@@ -5,7 +5,7 @@ import { EMPTY_GIT, EMPTY_TRANSCRIPT, DEFAULT_CONFIG, DEFAULT_DISPLAY } from '..
 import type { ClaudeCodeInput, GitStatus, RenderContext } from '../../src/types.js';
 import { NERD_ICONS } from '../../src/render/icons.js';
 import { normalize } from '../../src/normalize.js';
-import { displayWidth } from '../../src/render/text.js';
+import { displayWidth, safeCols } from '../../src/render/text.js';
 import { applyPreset } from '../../src/config.js';
 
 const c = createColors('named');
@@ -231,6 +231,66 @@ describe('renderLine1', () => {
       ctx.config = { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, agent: false } };
       const out = stripAnsi(renderLine1(ctx, c));
       expect(out).not.toContain(cube);
+    });
+  });
+
+  // ── line1Align (packed vs justified) ─────────────────────────────
+  describe('line1Align', () => {
+    it('justified layout (default) pins right content to the edge with a wide middle gap', () => {
+      const out = stripAnsi(renderLine1(makeCtx({ git }), c));
+      // The forced middle gap shows up as a long run of spaces.
+      expect(out).toMatch(/ {5,}/);
+    });
+
+    it('packed layout packs non-version segments to the left and pins version to the right', () => {
+      const ctx = makeCtx({ git, config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY }, line1Align: 'packed' } });
+      const out = stripAnsi(renderLine1(ctx, c));
+      // Right-cluster content (duration) is packed into the left flow, before version.
+      expect(out).toContain('│');
+      expect(out).toContain('v2.0.0');
+      expect(out.indexOf('1m00s')).toBeGreaterThan(-1);
+      expect(out.indexOf('1m00s')).toBeLessThan(out.indexOf('v2.0.0'));
+    });
+
+    it('explicit line1Align "justified" is byte-identical to the default', () => {
+      const def = renderLine1(makeCtx({ git }), c);
+      const explicit = renderLine1(makeCtx({ git, config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY }, line1Align: 'justified' } }), c);
+      expect(explicit).toBe(def);
+    });
+
+    it('packed packs content left and pins version to the true right edge on a wide terminal', () => {
+      const ctx = makeCtx({ git, cols: 180, config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY }, line1Align: 'packed' } });
+      const out = stripAnsi(renderLine1(ctx, c));
+      // Left-flow content (duration) sits before the gap …
+      const durIdx = out.indexOf('1m00s');
+      const verIdx = out.indexOf('v2.0.0');
+      expect(durIdx).toBeGreaterThan(-1);
+      expect(verIdx).toBeGreaterThan(durIdx);
+      // … and version is anchored at the true right edge (safeCols = cols - 4).
+      expect(displayWidth(out)).toBe(safeCols(180));
+    });
+
+    it('packed with version disabled leaves nothing anchored to the right edge', () => {
+      const ctx = makeCtx({
+        cols: 180,
+        config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY, version: false }, line1Align: 'packed' },
+      });
+      const out = stripAnsi(renderLine1(ctx, c));
+      // No version → no artificial right anchor, so content stops short of the edge.
+      expect(out).not.toContain('v2.0.0');
+      expect(displayWidth(out)).toBeLessThan(safeCols(180));
+    });
+
+    it('packed drops version entirely when it cannot fit alongside packed left content', () => {
+      // Accepted, researched tradeoff: with only version in the right-pinned
+      // group, a too-narrow terminal makes it vanish whole rather than truncate
+      // (same all-or-nothing behavior ccstatusline/starship/p10k ship). Not a bug.
+      const ctx = makeCtx(
+        { git, cols: 40, config: { ...DEFAULT_CONFIG, display: { ...DEFAULT_DISPLAY }, line1Align: 'packed' } },
+        { model: 'M'.repeat(100) },
+      );
+      const out = stripAnsi(renderLine1(ctx, c));
+      expect(out).not.toContain('v2.0.0');
     });
   });
 

--- a/tests/render/text.test.ts
+++ b/tests/render/text.test.ts
@@ -8,6 +8,12 @@ describe('displayWidth', () => {
   it('counts CJK as 2', () => { expect(displayWidth('\u4E16')).toBe(2); });
   it('counts emoji as 2', () => { expect(displayWidth('\u{1F600}')).toBe(2); });
   it('counts block chars as 1', () => { expect(displayWidth('\u2588\u2591')).toBe(2); });
+  // Box Drawing block (U+2500\u2013U+257F) is always single-cell. The vertical bar
+  // U+2502 is lumira's default segment separator (SEP), so miscounting it as 2
+  // over-reserves width on every line and makes right-anchored content misalign
+  // between lines (each line has a different separator count).
+  it('counts box-drawing separator \u2502 (U+2502) as 1', () => { expect(displayWidth('\u2502')).toBe(1); });
+  it('counts box-drawing chars as 1', () => { expect(displayWidth('\u2500\u2502\u250c\u2510\u2514\u2518')).toBe(6); });
   // Nerd Font BMP-PUA (fa-robot U+F418) and Supplementary PUA-A
   // (nf-md-battery U+F0083) glyphs both render single-cell on patched fonts;
   // width must reflect that or fitSegments over-reserves space.

--- a/tests/render/text.test.ts
+++ b/tests/render/text.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { displayWidth, truncField, truncatePath, fitSegments, padLine } from '../../src/render/text.js';
+import { displayWidth, truncField, truncatePath, fitSegments, padLine, safeCols } from '../../src/render/text.js';
 
 describe('displayWidth', () => {
   it('measures plain ASCII', () => { expect(displayWidth('hello')).toBe(5); });
@@ -74,6 +74,16 @@ describe('fitSegments', () => {
     const left = 'A'.repeat(16); // safeCols = 20-4 = 16
     const result = fitSegments([left], [], ' | ', 20);
     expect(result).toBe(left);
+  });
+});
+
+describe('safeCols', () => {
+  it('reserves a 4-cell right margin', () => { expect(safeCols(120)).toBe(116); });
+  it('never returns below 1', () => { expect(safeCols(2)).toBe(1); });
+  it('matches the width fitSegments fits into', () => {
+    // fitSegments must not exceed safeCols(cols) for the same cols.
+    const result = fitSegments(['X'.repeat(200)], [], ' | ', 50);
+    expect(displayWidth(result)).toBeLessThanOrEqual(safeCols(50));
   });
 });
 

--- a/tests/utils/terminal.test.ts
+++ b/tests/utils/terminal.test.ts
@@ -38,8 +38,10 @@ describe('extractPpid from /proc/<pid>/stat', () => {
 
 describe('getLayoutCols', () => {
   it('returns raw cols when TTY', () => { expect(getLayoutCols(120, true)).toBe(120); });
-  it('applies default 0.9 reduction when not TTY (10% headroom for host chrome)', () => {
-    expect(getLayoutCols(120, false)).toBe(108);
+  // Default is full width (1.0): CC renders its hints on a separate line, not
+  // appended to the statusline row, so no chrome headroom is reserved.
+  it('uses full width when not TTY (default factor 1.0, no chrome reservation)', () => {
+    expect(getLayoutCols(120, false)).toBe(120);
   });
   it('applies custom reduction factor', () => { expect(getLayoutCols(100, false, 0.5)).toBe(50); });
   it('clamps factor between 0.3 and 1.0', () => {


### PR DESCRIPTION
Bundle de mejoras de layout de línea 1 para **v1.15.0**.

## Cambios

- **fix(text): box-drawing glyphs cuentan como 1 celda en `displayWidth`** — el rango wide `0x2300–0x257F` barría el bloque Box Drawing (`U+2500–U+257F`), incluido `│` (`U+2502`), el separador default de lumira. Cada separador se sobrecontaba en 1 celda → toda línea con separadores quedaba mal alineada respecto al borde real, y el contenido anclado a la derecha (versión en línea 1, thinking/effort/vim en línea 2) se desalineaba entre líneas por tener distinta cantidad de separadores. **Afecta a todos los usuarios del modo classic.** Rango cortado en `0x24FF`.
- **feat(line1): `line1Align: "justified" | "packed"`** (default `"justified"`, byte-idéntico al output actual). En `packed`, todo se empaqueta a la izquierda y solo la versión queda anclada al borde derecho real — mismo idioma que los indicadores de línea 2. Powerline ya empaqueta left-to-right, así que es classic-only.
- **fix(terminal): factor de cols `0.9 → 1.0`** en no-TTY — la reserva del 10% "por chrome de CC" era especulativa (CC no dibuja nada en la fila del statusline; su hint bar va aparte). El margen `-4` de `fitSegments` es distinto y se mantiene.

## Verificación

- `npx vitest run` → 1339/1339 ✓ (incluye tests nuevos de box-drawing, line1Align packed, y anclaje de versión)
- `npm run build` → limpio, dist en sync
- Descuadre cerebrito/versión verificado como resuelto midiendo anchos reales en Kitty + CommitMono Nerd Font Mono

Rebasado sobre `main` tras el merge de #185 (reorder branch→repo→directory).