### PR TITLE
docs: sync docs with v1.15 + release v1.15.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Real-time statusline HUD for Claude Code and Qwen Code — analytics, quota projection, themes, powerline",
-    "version": "1.15.0"
+    "version": "1.15.1"
   },
   "plugins": [
     {
       "name": "lumira",
       "source": "./",
       "description": "Real-time statusline HUD for Claude Code and Qwen Code. Session analytics, API latency widget, 7-day quota projection, auto-compact warnings, 7 themes, powerline support. Zero runtime dependencies. Run /lumira:setup after install to activate.",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "author": {
         "name": "Carlos Cativo"
       },
@@ -32,5 +32,5 @@
       ]
     }
   ],
-  "version": "1.15.0"
+  "version": "1.15.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Real-time statusline HUD for Claude Code and Qwen Code — session analytics, API latency, 7-day quota projection, auto-compact warnings, 7 themes, powerline. Zero runtime deps.",
   "author": {
     "name": "Carlos Cativo"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.1] - 2026-07-14
+
+### Documentation
+
+- Synced docs with the v1.15.0 changes: the README "What's new" banner was refreshed (it had been frozen at v1.9.0 and never mentioned v1.10–v1.15), the obsolete "What's next → v1.0" note was removed (v1.0 shipped long ago), and the `/lumira` configuration skill (`skills/lumira/SKILL.md`) now documents the `line1Align` field with an example. No runtime code changed.
+
 ## [1.15.0] - 2026-07-14
 
 ### Added
@@ -617,7 +623,8 @@ First stable release. API is now considered stable under SemVer.
 - GSD session IDs sanitized against path traversal
 - `execFile` used instead of `exec` to prevent shell injection (except terminal width detection where shell redirect is required with procfs-sourced paths)
 
