### PR TITLE
fix(installer): preserve preset/theme/icons on non-TTY reinstall

### DIFF
--- a/dist/installer.js
+++ b/dist/installer.js
@@ -285,9 +285,19 @@ export async function install(opts = {}) {
         wizard = result;
     }
     else {
-        // Non-TTY: use defaults
-        wizard = { preset: 'balanced', icons: 'nerd' };
-        lines.push(ok('Non-interactive mode — using defaults (preset: balanced, icons: nerd)'));
+        // Non-TTY: preserve any existing preset/theme/icons; only default the fields
+        // that were genuinely unset. Never wipe a user's live config.
+        const preset = current.preset ?? 'balanced';
+        const icons = current.icons ?? 'nerd';
+        wizard = { preset, icons };
+        if (current.theme !== undefined)
+            wizard.theme = current.theme;
+        const isFirstInstall = current.preset === undefined && current.icons === undefined && current.theme === undefined;
+        const verb = isFirstInstall ? 'using defaults' : 'keeping existing config';
+        const parts = [`preset: ${preset}`, `icons: ${icons}`];
+        if (wizard.theme !== undefined)
+            parts.push(`theme: ${wizard.theme}`);
+        lines.push(ok(`Non-interactive mode — ${verb} (${parts.join(', ')})`));
     }
     // Save config + emit footer + render output. Shared by every exit below.
     const finalize = () => {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -326,9 +326,19 @@ export async function install(opts: InstallerOptions = {}): Promise<string> {
     }
     wizard = result;
   } else {
-    // Non-TTY: use defaults
-    wizard = { preset: 'balanced', icons: 'nerd' };
-    lines.push(ok('Non-interactive mode — using defaults (preset: balanced, icons: nerd)'));
+    // Non-TTY: preserve any existing preset/theme/icons; only default the fields
+    // that were genuinely unset. Never wipe a user's live config.
+    const preset = current.preset ?? 'balanced';
+    const icons = current.icons ?? 'nerd';
+    wizard = { preset, icons };
+    if (current.theme !== undefined) wizard.theme = current.theme;
+
+    const isFirstInstall = current.preset === undefined && current.icons === undefined && current.theme === undefined;
+    const verb = isFirstInstall ? 'using defaults' : 'keeping existing config';
+
+    const parts = [`preset: ${preset}`, `icons: ${icons}`];
+    if (wizard.theme !== undefined) parts.push(`theme: ${wizard.theme}`);
+    lines.push(ok(`Non-interactive mode — ${verb} (${parts.join(', ')})`));
   }
 
   // Save config + emit footer + render output. Shared by every exit below.

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -486,6 +486,27 @@ describe('install — wizard integration', () => {
     expect(output).toContain('Non-interactive');
   });
 
+  it('preserves an existing preset/theme/icons on a non-TTY re-install instead of resetting to defaults', async () => {
+    const settingsPath = join(dir, 'settings.json');
+    const configPath = join(dir, 'config.json');
+    writeFileSync(configPath, JSON.stringify({ preset: 'full', theme: 'tokyo-night', icons: 'emoji' }));
+    const stdin = createMockStdin(false);
+
+    const output = await install({
+      settingsPath, configPath,
+      confirm: async () => true,
+      stdin,
+      hasGlobalBin: () => false,
+      installGlobal: () => true,
+    });
+
+    const cfg = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(cfg.preset).toBe('full');
+    expect(cfg.theme).toBe('tokyo-night');
+    expect(cfg.icons).toBe('emoji');
+    expect(output).toContain('Non-interactive');
+  });
+
   it('aborts cleanly when user Escs — no settings.json, no config.json', async () => {
     const settingsPath = join(dir, 'settings.json');
     const configPath = join(dir, 'config.json');


### PR DESCRIPTION
## Summary

Real user-facing data-loss bug, found via manual smoke-testing right after the v1.16.0 release (whose own `refreshInterval` feature pushes users to re-run `lumira install`).

- The non-TTY branch in `src/installer.ts` (~line 329) unconditionally set `wizard = { preset: 'balanced', icons: 'nerd' }`, ignoring the `current` object already loaded from the existing `config.json` a few lines earlier.
- `saveConfig` (`src/config.ts`) merges `preset`/`icons` from `wizard` (overwriting) and explicitly `delete merged.theme` when `wizard.theme` is `undefined`.
- Net effect: any non-interactive re-install (piped stdin, CI, or a user following the docs to enable `refreshInterval`) silently reset `preset` to `balanced` and **deleted** the user's `theme`, even with a fully custom config already in place. Reproduced live on my own machine.

## Fix

Non-TTY branch now falls back to the existing config's `preset`/`icons`/`theme` (via the already-loaded `current` object), defaulting to `balanced`/`nerd`/no-theme only for fields genuinely unset. Log message now says "keeping existing config" vs. "using defaults" accurately.

## Test plan
- [x] TDD: new test added (`preserves an existing preset/theme/icons on a non-TTY re-install instead of resetting to defaults`), confirmed red (`expected 'balanced' to be 'full'`) before the fix
- [x] Existing first-install-defaults test still green (no existing config → still defaults to balanced/nerd/no-theme)
- [x] Full suite: 1356/1356 passing
- [x] `dist/` rebuilt to match `src/`
- [ ] Opus code review (parallel-code-reviewer) before merge