### PR TITLE
chore(release): v1.15.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Real-time statusline HUD for Claude Code and Qwen Code — analytics, quota projection, themes, powerline",
-    "version": "1.14.0"
+    "version": "1.15.0"
   },
   "plugins": [
     {
       "name": "lumira",
       "source": "./",
       "description": "Real-time statusline HUD for Claude Code and Qwen Code. Session analytics, API latency widget, 7-day quota projection, auto-compact warnings, 7 themes, powerline support. Zero runtime dependencies. Run /lumira:setup after install to activate.",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "author": {
         "name": "Carlos Cativo"
       },
@@ -32,5 +32,5 @@
       ]
     }
   ],
-  "version": "1.14.0"
+  "version": "1.15.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Real-time statusline HUD for Claude Code and Qwen Code — session analytics, API latency, 7-day quota projection, auto-compact warnings, 7 themes, powerline. Zero runtime deps.",
   "author": {
     "name": "Carlos Cativo"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.15.0] - 2026-07-14
+
+### Added
+
+- **`line1Align` config (`"justified" | "packed"`, default `"justified"`).** New top-level key controlling line-1 horizontal layout in the classic renderer. `"justified"` is the current behavior (left cluster pinned to the start, right cluster to the end, gap between). `"packed"` chains every segment tightly to the left except the version string, which stays pinned to the true right edge — the same idiom line 2 uses for its right-anchored indicators — removing the large mid-line gap on wide terminals. Defaults preserve existing output byte-for-byte. On a terminal too narrow to fit the version, it drops whole rather than truncating (accepted tradeoff, matches ccstatusline/starship/oh-my-posh). Powerline already packs left-to-right, so this is classic-only.
 
 ### Changed
 
+- **Line 1 groups the repo segment next to branch, before directory.** `branch` and `repo` are both git-identity (position in the DAG + which remote it tracks); the local `directory` is orthogonal filesystem context. Rendering order is now `branch → repo → directory` in both classic and powerline renderers, and the powerline repo segment's priority was bumped above directory so git identity survives narrow-terminal eviction a step longer. (#185)
 - **Layout-cols headroom factor raised from 0.9 to 1.0 when stdout is non-TTY.** The statusline now uses the full detected terminal width. The previous 10% reservation assumed Claude Code appends chrome (separators, gutters) to the statusline's own row; inspecting a real render disproved that — CC's own hints ("bypass permissions …", "PR #…", "← for agents") render on a separate line below the statusline, never on its row. So the reserved 10% never held anything, showing up only as empty space at the far-right edge. Dropping it is safe because every renderer that treats `cols` as a width budget already subtracts a proven 4-column margin internally (`fitSegments` for line1/line2, `renderPowerline` for the powerline lines); that `-4` bug-fix margin is untouched.
+
+### Fixed
+
+- **Box Drawing glyphs now count as a single cell in `displayWidth`.** The wide-glyph range `0x2300–0x257F` swept in the Box Drawing block (`U+2500–U+257F`), whose glyphs are all single-cell — including `│` (`U+2502`), lumira's default segment separator (`SEP`). Every separated line was over-counted by one cell per separator, so right-anchored content drew short of the true edge, and lines with different separator counts (line 1 vs line 2) misaligned relative to each other — visible once `line1Align: "packed"` pinned the version to the edge. The range now stops at `0x24FF`, so alignment matches the real drawn width.
 
 ## [1.14.0] - 2026-06-29
 
@@ -608,7 +617,8 @@ First stable release. API is now considered stable under SemVer.
 - GSD session IDs sanitized against path traversal
 - `execFile` used instead of `exec` to prevent shell injection (except terminal width detection where shell redirect is required with procfs-sourced paths)
 
-[Unreleased]: https://github.com/cativo23/lumira/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/cativo23/lumira/compare/v1.15.0...HEAD
+[1.15.0]: https://github.com/cativo23/lumira/compare/v1.14.0...v1.15.0
 [1.6.0]: https://github.com/cativo23/lumira/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/cativo23/lumira/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/cativo23/lumira/compare/v1.4.0...v1.4.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lumira",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lumira",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "license": "MIT",
       "bin": {
         "lumira": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Real-time statusline HUD for Claude Code and Qwen Code. Includes session analytics CLI, API latency overhead widget, 7d quota projection, auto-compact proximity warnings, themes, and powerline. Zero deps.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release bundle. Bumps version to 1.15.0, syncs plugin manifests, dates the CHANGELOG.

Contents (already merged to main via #185 and #186):
- refactor(line1): group repo next to branch, before directory (#185)
- feat(line1): line1Align justified/packed with right-pinned version
- fix(terminal): full-width cols (factor 1.0)
- fix(text): Box Drawing glyphs count as single-cell in displayWidth

Merging this, then tagging v1.15.0 on main, triggers the auto-release workflow.