-[Unreleased]: https://github.com/cativo23/lumira/compare/v1.15.0...HEAD
+[Unreleased]: https://github.com/cativo23/lumira/compare/v1.15.1...HEAD
+[1.15.1]: https://github.com/cativo23/lumira/compare/v1.15.0...v1.15.1
 [1.15.0]: https://github.com/cativo23/lumira/compare/v1.14.0...v1.15.0
 [1.6.0]: https://github.com/cativo23/lumira/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/cativo23/lumira/compare/v1.4.1...v1.5.0

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Interactive wizard — preset, theme, icons — previewed live before write.
 ![Claude Code](https://img.shields.io/badge/Claude_Code-compatible-2d3748?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMjggMTI4IiB3aWR0aD0iMTI4IiBoZWlnaHQ9IjEyOCI+PHBhdGggZD0iTTY0IDEyOEMzNS44IDEyOCAxMyAxMDUuMiAxMyA3N0MxMyA0OC44IDM1LjggMjYgNjQgMjZjMjguMiAwIDUxIDIyLjggNTEgNTFzLTIyLjggNTEtNTEgNTF6IiBmaWxsPSIjMjQyNTJGIi8+PC9zdmc+)
 ![Qwen Code](https://img.shields.io/badge/Qwen_Code-compatible-6156FF)
 
-> **What's new in v1.9.0:** lumira is now a **Claude Code plugin** — install with `/plugin marketplace add cativo23/lumira`, no npm required. Run `/lumira:setup` to activate. v1.8.2 made the installer write a fast per-render command (~10× faster). v1.8.1 brought the GSD widget to parity with GSD 1.42.3. Earlier: compaction counter `⊙ N` (v1.8.0), added-dirs badge + worktree breadcrumb (v1.7.0), [`lumira stats` CLI](#stats-cli) (v1.5), `API N%` latency widget (v1.4.0), 7-day quota projection (v1.3.0).
+> **What's new in v1.15.0:** `line1Align: "packed"` packs line 1 tightly to the left with only the version pinned to the true right edge; the repo segment now sits next to the branch (git identity grouped, `branch → repo → directory`); and a Box Drawing width fix (the `│` separator was miscounted) aligns every line to the real terminal edge. Recent highlights: [subagent panel rows](#subagent-rows) (v1.14), extended-thinking badge (v1.12), [PR widget](#features) (v1.11), repo-identity segment + a full [feature comparison](#how-lumira-compares) (v1.10–v1.13). Still a **Claude Code plugin** — `/plugin marketplace add cativo23/lumira`, no npm required; run `/lumira:setup` to activate.
 
 ## Table of contents
 
@@ -487,9 +487,10 @@ PRs welcome — particularly for new themes (one of the most common contribution
 
 ### What's next
 
-- **v1.0** — soak window on v0.7.x, then tagging stable. CLI flags, preset names, and config schema are considered frozen from this point.
 - **Themes** — community theme contributions welcome via the theme PR template.
 - **Backlog** — incremental transcript parsing for very large sessions (deferred; full re-parse stays under budget for real-world transcripts).
+
+CLI flags, preset names, and the config schema have been stable since v1.0 — additive changes only.
 
 For security issues, see [SECURITY.md](SECURITY.md).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lumira",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lumira",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "license": "MIT",
       "bin": {
         "lumira": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumira",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Real-time statusline HUD for Claude Code and Qwen Code. Includes session analytics CLI, API latency overhead widget, 7d quota projection, auto-compact proximity warnings, themes, and powerline. Zero deps.",
   "type": "module",
   "main": "dist/index.js",

--- a/skills/lumira/SKILL.md
+++ b/skills/lumira/SKILL.md
@@ -30,6 +30,7 @@ Your job: read the user's current config, translate their natural-language reque
 | `icons` | string | `"nerd"` \| `"emoji"` \| `"none"` | Default `"nerd"` (requires Nerd Font) |
 | `theme` | string | `"dracula"` \| `"nord"` \| `"tokyo-night"` \| `"catppuccin"` \| `"monokai"` \| `"gruvbox"` \| `"solarized"` | Requires `colors.mode: "truecolor"` to take effect |
 | `style` | string | `"classic"` \| `"powerline"` | Visual style for line 1 |
+| `line1Align` | string | `"justified"` \| `"packed"` | Line 1 classic layout. `"justified"` (default) pins the left cluster to the start and the right cluster to the end. `"packed"` packs everything tightly to the left, leaving only the version pinned to the true right edge. No-op in powerline mode (always packs). |
 | `powerline.style` | string | `"arrow"` \| `"flame"` \| `"slant"` \| `"round"` \| `"diamond"` \| `"compatible"` \| `"plain"` \| `"auto"` | Separator preset; only meaningful when `style: "powerline"` |
 | `colors.mode` | string | `"auto"` \| `"named"` \| `"256"` \| `"truecolor"` | Color depth |
 | `gsd` | boolean | `true` \| `false` | Show GSD task info section |
@@ -78,6 +79,13 @@ User intent → minimal JSON patch (assume existing config is preserved unless e
   "powerline": { "style": "flame" },
   "theme": "dracula",
   "colors": { "mode": "truecolor" }
+}
+```
+
+**"pegá todo a la izquierda, sacá el hueco del medio"** / "packed line 1"
+```json
+{
+  "line1Align": "packed"
 }
 ```
 


### PR DESCRIPTION
Docs-only patch (no runtime code changed).

- **README** — 'What's new' banner refreshed (was frozen at v1.9.0, never mentioned v1.10–v1.15); obsolete 'What's next → v1.0' note removed.
- **skills/lumira/SKILL.md** — documents `line1Align` in the config catalog + a few-shot example, so the /lumira skill can actually offer it.
- **CHANGELOG** — v1.15.1 entry.
- Version bumped to 1.15.1 (manifests synced).

Merging then tagging v1.15.1 triggers the auto-release so the updated skill ships with the plugin/package.